### PR TITLE
Add game detail page

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -43,3 +43,24 @@ exports.searchTeams = async (req, res, next) => {
     next(err);
   }
 };
+
+exports.showGame = async (req, res, next) => {
+  try {
+    const game = await Game.findById(req.params.id)
+      .populate('homeTeam')
+      .populate('awayTeam');
+    if (!game) return res.status(404).render('error', { message: 'Game not found' });
+    res.render('game', { game });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.checkIn = async (req, res, next) => {
+  try {
+    // Placeholder implementation
+    res.redirect(`/games/${req.params.id}`);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/main.js
+++ b/main.js
@@ -100,6 +100,8 @@ app.get('/newProject', requireAuth, projectsController.getNewProject);
 
 app.get('/games', gamesController.listGames);
 app.get('/teams/search', gamesController.searchTeams);
+app.get('/games/:id', gamesController.showGame);
+app.post('/games/:id/checkin', gamesController.checkIn);
 
 
 app.use(homeController.logRequestPaths);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -192,3 +192,69 @@
 .game-date {
     font-weight: 600;
 }
+
+/* Interactive game link */
+.game-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+
+.game-link .game-card {
+    transition: transform 0.2s;
+}
+
+.game-link:hover .game-card {
+    transform: scale(1.05);
+}
+
+/* Game detail page */
+.team-diagonal-square {
+    position: relative;
+    width: 100%;
+    padding-bottom: 100%;
+    overflow: hidden;
+}
+
+.team-diagonal-square .triangle {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}
+
+.team-diagonal-square .home-bg {
+    clip-path: polygon(100% 0, 100% 100%, 0 0);
+}
+
+.team-diagonal-square .away-bg {
+    clip-path: polygon(0 100%, 0 0, 100% 100%);
+}
+
+.team-logo-detail {
+    position: absolute;
+    width: 60%;
+    max-width: 200px;
+}
+
+.team-logo-detail.away-logo {
+    bottom: 0;
+    left: 0;
+    transform: translate(-20%, 20%);
+}
+
+.team-logo-detail.home-logo {
+    top: 0;
+    right: 0;
+    transform: translate(20%, -20%);
+}
+
+.gradient-btn {
+    background: linear-gradient(to right, #7e22ce, #14b8a6);
+    color: #fff;
+    border: none;
+    transition: filter 0.2s;
+}
+
+.gradient-btn:hover {
+    filter: brightness(1.1);
+}

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Game Details</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/custom.css">
+</head>
+<body class="d-flex flex-column min-vh-100 gradient-bg">
+  <%- include('partials/header') %>
+
+  <div class="container my-4 flex-grow-1">
+    <div class="row g-4 align-items-center">
+      <div class="col-md-5">
+        <div class="team-diagonal-square mx-auto" style="--homeColor:<%= game.homeTeam && game.homeTeam.alternateColor ? game.homeTeam.alternateColor : '#ffffff' %>; --awayColor:<%= game.awayTeam && game.awayTeam.alternateColor ? game.awayTeam.alternateColor : '#ffffff' %>">
+          <div class="triangle home-bg" style="background: var(--homeColor);"></div>
+          <div class="triangle away-bg" style="background: var(--awayColor);"></div>
+          <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">
+          <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
+        </div>
+      </div>
+      <div class="col-md-7 text-white text-center text-md-start">
+        <h2 class="fw-bold mb-2" id="gameStart"></h2>
+        <h3 class="mb-3"><%= game.awayTeamName %> @ <%= game.homeTeamName %></h3>
+        <p class="mb-1">(<%= game.awayRecord || '0-0' %>) vs (<%= game.homeRecord || '0-0' %>)</p>
+        <p class="mb-3"><%= game.venue %> - <%= game.homeTeam && game.homeTeam.location ? game.homeTeam.location.city : '' %></p>
+        <form method="post" action="/games/<%= game._id %>/checkin" class="d-inline">
+          <button type="submit" class="btn gradient-btn px-4">Check-In</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const startDate = new Date('<%= game.startDate.toISOString() %>');
+    document.getElementById('gameStart').textContent =
+      new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(startDate);
+  </script>
+</body>
+</html>

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -30,6 +30,7 @@
            const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
       %>
         <div class="col">
+          <a href="/games/<%= game._id %>" class="game-link">
           <div class="card shadow-sm h-100 game-card p-3 text-center" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
             <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
             <div class="d-flex justify-content-between align-items-center position-relative mb-2">
@@ -48,6 +49,7 @@
               <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4">@</div>
             </div>
           </div>
+          </a>
         </div>
       <% }); %>
     </div>


### PR DESCRIPTION
## Summary
- upgrade Games page to use clickable cards
- style cards with hover scale
- add new Game Details page
- add check-in endpoint
- wire up new routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa4beb43083268f0daa3a30c6b870