### PR TITLE
Improve games page UI layout

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -156,3 +156,39 @@
     object-fit: cover;
     margin-right: 0.5rem;
 }
+
+/* Games page enhancements */
+.logo-wrapper {
+    width: 80px;
+    text-align: center;
+}
+
+.team-logo-container {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: rgba(240,240,240,0.6);
+    border: 2px solid #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 0.25rem;
+}
+
+.team-logo-container img {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.team-name {
+    display: block;
+    font-size: 0.9rem;
+    line-height: 1.1;
+    word-break: break-word;
+}
+
+.game-date {
+    font-weight: 600;
+}

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -25,20 +25,27 @@
     </form>
 
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-      <% games.forEach(function(game){ %>
+      <% games.forEach(function(game){
+           const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
+           const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
+      %>
         <div class="col">
-          <div class="card shadow-sm h-100 game-card p-3 text-center" style="background: linear-gradient(to right, <%= game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff' %>, <%= game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff' %>);">
-            <div class="fw-bold mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
-            <div class="d-flex align-items-center justify-content-center mb-2">
-              <div class="me-3 text-center">
-                <img loading="lazy" class="team-logo mb-1" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
-                <div class="small"><%= game.awayTeamName %></div>
+          <div class="card shadow-sm h-100 game-card p-3 text-center" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+            <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+            <div class="d-flex justify-content-between align-items-center position-relative mb-2">
+              <div class="logo-wrapper me-3">
+                <div class="team-logo-container">
+                  <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                </div>
+                <span class="team-name"><%= game.awayTeamName %></span>
               </div>
-              <div class="fw-bold fs-4">@</div>
-              <div class="ms-3 text-center">
-                <img loading="lazy" class="team-logo mb-1" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
-                <div class="small"><%= game.homeTeamName %></div>
+              <div class="logo-wrapper ms-3">
+                <div class="team-logo-container">
+                  <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                </div>
+                <span class="team-name"><%= game.homeTeamName %></span>
               </div>
+              <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4">@</div>
             </div>
           </div>
         </div>
@@ -78,6 +85,56 @@
           document.location.search = params.toString();
         });
       }
+
+      function hexToRgb(hex){
+        if(!hex) return [255,255,255];
+        hex = hex.replace('#','');
+        if(hex.length===3) hex = hex.split('').map(c=>c+c).join('');
+        const num = parseInt(hex,16);
+        return [(num>>16)&255,(num>>8)&255,num&255];
+      }
+
+      function luminance(r,g,b){
+        const a=[r,g,b].map(v=>{
+          v/=255;
+          return v<=0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4);
+        });
+        return 0.2126*a[0] + 0.7152*a[1] + 0.0722*a[2];
+      }
+
+      function chooseTextColor(colors){
+        const lums = colors.map(c=>{
+          const [r,g,b] = hexToRgb(c);
+          return luminance(r,g,b);
+        });
+        const avg = lums.reduce((a,b)=>a+b,0)/lums.length;
+        return avg > 0.5 ? '#333333' : '#ffffff';
+      }
+
+      document.querySelectorAll('.game-card').forEach(card=>{
+        const away = card.dataset.awayColor;
+        const home = card.dataset.homeColor;
+        const textColor = chooseTextColor([away, home]);
+        card.querySelectorAll('.game-date, .team-name').forEach(el=>{
+          el.style.color = textColor;
+        });
+      });
+
+      function fitTeamNames(){
+        document.querySelectorAll('.team-name').forEach(name=>{
+          const wrapper = name.parentElement; // logo-wrapper
+          const maxWidth = wrapper.clientWidth;
+          let fontSize = parseFloat(window.getComputedStyle(name).fontSize);
+          name.style.fontSize = fontSize + 'px';
+          while(name.scrollWidth > maxWidth && fontSize > 8){
+            fontSize -= 1;
+            name.style.fontSize = fontSize + 'px';
+          }
+        });
+      }
+
+      window.addEventListener('load', fitTeamNames);
+      window.addEventListener('resize', fitTeamNames);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance design of game listings
- add dynamic text color selection and font scaling for team names
- style logo containers with light backgrounds
- center the `@` symbol between teams

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a57f35808326908565a82f0a176d