### PR TITLE
Restore circular logos on games page

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -168,7 +168,7 @@
     height: 60px;
     border-radius: 50%;
     background: rgba(240,240,240,0.6);
-    border: 2px solid #fff;
+    border: 2px solid rgba(255,255,255,0.6);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -33,19 +33,17 @@
           <a href="/games/<%= game._id %>" class="game-link">
             <div class="card shadow-sm h-100 game-card p-3 text-center" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
               <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
-              <div class="game-diagonal-square mx-auto mb-3">
-                <div class="triangle away-bg" style="background:<%= awayColor %>">
-                  <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/100' %>" alt="<%= game.awayTeamName %>" class="triangle-logo">
-                </div>
-                <div class="triangle home-bg" style="background:<%= homeColor %>">
-                  <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/100' %>" alt="<%= game.homeTeamName %>" class="triangle-logo">
-                </div>
-              </div>
-              <div class="d-flex justify-content-between align-items-center position-relative">
-                <div class="team-name-wrapper text-end flex-grow-1 pe-2">
+              <div class="d-flex justify-content-between align-items-center position-relative mb-2">
+                <div class="logo-wrapper me-3">
+                  <div class="team-logo-container">
+                    <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                  </div>
                   <span class="team-name"><%= game.awayTeamName %></span>
                 </div>
-                <div class="team-name-wrapper text-start flex-grow-1 ps-2">
+                <div class="logo-wrapper ms-3">
+                  <div class="team-logo-container">
+                    <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                  </div>
                   <span class="team-name"><%= game.homeTeamName %></span>
                 </div>
                 <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4">@</div>
@@ -126,7 +124,7 @@
 
       function fitTeamNames(){
         document.querySelectorAll('.team-name').forEach(name=>{
-          const wrapper = name.parentElement; // team-name-wrapper
+          const wrapper = name.parentElement; // logo-wrapper
           const maxWidth = wrapper.clientWidth;
           let fontSize = parseFloat(window.getComputedStyle(name).fontSize);
           name.style.fontSize = fontSize + 'px';


### PR DESCRIPTION
## Summary
- revert games.ejs listing markup back to circular team logo layout
- use subtler semi‑transparent border for team logo containers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab9d8ddf0832683df9cbf892c67f3