### PR TITLE
Add styled profile page

### DIFF
--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,11 +1,13 @@
 <header class="shadow-sm bg-white">
   <nav class="container d-flex align-items-center justify-content-between py-3">
     <a href="/" class="fw-bold fs-4 text-decoration-none">App Logo</a>
-    <ul class="d-none d-md-flex list-unstyled mb-0 gap-4">
-      <li><a href="#" class="text-decoration-none text-body">Games</a></li>
-      <li><a href="#" class="text-decoration-none text-body">Social</a></li>
-      <li><a href="#" class="text-decoration-none text-body">Plans &amp; Pricing</a></li>
-      <li><a href="/about" class="text-decoration-none text-body">About</a></li>
+    <ul class="d-none d-md-flex list-unstyled mb-0 gap-3">
+      <li>
+        <a href="#" class="text-decoration-none px-3 py-1 rounded-pill bg-primary text-white">Games</a>
+      </li>
+      <li><a href="#" class="text-decoration-none text-body px-3 py-1 rounded">Social</a></li>
+      <li><a href="#" class="text-decoration-none text-body px-3 py-1 rounded">Plans &amp; Pricing</a></li>
+      <li><a href="/about" class="text-decoration-none text-body px-3 py-1 rounded">About</a></li>
     </ul>
     <div class="text-nowrap d-flex align-items-center">
       <% if (user) { %>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -5,30 +5,73 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Profile</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <style>
+        .profile-header {
+            background: linear-gradient(to right, #7e22ce, #14b8a6);
+        }
+        .trophy-panel {
+            background-color: rgba(255,255,255,0.15);
+        }
+    </style>
 </head>
 <body class="d-flex flex-column min-vh-100">
     <%- include('partials/header') %>
 
-    <div class="container my-5">
-        <div class="row justify-content-center">
-            <div class="col-md-6 text-center">
-                <img src="<%= user.profileImage || 'https://via.placeholder.com/150' %>" class="rounded-circle mb-3" style="width:150px;height:150px; object-fit:cover;" alt="Profile Photo">
-                <h2 class="mb-0"><%= user.name %></h2>
-                <p class="text-muted">@<%= user.email %></p>
-                <div class="d-flex justify-content-center mb-4">
-                    <div class="mx-3">
-                        <span class="h5 d-block"><%= user.followersCount %></span>
-                        <small class="text-muted">Followers</small>
-                    </div>
-                    <div class="mx-3">
-                        <span class="h5 d-block"><%= user.followingCount %></span>
-                        <small class="text-muted">Following</small>
+    <div class="profile-header py-5 text-white">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-3 text-center mb-4 mb-md-0">
+                    <img src="<%= user.profileImage || 'https://via.placeholder.com/150' %>" class="rounded-circle" style="width:150px;height:150px; object-fit:cover;" alt="Profile Photo">
+                    <div class="mt-2 fw-bold">💎 675</div>
+                </div>
+                <div class="col-md-6 text-center text-md-start">
+                    <h2 class="fw-bold mb-1"><%= user.name %></h2>
+                    <p class="mb-2">@<%= user.email %></p>
+                    <div class="d-flex justify-content-center justify-content-md-start">
+                        <div class="me-4">
+                            <div class="fw-bold text-primary"><%= user.followersCount %></div>
+                            <small class="text-white-50">Followers</small>
+                        </div>
+                        <div>
+                            <div class="fw-bold text-info"><%= user.followingCount %></div>
+                            <small class="text-white-50">Following</small>
+                        </div>
                     </div>
                 </div>
-                <a href="/profile/edit" class="btn btn-primary">Edit Profile</a>
+                <div class="col-md-3 text-center text-md-end">
+                    <a href="/profile/edit" class="btn btn-primary rounded-pill px-4">Edit Profile</a>
+                </div>
+            </div>
+            <div class="row mt-4">
+                <div class="col-md-9 offset-md-3">
+                    <div class="trophy-panel p-3 rounded shadow-sm d-flex justify-content-around">
+                        <i class="bi bi-star-fill fs-3 text-warning"></i>
+                        <i class="bi bi-football fs-3 text-white"></i>
+                        <i class="bi bi-basketball fs-3 text-white"></i>
+                        <i class="bi bi-trophy-fill fs-3 text-warning"></i>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
+
+    <section class="container my-5">
+        <div class="row g-3">
+            <div class="col-6 col-md-3">
+                <div class="bg-light border rounded position-relative" style="height:150px; transform: rotate(-2deg);"></div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="bg-light border rounded position-relative" style="height:150px; transform: rotate(1deg);"></div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="bg-light border rounded position-relative" style="height:150px; transform: rotate(-1deg);"></div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="bg-light border rounded position-relative" style="height:150px; transform: rotate(2deg);"></div>
+            </div>
+        </div>
+    </section>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- highlight active menu item in header navigation
- redesign profile page with gradient header, trophy case, and placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875654bcef48326a6fec8a357691baa