### PR TITLE
Improve profile styling

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,0 +1,29 @@
+.avatar {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+    display: block;
+}
+
+.avatar-sm { width:40px; height:40px; }
+.avatar-md { width:120px; height:120px; }
+.avatar-lg { width:150px; height:150px; }
+
+.profile-search {
+    background-color: rgba(255,255,255,0.2);
+    border: none;
+    color: #fff;
+    padding-left: 2.25rem;
+    border-radius: 0.5rem;
+}
+.profile-search::placeholder {
+    color: #fff;
+}
+.search-icon {
+    position: absolute;
+    left: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #fff;
+}

--- a/views/editProfile.ejs
+++ b/views/editProfile.ejs
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Edit Profile</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
     <%- include('partials/header') %>
@@ -14,7 +15,7 @@
             <div class="col-md-6">
                 <form action="/profile/edit" method="post">
                     <div class="text-center mb-4">
-                        <img src="<%= user.profileImage || 'https://via.placeholder.com/150' %>" class="rounded-circle" style="width:120px;height:120px; object-fit:cover;" alt="Profile Photo">
+                        <img src="<%= user.profileImage || 'https://via.placeholder.com/150' %>" class="avatar avatar-md" alt="Profile Photo">
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Username</label>

--- a/views/followList.ejs
+++ b/views/followList.ejs
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= title %></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
     <%- include('partials/header') %>
@@ -13,7 +14,7 @@
         <div class="list-group">
             <% users.forEach(function(u){ %>
                 <a href="/users/<%= u._id %>" class="list-group-item list-group-item-action d-flex align-items-center">
-                    <img src="<%= u.profileImage || 'https://via.placeholder.com/40' %>" class="rounded-circle me-2" style="width:40px;height:40px;object-fit:cover;">
+                    <img src="<%= u.profileImage || 'https://via.placeholder.com/40' %>" class="avatar avatar-sm me-2">
                     <%= u.username %>
                 </a>
             <% }) %>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="/css/custom.css">
 <header class="shadow-sm bg-white">
   <nav class="container d-flex align-items-center justify-content-between py-3">
     <a href="/" class="fw-bold fs-4 text-decoration-none">App Logo</a>
@@ -12,7 +13,7 @@
     <div class="text-nowrap d-flex align-items-center">
       <% if (loggedInUser) { %>
         <a href="/profile" class="me-3">
-          <img src="<%= loggedInUser.profileImage || 'https://via.placeholder.com/40' %>" alt="Profile" class="rounded-circle" style="width:40px;height:40px; object-fit:cover;">
+          <img src="<%= loggedInUser.profileImage || 'https://via.placeholder.com/40' %>" alt="Profile" class="avatar avatar-sm">
         </a>
         <a href="/logout" class="btn btn-outline-secondary">Log Out</a>
       <% } else { %>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Profile</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <style>
         .profile-header {
@@ -25,7 +26,7 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-md-3 text-center mb-4 mb-md-0">
-                    <img src="<%= user.profileImage || 'https://via.placeholder.com/150' %>" class="rounded-circle" style="width:150px;height:150px; object-fit:cover;" alt="Profile Photo">
+                    <img src="<%= user.profileImage || 'https://via.placeholder.com/150' %>" class="avatar avatar-lg" alt="Profile Photo">
                     <div class="mt-2 fw-bold">💎 675</div>
                 </div>
                 <div class="col-md-6 text-center text-md-start">
@@ -54,6 +55,17 @@
                     <% } %>
                 </div>
             </div>
+            <% if (isCurrentUser) { %>
+            <div class="row mt-3">
+                <div class="col-md-6 offset-md-3">
+                    <div class="position-relative">
+                        <i class="bi bi-search search-icon"></i>
+                        <input type="text" id="searchInput" class="form-control profile-search mb-3" placeholder="Find users">
+                    </div>
+                    <div id="searchResults" class="row g-3" style="max-height:300px;overflow:auto;"></div>
+                </div>
+            </div>
+            <% } %>
             <div class="row mt-4">
                 <div class="col-md-9 offset-md-3">
                     <div class="trophy-panel p-3 rounded shadow-sm d-flex justify-content-around">
@@ -79,14 +91,6 @@
             <p>No favorite teams selected.</p>
         <% } %>
     </div>
-
-    <% if (isCurrentUser) { %>
-    <div class="container my-4">
-        <h4>Find Users</h4>
-        <input type="text" id="searchInput" class="form-control mb-3" placeholder="Search by username">
-        <div id="searchResults" class="row g-3" style="max-height:300px;overflow:auto;"></div>
-    </div>
-    <% } %>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script>
@@ -134,7 +138,7 @@
                 resultsEl.innerHTML = data.map(u=>{
                     const following = u.followers && u.followers.includes(currentId);
                     return `<div class="col-md-4"><div class="card p-2 d-flex flex-row align-items-center gap-2">`+
-                        `<img src="${u.profileImage || 'https://via.placeholder.com/40'}" class="rounded-circle" style="width:40px;height:40px;object-fit:cover;">`+
+                        `<img src="${u.profileImage || 'https://via.placeholder.com/40'}" class="avatar avatar-sm">`+
                         `<div class="flex-grow-1"><a href="/users/${u._id}" class="text-decoration-none">${u.username}</a></div>`+
                         (currentId && u._id !== currentId ? `<button data-id="${u._id}" class="btn btn-${following?'secondary':'primary'} btn-sm follow-toggle">${following?'Following':'Follow'}</button>`:'')+
                         `</div></div>`; }).join('');


### PR DESCRIPTION
## Summary
- add custom CSS for avatars and search bar
- link custom styles in header and profile pages
- move user search bar to profile header
- use circular avatar classes across profile-related pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c941c6388326b71b8bf854135704