### PR TITLE
Adjust game page visuals

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -1,6 +1,26 @@
 const Game = require('../models/Game');
 const Team = require('../models/Team');
 
+function hexToRgb(hex) {
+  if (!hex) return null;
+  const sanitized = hex.replace('#', '');
+  const bigint = parseInt(sanitized, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255
+  };
+}
+
+function colorDistance(c1, c2) {
+  if (!c1 || !c2) return Number.MAX_VALUE;
+  return Math.sqrt(
+    Math.pow(c1.r - c2.r, 2) +
+    Math.pow(c1.g - c2.g, 2) +
+    Math.pow(c1.b - c2.b, 2)
+  );
+}
+
 exports.listGames = async (req, res, next) => {
   try {
     const { team, date } = req.query;
@@ -50,7 +70,17 @@ exports.showGame = async (req, res, next) => {
       .populate('homeTeam')
       .populate('awayTeam');
     if (!game) return res.status(404).render('error', { message: 'Game not found' });
-    res.render('game', { game });
+    let homeBgColor = game.homeTeam && game.homeTeam.alternateColor ? game.homeTeam.alternateColor : '#ffffff';
+    const awayBgColor = game.awayTeam && game.awayTeam.alternateColor ? game.awayTeam.alternateColor : '#ffffff';
+
+    if (game.homeTeam && game.awayTeam && game.homeTeam.alternateColor && game.awayTeam.alternateColor) {
+      const diff = colorDistance(hexToRgb(game.homeTeam.alternateColor), hexToRgb(game.awayTeam.alternateColor));
+      if (diff < 60 && game.homeTeam.color) {
+        homeBgColor = game.homeTeam.color;
+      }
+    }
+
+    res.render('game', { game, homeBgColor, awayBgColor });
   } catch (err) {
     next(err);
   }

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -222,30 +222,32 @@
     height: 100%;
 }
 
+
 .team-diagonal-square .home-bg {
-    clip-path: polygon(100% 0, 100% 100%, 0 0);
+    /* Top-left triangle when divider runs bottom-left to top-right */
+    clip-path: polygon(0 0, 0 100%, 100% 0);
 }
 
 .team-diagonal-square .away-bg {
-    clip-path: polygon(0 100%, 0 0, 100% 100%);
+    /* Bottom-right triangle */
+    clip-path: polygon(100% 0, 100% 100%, 0 100%);
 }
 
 .team-logo-detail {
     position: absolute;
-    width: 60%;
-    max-width: 200px;
-}
-
-.team-logo-detail.away-logo {
-    bottom: 0;
-    left: 0;
-    transform: translate(-20%, 20%);
+    width: 50%;
+    max-width: 150px;
+    transform: translate(-50%, -50%);
 }
 
 .team-logo-detail.home-logo {
-    top: 0;
-    right: 0;
-    transform: translate(20%, -20%);
+    top: 33%;
+    left: 33%;
+}
+
+.team-logo-detail.away-logo {
+    top: 67%;
+    left: 67%;
 }
 
 .gradient-btn {

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -13,7 +13,7 @@
   <div class="container my-4 flex-grow-1">
     <div class="row g-4 align-items-center">
       <div class="col-md-5">
-        <div class="team-diagonal-square mx-auto" style="--homeColor:<%= game.homeTeam && game.homeTeam.alternateColor ? game.homeTeam.alternateColor : '#ffffff' %>; --awayColor:<%= game.awayTeam && game.awayTeam.alternateColor ? game.awayTeam.alternateColor : '#ffffff' %>">
+        <div class="team-diagonal-square mx-auto" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>">
           <div class="triangle home-bg" style="background: var(--homeColor);"></div>
           <div class="triangle away-bg" style="background: var(--awayColor);"></div>
           <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">


### PR DESCRIPTION
## Summary
- center team logos inside diagonal square and flip the divider
- swap alternate color if too close to opponent's alternate color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa8cf9f488326a4110c387d3c6f35