### PR TITLE
Add follow users modal on profile

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -84,3 +84,28 @@
     object-fit: cover;
     border-radius: 50%;
 }
+
+/* Modal backdrop blur */
+.modal-backdrop {
+    backdrop-filter: blur(8px);
+    background-color: rgba(0, 0, 0, 0.3);
+}
+
+/* User search modal sizing */
+.user-search-modal .modal-dialog {
+    max-width: 100%;
+}
+
+@media (min-width: 768px) {
+    .user-search-modal .modal-dialog {
+        max-width: 50%;
+    }
+}
+
+.user-search-modal .modal-content {
+    border-radius: 0.5rem;
+}
+
+.follow-users-btn {
+    transition: background-color 0.3s, color 0.3s;
+}

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -78,12 +78,6 @@
                 <div class="col-md-6 text-center text-md-start">
                     <div class="d-flex flex-column flex-md-row align-items-center">
                         <h2 class="fw-bold mb-1 me-md-3"><%= user.username %></h2>
-                        <% if (isCurrentUser) { %>
-                        <div class="position-relative profile-search-wrapper w-100 mt-2 mt-md-0">
-                            <i class="bi bi-search search-icon"></i>
-                            <input type="text" id="searchInput" class="form-control profile-search" placeholder="Find users">
-                        </div>
-                        <% } %>
                     </div>
                     <p class="mb-2">@<%= user.email %></p>
                     <div class="d-flex justify-content-center justify-content-md-start">
@@ -100,6 +94,11 @@
                             </a>
                         </div>
                     </div>
+                    <% if (isCurrentUser) { %>
+                    <div class="mt-3">
+                        <button id="openUserModal" class="btn btn-primary rounded-pill follow-users-btn px-4" data-bs-toggle="modal" data-bs-target="#userSearchModal">Follow Users</button>
+                    </div>
+                    <% } %>
                 </div>
                 <div class="col-md-3 text-center text-md-end">
                     <% if (isCurrentUser) { %>
@@ -109,12 +108,30 @@
                     <% } %>
                 </div>
             </div>
-            <% if (isCurrentUser) { %>
-            <div id="searchResults" class="row g-3 mt-2" style="max-height:300px;overflow:auto;"></div>
-            <% } %>
+
             
     </div>
 </div>
+
+    <% if (isCurrentUser) { %>
+    <div class="modal fade user-search-modal" id="userSearchModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content p-3">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title">Find Users</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="position-relative mb-3 profile-search-wrapper w-100">
+                        <i class="bi bi-search search-icon"></i>
+                        <input type="text" id="searchInput" class="form-control profile-search" placeholder="Find users">
+                    </div>
+                    <div id="searchResults" class="row g-3" style="max-height:300px;overflow:auto;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <% } %>
 
     <div class="container my-4">
         <h4>Favorite Teams</h4>
@@ -137,6 +154,7 @@
         const searchInput = document.getElementById('searchInput');
         const resultsEl = document.getElementById('searchResults');
         const followBtn = document.getElementById('followBtn');
+        const userSearchModal = document.getElementById('userSearchModal');
 
         if(followBtn){
             followBtn.addEventListener('click', async function(){
@@ -207,6 +225,15 @@
                     alert('Action failed');
                 }finally{
                     btn.disabled = false;
+                }
+            });
+        }
+
+        if(userSearchModal){
+            userSearchModal.addEventListener('hidden.bs.modal', () => {
+                if(searchInput){
+                    searchInput.value = '';
+                    resultsEl.innerHTML = '';
                 }
             });
         }


### PR DESCRIPTION
## Summary
- add modal styling and blur effect in `custom.css`
- replace profile page search bar with "Follow Users" button
- implement user search modal with backdrop blur
- reset search when modal closes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876dc28bef88326acbaaf59eda49438