### PR TITLE
Update game page logo layout and button

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -257,6 +257,10 @@
     position: absolute;
     width: 100%;
     height: 100%;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 
@@ -271,21 +275,16 @@
 }
 
 .team-logo-detail {
-    position: absolute;
-    width: 50%;
-    max-width: 150px;
-    transform: translate(-50%, -50%);
+    width: 75%;
+    height: 75%;
+    max-width: 225px;
+    max-height: 225px;
+    object-fit: contain;
 }
 
-.team-logo-detail.home-logo {
-    top: 33%;
-    left: 33%;
-}
+.team-logo-detail.home-logo {}
 
-.team-logo-detail.away-logo {
-    top: 67%;
-    left: 67%;
-}
+.team-logo-detail.away-logo {}
 
 .gradient-btn {
     background: linear-gradient(to right, #7e22ce, #14b8a6);
@@ -296,4 +295,14 @@
 
 .gradient-btn:hover {
     filter: brightness(1.1);
+}
+
+.checkin-btn {
+    background-color: #28a745;
+    border-color: #28a745;
+    color: #fff;
+}
+
+.checkin-btn:hover {
+    filter: brightness(1.05);
 }

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -15,21 +15,16 @@
       <div class="col-md-5">
         <div class="team-diagonal-square mx-auto" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>">
           <!-- Away Team: Top-left triangle -->
-          <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);"></div>
-          
+          <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);">
+            <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>"
+                 alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">
+          </div>
+
           <!-- Home Team: Bottom-right triangle -->
-          <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);"></div>
-          
-          <!-- Logos -->
-          <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>" 
-               alt="<%= game.awayTeamName %>" 
-               class="team-logo-detail away-logo" 
-               style="position:absolute; top:25%; left:25%; transform:translate(-50%, -50%);">
-          
-          <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>" 
-               alt="<%= game.homeTeamName %>" 
-               class="team-logo-detail home-logo" 
-               style="position:absolute; top:75%; left:75%; transform:translate(-50%, -50%);">
+          <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);">
+            <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>"
+                 alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
+          </div>
         </div>
       </div>
       <div class="col-md-7 text-white text-center text-md-start">
@@ -37,8 +32,8 @@
         <h3 class="mb-3"><%= game.awayTeamName %> @ <%= game.homeTeamName %></h3>
         <p class="mb-1">(<%= game.awayRecord || '0-0' %>) vs (<%= game.homeRecord || '0-0' %>)</p>
         <p class="mb-3"><%= game.venue %> - <%= game.homeTeam && game.homeTeam.location ? game.homeTeam.location.city : '' %></p>
-        <form method="post" action="/games/<%= game._id %>/checkin" class="d-inline">
-          <button type="submit" class="btn gradient-btn px-4">Check-In</button>
+        <form method="post" action="/games/<%= game._id %>/checkin" class="d-inline w-100">
+          <button type="submit" class="btn checkin-btn w-100">Check-In</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- center logos inside diagonal triangles on the game detail page
- enlarge team logos by 50%
- add green Check‑In button that stretches full width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab47da6b88326b6b5bfbbda01ddd1