### PR TITLE
Enhance games list UI

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -3,7 +3,7 @@ const Team = require('../models/Team');
 
 exports.listGames = async (req, res, next) => {
   try {
-    const { team, date, page = 1 } = req.query;
+    const { team, date } = req.query;
     const query = {};
     if (team) {
       query.$or = [
@@ -17,35 +17,14 @@ exports.listGames = async (req, res, next) => {
       endOfDay.setDate(endOfDay.getDate() + 1);
       query.startDate = { $gte: startOfDay, $lt: endOfDay };
     }
-    const limit = 50;
-    const skip = (parseInt(page) - 1) * limit;
-
     let games = await Game.find(query)
       .populate('homeTeam')
       .populate('awayTeam')
-      .sort({ startDate: 1 })
-      .skip(skip)
-      .limit(limit + 1); // fetch one extra to check if next page exists
-
-    const hasNextPage = games.length > limit;
-    if (hasNextPage) games = games.slice(0, limit);
-
-    const buildQS = (extra = {}) => {
-      const params = new URLSearchParams();
-      if (team) params.append('team', team);
-      if (date) params.append('date', date);
-      Object.keys(extra).forEach(k => {
-        if (extra[k]) params.append(k, extra[k]);
-      });
-      return params.toString();
-    };
+      .sort({ startDate: 1 });
 
     res.render('games', {
       games,
-      filters: { team, date },
-      page: parseInt(page),
-      hasNextPage,
-      buildQS
+      filters: { team, date }
     });
   } catch (err) {
     next(err);

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -27,16 +27,16 @@
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
       <% games.forEach(function(game){ %>
         <div class="col">
-          <div class="card shadow-sm h-100 game-card p-3 text-center">
+          <div class="card shadow-sm h-100 game-card p-3 text-center" style="background: linear-gradient(to right, <%= game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff' %>, <%= game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff' %>);">
             <div class="fw-bold mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
             <div class="d-flex align-items-center justify-content-center mb-2">
               <div class="me-3 text-center">
-                <img class="team-logo mb-1" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                <img loading="lazy" class="team-logo mb-1" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
                 <div class="small"><%= game.awayTeamName %></div>
               </div>
               <div class="fw-bold fs-4">@</div>
               <div class="ms-3 text-center">
-                <img class="team-logo mb-1" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                <img loading="lazy" class="team-logo mb-1" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
                 <div class="small"><%= game.homeTeamName %></div>
               </div>
             </div>
@@ -44,23 +44,6 @@
         </div>
       <% }); %>
     </div>
-
-    <% if (hasNextPage || page > 1) { %>
-      <nav class="mt-4">
-        <ul class="pagination justify-content-center">
-          <% if (page > 1) { %>
-            <li class="page-item">
-              <a class="page-link" href="?<%= buildQS({ page: page - 1 }) %>">Previous</a>
-            </li>
-          <% } %>
-          <% if (hasNextPage) { %>
-            <li class="page-item">
-              <a class="page-link" href="?<%= buildQS({ page: page + 1 }) %>">Next</a>
-            </li>
-          <% } %>
-        </ul>
-      </nav>
-    <% } %>
   </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- fetch all games without pagination
- show gradient backgrounds for matchups based on team colors
- lazy load team logos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879a314acb483268d51a2fc4dd1212f