### PR TITLE
Add games listing with filters

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -1,0 +1,54 @@
+const Game = require('../models/Game');
+const Team = require('../models/Team');
+
+exports.listGames = async (req, res, next) => {
+  try {
+    const { team, start, end, page = 1 } = req.query;
+    const query = {};
+    if (team) {
+      query.$or = [
+        { homeTeamName: { $regex: team, $options: 'i' } },
+        { awayTeamName: { $regex: team, $options: 'i' } }
+      ];
+    }
+    if (start) {
+      query.startDate = { ...(query.startDate || {}), $gte: new Date(start) };
+    }
+    if (end) {
+      query.startDate = { ...(query.startDate || {}), $lte: new Date(end) };
+    }
+    const limit = 50;
+    const skip = (parseInt(page) - 1) * limit;
+
+    let games = await Game.find(query)
+      .populate('homeTeam')
+      .populate('awayTeam')
+      .sort({ startDate: 1 })
+      .skip(skip)
+      .limit(limit + 1); // fetch one extra to check if next page exists
+
+    const hasNextPage = games.length > limit;
+    if (hasNextPage) games = games.slice(0, limit);
+
+    const buildQS = (extra = {}) => {
+      const params = new URLSearchParams();
+      if (team) params.append('team', team);
+      if (start) params.append('start', start);
+      if (end) params.append('end', end);
+      Object.keys(extra).forEach(k => {
+        if (extra[k]) params.append(k, extra[k]);
+      });
+      return params.toString();
+    };
+
+    res.render('games', {
+      games,
+      filters: { team, start, end },
+      page: parseInt(page),
+      hasNextPage,
+      buildQS
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const express = require("express"),
     homeController = require("./controllers/homeController"),
     profileController = require("./controllers/profileController"),
     projectsController = require("./controllers/projectsController"),
+    gamesController = require("./controllers/gamesController"),
     layouts = require('express-ejs-layouts'),
     mongoose = require('mongoose'),
     cookieParser = require('cookie-parser'),
@@ -95,6 +96,8 @@ app.get('/about', requireAuth, homeController.showAbout);
 
 app.get('/projects', requireAuth, projectsController.getProjects);
 app.get('/newProject', requireAuth, projectsController.getNewProject);
+
+app.get('/games', gamesController.listGames);
 
 
 app.use(homeController.logRequestPaths);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -117,3 +117,16 @@
 .profile-photo-preview {
     border: 2px solid #ddd;
 }
+
+/* Games page */
+.game-card {
+    border-radius: .5rem;
+}
+
+.team-logo {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid #ccc;
+}

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Games</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/custom.css">
+  <style>
+    .game-card { border-radius: .5rem; }
+    .team-logo { width:60px; height:60px; border-radius:50%; object-fit:cover; border:1px solid #ccc; }
+  </style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+  <%- include('partials/header') %>
+
+  <div class="container my-4 flex-grow-1">
+    <form class="row g-3 mb-4" method="get" action="/games">
+      <div class="col-sm-4">
+        <input type="text" class="form-control" name="team" placeholder="Search by team" value="<%= filters.team || '' %>">
+      </div>
+      <div class="col-sm-3">
+        <input type="date" class="form-control" name="start" value="<%= filters.start || '' %>">
+      </div>
+      <div class="col-sm-3">
+        <input type="date" class="form-control" name="end" value="<%= filters.end || '' %>">
+      </div>
+      <div class="col-sm-2 d-grid">
+        <button type="submit" class="btn btn-primary">Filter</button>
+      </div>
+    </form>
+
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+      <% games.forEach(function(game){ %>
+        <div class="col">
+          <div class="card shadow-sm h-100 game-card p-3 text-center">
+            <div class="fw-bold mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+            <div class="d-flex align-items-center justify-content-center mb-2">
+              <div class="me-3 text-center">
+                <img class="team-logo mb-1" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                <div class="small"><%= game.awayTeamName %></div>
+              </div>
+              <div class="fw-bold fs-4">@</div>
+              <div class="ms-3 text-center">
+                <img class="team-logo mb-1" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                <div class="small"><%= game.homeTeamName %></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% }); %>
+    </div>
+
+    <% if (hasNextPage || page > 1) { %>
+      <nav class="mt-4">
+        <ul class="pagination justify-content-center">
+          <% if (page > 1) { %>
+            <li class="page-item">
+              <a class="page-link" href="?<%= buildQS({ page: page - 1 }) %>">Previous</a>
+            </li>
+          <% } %>
+          <% if (hasNextPage) { %>
+            <li class="page-item">
+              <a class="page-link" href="?<%= buildQS({ page: page + 1 }) %>">Next</a>
+            </li>
+          <% } %>
+        </ul>
+      </nav>
+    <% } %>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    document.querySelectorAll('[data-start]').forEach(function(el){
+      var date = new Date(el.dataset.start);
+      el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add controller to fetch/populate games
- create new games.ejs page with responsive cards and filter form
- include new styling for game cards
- wire up `/games` route in Express

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68799cdae50083269c5629cdea363742