### PR TITLE
Implement basic messaging

### DIFF
--- a/controllers/messagesController.js
+++ b/controllers/messagesController.js
@@ -1,0 +1,66 @@
+const Message = require('../models/Message');
+const User = require('../models/users');
+
+exports.listThreads = async (req, res, next) => {
+    try {
+        const threads = await Message.find({ participants: req.user.id })
+            .sort({ lastUpdated: -1 })
+            .populate('participants messages.sender');
+        res.render('messages', { threads });
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.viewThread = async (req, res, next) => {
+    try {
+        const thread = await Message.findById(req.params.id)
+            .populate('participants messages.sender');
+        if (!thread || !thread.participants.some(p => String(p._id||p) === req.user.id)) {
+            return res.redirect('/messages');
+        }
+        thread.unreadBy = thread.unreadBy.filter(u => String(u) !== req.user.id);
+        await thread.save();
+        res.render('thread', { thread });
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.startThread = async (req, res, next) => {
+    try {
+        const otherId = req.params.id;
+        if (otherId === req.user.id) return res.redirect('/profile');
+        let thread = await Message.findOne({
+            participants: { $all: [req.user.id, otherId] },
+            'participants.2': { $exists: false }
+        });
+        if (!thread) {
+            thread = new Message({ participants: [req.user.id, otherId], messages: [], unreadBy: [] });
+            await thread.save();
+            await User.updateMany({ _id: { $in: [req.user.id, otherId] } }, { $push: { messageThreads: thread._id } });
+        }
+        res.redirect(`/messages/${thread._id}`);
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.sendMessage = async (req, res, next) => {
+    try {
+        const thread = await Message.findById(req.params.id);
+        if (!thread || !thread.participants.some(p => String(p) === req.user.id)) {
+            return res.redirect('/messages');
+        }
+        const content = req.body.content;
+        if (content && content.trim().length) {
+            thread.messages.push({ sender: req.user.id, content: content.trim() });
+            thread.lastUpdated = new Date();
+            thread.unreadBy = thread.participants.filter(p => String(p) !== req.user.id);
+            await thread.save();
+        }
+        res.redirect(`/messages/${thread._id}`);
+    } catch (err) {
+        next(err);
+    }
+};

--- a/models/Message.js
+++ b/models/Message.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const messageSchema = new mongoose.Schema({
+    participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    messages: [{
+        sender: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        content: String,
+        timestamp: { type: Date, default: Date.now }
+    }],
+    unreadBy: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    lastUpdated: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Message', messageSchema);

--- a/models/users.js
+++ b/models/users.js
@@ -30,7 +30,8 @@ const userSchema = new mongoose.Schema({
     followingCount: {
         type: Number,
         default: 0
-    }
+    },
+    messageThreads: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Message' }]
 });
 
 // Automatically hash a password before saving

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -316,3 +316,13 @@
 .checkin-btn:hover {
     filter: brightness(1.05);
 }
+
+.msg-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    position: absolute;
+    top: 0;
+    right: 0;
+    background-color: red;
+}

--- a/views/messages.ejs
+++ b/views/messages.ejs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Messages</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <%- include('partials/header') %>
+    <div class="container my-4 flex-grow-1">
+        <% if (threads.length === 0) { %>
+            <div class="d-flex justify-content-center align-items-center" style="height:60vh;">
+                <h4 class="text-muted">No Messages Yet</h4>
+            </div>
+        <% } else { %>
+            <div class="list-group">
+                <% threads.forEach(function(t){
+                    const other = t.participants.find(p=> String(p._id||p) !== locals.loggedInUser.id);
+                    const last = t.messages[t.messages.length-1];
+                    const unread = t.unreadBy.some(u=> String(u) === locals.loggedInUser.id);
+                %>
+                <a href="/messages/<%= t._id %>" class="list-group-item list-group-item-action d-flex align-items-center position-relative">
+                    <img src="<%= other.uploadedPic ? ('/uploads/profilePics/' + other.uploadedPic) : (other.profileImage || 'https://via.placeholder.com/40') %>" class="avatar avatar-sm me-2">
+                    <div class="flex-grow-1">
+                        <div class="fw-bold"><%= other.username %></div>
+                        <% if (last) { %>
+                            <small class="text-muted"><%= last.content.slice(0,40) %></small>
+                        <% } %>
+                    </div>
+                    <% if(last){ %><small class="text-nowrap ms-2"><%= new Date(last.timestamp).toLocaleString() %></small><% } %>
+                    <% if(unread){ %>
+                        <span class="position-absolute top-0 end-0 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
+                    <% } %>
+                </a>
+                <% }) %>
+            </div>
+        <% } %>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="/css/custom.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 <header class="shadow-sm bg-white">
   <nav class="container d-flex align-items-center justify-content-between py-3">
     <a href="/" class="fw-bold fs-4 text-decoration-none px-3 py-1 rounded-pill <%= currentPath === '/' ? 'bg-primary text-white' : 'text-body' %>">App Logo</a>
@@ -12,6 +13,12 @@
     </ul>
     <div class="text-nowrap d-flex align-items-center">
       <% if (loggedInUser) { %>
+        <a href="/messages" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
+          <i class="bi bi-envelope-fill fs-4"></i>
+          <% if(hasUnreadMessages){ %>
+            <span class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
+          <% } %>
+        </a>
         <a href="/profile" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">
           <img src="<%= loggedInUser.uploadedPic ? ('/uploads/profilePics/' + loggedInUser.uploadedPic) : (loggedInUser.profileImage || 'https://via.placeholder.com/40') %>" alt="Profile" class="nav-profile-icon">
         </a>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -147,6 +147,11 @@
                 <div class="col-md-6 text-center text-md-start">
                     <div class="d-flex flex-column flex-md-row align-items-center">
                         <h2 class="fw-bold mb-1 me-md-3"><%= user.username %></h2>
+                        <% if(!isCurrentUser){ %>
+                        <form method="post" action="/messages/start/<%= user._id %>">
+                            <button type="submit" class="btn btn-outline-light btn-sm ms-md-2">Message</button>
+                        </form>
+                        <% } %>
                     </div>
                     <p class="mb-2">@<%= user.email %></p>
                     <div class="d-flex justify-content-center justify-content-md-start">

--- a/views/thread.ejs
+++ b/views/thread.ejs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Conversation</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <%- include('partials/header') %>
+    <div class="container my-4 flex-grow-1 d-flex flex-column">
+        <div class="flex-grow-1 mb-3 overflow-auto" id="msgContainer">
+            <% thread.messages.forEach(function(m){ const isMine = String(m.sender._id||m.sender) === loggedInUser.id; %>
+                <div class="d-flex mb-2 <%= isMine ? 'justify-content-end' : 'justify-content-start' %>">
+                    <div class="p-2 rounded" style="max-width:70%; background-color:<%= isMine ? '#d1e7ff' : '#f1f1f1' %>">
+                        <%= m.content %><br>
+                        <small class="text-muted"><%= new Date(m.timestamp).toLocaleString() %></small>
+                    </div>
+                </div>
+            <% }) %>
+        </div>
+        <form method="POST" action="/messages/<%= thread._id %>/send" class="d-flex">
+            <input type="text" name="content" class="form-control me-2" autocomplete="off" required>
+            <button type="submit" class="btn btn-primary">Send</button>
+        </form>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        const container = document.getElementById('msgContainer');
+        container.scrollTop = container.scrollHeight;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Message model and message controller
- update User model with message thread ids
- show unread message indicator in nav
- implement messages list and thread views
- allow starting conversations from profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687acc7ffd088326aa6b95cfca745a27