### PR TITLE
Display home page to visitors

### DIFF
--- a/controllers/homeController.js
+++ b/controllers/homeController.js
@@ -1,6 +1,7 @@
 
+// Render landing page
 exports.index = (req, res) => {
-    res.render("index");
+    res.render("home", { layout: false });
 };
 
 exports.logRequestPaths = (req, res, next) => {

--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -6,7 +6,7 @@ const jwt = require('../lib/simpleJWT');
 const User = require('../models/users');
 
 exports.getSignUp = (req, res) => {
-    res.render('contact');
+    res.render('contact', { layout: false });
 };
 
 exports.getLogin = (req, res) => {

--- a/main.js
+++ b/main.js
@@ -59,7 +59,8 @@ const requireAuth = (req, res, next) => {
     next();
 };
 
-app.get('/',requireAuth, homeController.index);
+// Public landing page
+app.get('/', homeController.index);
 app.get('/signup', profileController.getSignUp);
 app.get('/login', profileController.getLogin);
 app.post('/signup', profileController.saveUser);


### PR DESCRIPTION
## Summary
- render `home.ejs` for the root URL
- allow anyone to access the home page (no auth)
- disable layout for the signup page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68754e1583748326a1ba68eead97ed75