### PR TITLE
Improve games page search and navigation

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,6 +52,7 @@ app.use((req, res, next) => {
         req.user = null;
     }
     res.locals.loggedInUser = req.user;
+    res.locals.currentPath = req.path;
     next();
 });
 
@@ -98,6 +99,7 @@ app.get('/projects', requireAuth, projectsController.getProjects);
 app.get('/newProject', requireAuth, projectsController.getNewProject);
 
 app.get('/games', gamesController.listGames);
+app.get('/teams/search', gamesController.searchTeams);
 
 
 app.use(homeController.logRequestPaths);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -130,3 +130,29 @@
     object-fit: cover;
     border: 1px solid #ccc;
 }
+
+.gradient-bg {
+    background: linear-gradient(to right, #7e22ce, #14b8a6);
+}
+
+.active-profile .nav-profile-icon {
+    box-shadow: 0 0 0 2px #0d6efd;
+}
+
+.team-suggestions {
+    position: absolute;
+    z-index: 1000;
+    width: 100%;
+    background: #fff;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.team-suggestions .list-group-item img {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-right: 0.5rem;
+}

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -6,24 +6,18 @@
   <title>Games</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/custom.css">
-  <style>
-    .game-card { border-radius: .5rem; }
-    .team-logo { width:60px; height:60px; border-radius:50%; object-fit:cover; border:1px solid #ccc; }
-  </style>
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 gradient-bg">
   <%- include('partials/header') %>
 
   <div class="container my-4 flex-grow-1">
-    <form class="row g-3 mb-4" method="get" action="/games">
-      <div class="col-sm-4">
-        <input type="text" class="form-control" name="team" placeholder="Search by team" value="<%= filters.team || '' %>">
+    <form class="row g-3 mb-4 position-relative" method="get" action="/games">
+      <div class="col-sm-5 position-relative">
+        <input id="teamInput" type="text" class="form-control" name="team" placeholder="Search by team" autocomplete="off" value="<%= filters.team || '' %>">
+        <div id="teamSuggestions" class="list-group team-suggestions"></div>
       </div>
-      <div class="col-sm-3">
-        <input type="date" class="form-control" name="start" value="<%= filters.start || '' %>">
-      </div>
-      <div class="col-sm-3">
-        <input type="date" class="form-control" name="end" value="<%= filters.end || '' %>">
+      <div class="col-sm-5">
+        <input type="date" class="form-control" name="date" value="<%= filters.date || '' %>">
       </div>
       <div class="col-sm-2 d-grid">
         <button type="submit" class="btn btn-primary">Filter</button>
@@ -69,12 +63,38 @@
     <% } %>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <script>
-    document.querySelectorAll('[data-start]').forEach(function(el){
-      var date = new Date(el.dataset.start);
-      el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
-    });
-  </script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      document.querySelectorAll('[data-start]').forEach(function(el){
+        var date = new Date(el.dataset.start);
+        el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+      });
+
+      const teamInput = document.getElementById('teamInput');
+      const suggestions = document.getElementById('teamSuggestions');
+      if(teamInput){
+        teamInput.addEventListener('input', async function(){
+          const q = this.value.trim();
+          if(!q){ suggestions.innerHTML=''; return; }
+          const res = await fetch('/teams/search?q='+encodeURIComponent(q));
+          if(!res.ok) return;
+          const data = await res.json();
+          suggestions.innerHTML = data.map(t=>`<button type="button" class="list-group-item list-group-item-action d-flex align-items-center" data-name="${t.school}">`+
+            `<img src="${t.logos && t.logos[0] ? t.logos[0] : 'https://via.placeholder.com/30'}">`+
+            `${t.school}</button>`).join('');
+        });
+
+        suggestions.addEventListener('click', function(e){
+          const btn = e.target.closest('button[data-name]');
+          if(!btn) return;
+          const name = btn.getAttribute('data-name');
+          teamInput.value = name;
+          suggestions.innerHTML='';
+          const params = new URLSearchParams(window.location.search);
+          params.set('team', name);
+          document.location.search = params.toString();
+        });
+      }
+    </script>
 </body>
 </html>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,18 +1,18 @@
 <link rel="stylesheet" href="/css/custom.css">
 <header class="shadow-sm bg-white">
   <nav class="container d-flex align-items-center justify-content-between py-3">
-    <a href="/" class="fw-bold fs-4 text-decoration-none">App Logo</a>
+    <a href="/" class="fw-bold fs-4 text-decoration-none px-3 py-1 rounded-pill <%= currentPath === '/' ? 'bg-primary text-white' : 'text-body' %>">App Logo</a>
     <ul class="d-none d-md-flex list-unstyled mb-0 gap-3">
       <li>
-        <a href="#" class="text-decoration-none px-3 py-1 rounded-pill bg-primary text-white">Games</a>
+        <a href="/games" class="text-decoration-none px-3 py-1 rounded-pill <%= currentPath.startsWith('/games') ? 'bg-primary text-white' : 'text-body' %>">Games</a>
       </li>
-      <li><a href="#" class="text-decoration-none text-body px-3 py-1 rounded">Social</a></li>
-      <li><a href="#" class="text-decoration-none text-body px-3 py-1 rounded">Plans &amp; Pricing</a></li>
-      <li><a href="/about" class="text-decoration-none text-body px-3 py-1 rounded">About</a></li>
+      <li><a href="#" class="text-decoration-none px-3 py-1 rounded <%= currentPath.startsWith('/social') ? 'bg-primary text-white' : 'text-body' %>">Social</a></li>
+      <li><a href="#" class="text-decoration-none px-3 py-1 rounded <%= currentPath.startsWith('/plans') ? 'bg-primary text-white' : 'text-body' %>">Plans &amp; Pricing</a></li>
+      <li><a href="/about" class="text-decoration-none px-3 py-1 rounded <%= currentPath.startsWith('/about') ? 'bg-primary text-white' : 'text-body' %>">About</a></li>
     </ul>
     <div class="text-nowrap d-flex align-items-center">
       <% if (loggedInUser) { %>
-        <a href="/profile" class="me-3">
+        <a href="/profile" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">
           <img src="<%= loggedInUser.uploadedPic ? ('/uploads/profilePics/' + loggedInUser.uploadedPic) : (loggedInUser.profileImage || 'https://via.placeholder.com/40') %>" alt="Profile" class="nav-profile-icon">
         </a>
         <a href="/logout" class="btn btn-outline-secondary">Log Out</a>


### PR DESCRIPTION
## Summary
- show active nav links based on current URL
- add gradient background and team search dropdown on games page
- simplify date filter to a single date
- support team suggestions API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879a015a46c83269532f5f180235c94