### PR TITLE
Improve profile search bar layout

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -20,11 +20,16 @@
 .avatar-lg { width:150px; height:150px; }
 
 .profile-search {
-    background-color: rgba(255,255,255,0.2);
-    border: none;
+    background-color: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.3);
     color: #fff;
     padding-left: 2.25rem;
     border-radius: 0.5rem;
+}
+.profile-search:focus {
+    background-color: rgba(255, 255, 255, 0.2);
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
 }
 .profile-search::placeholder {
     color: #fff;
@@ -35,6 +40,16 @@
     top: 50%;
     transform: translateY(-50%);
     color: #fff;
+}
+
+.profile-search-wrapper {
+    width: 100%;
+}
+
+@media (min-width: 768px) {
+    .profile-search-wrapper {
+        width: 50%;
+    }
 }
 
 /* Necklace styles around profile avatar */

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -76,7 +76,15 @@
                     </div>
                 </div>
                 <div class="col-md-6 text-center text-md-start">
-                    <h2 class="fw-bold mb-1"><%= user.username %></h2>
+                    <div class="d-flex flex-column flex-md-row align-items-center">
+                        <h2 class="fw-bold mb-1 me-md-3"><%= user.username %></h2>
+                        <% if (isCurrentUser) { %>
+                        <div class="position-relative profile-search-wrapper w-100 mt-2 mt-md-0">
+                            <i class="bi bi-search search-icon"></i>
+                            <input type="text" id="searchInput" class="form-control profile-search" placeholder="Find users">
+                        </div>
+                        <% } %>
+                    </div>
                     <p class="mb-2">@<%= user.email %></p>
                     <div class="d-flex justify-content-center justify-content-md-start">
                         <div class="me-4">
@@ -102,15 +110,7 @@
                 </div>
             </div>
             <% if (isCurrentUser) { %>
-            <div class="row mt-3">
-                <div class="col-md-6 offset-md-3">
-                    <div class="position-relative">
-                        <i class="bi bi-search search-icon"></i>
-                        <input type="text" id="searchInput" class="form-control profile-search mb-3" placeholder="Find users">
-                    </div>
-                    <div id="searchResults" class="row g-3" style="max-height:300px;overflow:auto;"></div>
-                </div>
-            </div>
+            <div id="searchResults" class="row g-3 mt-2" style="max-height:300px;overflow:auto;"></div>
             <% } %>
             
     </div>


### PR DESCRIPTION
## Summary
- place the profile search bar beside the username
- keep transparency styling on focus
- adjust width responsively using new `.profile-search-wrapper` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876d6e988b483269d10326f9f1d860e