### PR TITLE
Update game cards with diagonal team logos

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -208,6 +208,43 @@
     transform: scale(1.05);
 }
 
+/* Game listing diagonal logos */
+.game-diagonal-square {
+    position: relative;
+    width: 100%;
+    padding-bottom: 100%;
+    overflow: hidden;
+}
+
+.game-diagonal-square .triangle {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.game-diagonal-square .away-bg {
+    clip-path: polygon(0 0, 0 100%, 100% 0);
+}
+
+.game-diagonal-square .home-bg {
+    clip-path: polygon(100% 0, 100% 100%, 0 100%);
+}
+
+.game-diagonal-square .triangle-logo {
+    width: 130%;
+    height: 130%;
+    object-fit: contain;
+}
+
+.team-name-wrapper {
+    width: 45%;
+    flex: 0 0 45%;
+}
+
 /* Game detail page */
 .team-diagonal-square {
     position: relative;

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -31,24 +31,26 @@
       %>
         <div class="col">
           <a href="/games/<%= game._id %>" class="game-link">
-          <div class="card shadow-sm h-100 game-card p-3 text-center" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-            <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
-            <div class="d-flex justify-content-between align-items-center position-relative mb-2">
-              <div class="logo-wrapper me-3">
-                <div class="team-logo-container">
-                  <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+            <div class="card shadow-sm h-100 game-card p-3 text-center" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+              <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+              <div class="game-diagonal-square mx-auto mb-3">
+                <div class="triangle away-bg" style="background:<%= awayColor %>">
+                  <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/100' %>" alt="<%= game.awayTeamName %>" class="triangle-logo">
                 </div>
-                <span class="team-name"><%= game.awayTeamName %></span>
-              </div>
-              <div class="logo-wrapper ms-3">
-                <div class="team-logo-container">
-                  <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                <div class="triangle home-bg" style="background:<%= homeColor %>">
+                  <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/100' %>" alt="<%= game.homeTeamName %>" class="triangle-logo">
                 </div>
-                <span class="team-name"><%= game.homeTeamName %></span>
               </div>
-              <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4">@</div>
+              <div class="d-flex justify-content-between align-items-center position-relative">
+                <div class="team-name-wrapper text-end flex-grow-1 pe-2">
+                  <span class="team-name"><%= game.awayTeamName %></span>
+                </div>
+                <div class="team-name-wrapper text-start flex-grow-1 ps-2">
+                  <span class="team-name"><%= game.homeTeamName %></span>
+                </div>
+                <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4">@</div>
+              </div>
             </div>
-          </div>
           </a>
         </div>
       <% }); %>
@@ -124,7 +126,7 @@
 
       function fitTeamNames(){
         document.querySelectorAll('.team-name').forEach(name=>{
-          const wrapper = name.parentElement; // logo-wrapper
+          const wrapper = name.parentElement; // team-name-wrapper
           const maxWidth = wrapper.clientWidth;
           let fontSize = parseFloat(window.getComputedStyle(name).fontSize);
           name.style.fontSize = fontSize + 'px';


### PR DESCRIPTION
## Summary
- show away team top-left and home team bottom-right in game list
- use clip-path triangles for background
- enlarge logos with overflow clipping
- adjust team name layout and resizing script

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687aafbe1df48326a638d451981b6703