### PR TITLE
Add mutual follow checks and modal-based messaging

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -169,8 +169,14 @@ exports.viewUser = async (req, res, next) => {
         const user = await User.findById(req.params.id).populate('favoriteTeams');
         if (!user) return res.redirect('/profile');
         const isCurrentUser = req.user && String(req.user.id) === String(user._id);
-        const isFollowing = req.user && user.followers.some(f => String(f) === String(req.user.id));
-        res.render('profile', { user, isCurrentUser, isFollowing, viewer: req.user });
+        let isFollowing = false, canMessage = false;
+        if(req.user){
+            const viewer = await User.findById(req.user.id);
+            isFollowing = viewer.following.some(f => String(f) === String(user._id));
+            const followsBack = user.following.some(f => String(f) === String(viewer._id));
+            canMessage = isFollowing && followsBack;
+        }
+        res.render('profile', { user, isCurrentUser, isFollowing, canMessage, viewer: req.user });
     } catch (err) {
         next(err);
     }

--- a/main.js
+++ b/main.js
@@ -99,6 +99,7 @@ app.get('/users/:id/followers', requireAuth, profileController.viewFollowers);
 app.get('/users/:id/following', requireAuth, profileController.viewFollowing);
 
 app.get('/messages', requireAuth, messagesController.listThreads);
+app.get('/messages/modal', requireAuth, messagesController.renderModal);
 app.get('/messages/:id', requireAuth, messagesController.viewThread);
 app.post('/messages/start/:id', requireAuth, messagesController.startThread);
 app.post('/messages/:id/send', requireAuth, messagesController.sendMessage);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -326,3 +326,20 @@
     right: 0;
     background-color: red;
 }
+
+/* Messaging modal styles */
+.messages-modal .modal-dialog{ max-width:60vw; }
+@media (max-width:768px){
+  .messages-modal .modal-dialog{ max-width:90vw; }
+  .messages-modal .modal-body{ flex-direction:column; }
+  .messages-modal .threads{ width:100% !important; max-height:200px !important; }
+  .messages-modal .conversation{ width:100% !important; }
+}
+.messages-modal .modal-content{
+  background: linear-gradient(to right, #7e22ce, #14b8a6);
+  background-clip: padding-box;
+  border-radius:1rem;
+  border:1px solid rgba(255,255,255,0.2);
+  color:#fff;
+  backdrop-filter: blur(10px);
+}

--- a/public/js/messagesModal.js
+++ b/public/js/messagesModal.js
@@ -1,0 +1,79 @@
+// Handles loading and displaying the messaging modal
+(function(){
+  const modalEl = document.getElementById('messagesModal');
+  if(!modalEl) return;
+  const bsModal = new bootstrap.Modal(modalEl);
+
+  async function loadModal(threadId){
+    try{
+      const res = await fetch(`/messages/modal${threadId?`?thread=${threadId}`:''}`);
+      const html = await res.text();
+      modalEl.querySelector('.modal-content').innerHTML = html;
+      bsModal.show();
+      const msgContainer = modalEl.querySelector('#msgContainer');
+      if(msgContainer) msgContainer.scrollTop = msgContainer.scrollHeight;
+    }catch(err){
+      console.error(err);
+    }
+  }
+
+  document.querySelectorAll('a[href="/messages"]').forEach(link=>{
+    link.addEventListener('click', function(e){
+      e.preventDefault();
+      loadModal();
+    });
+  });
+
+  document.addEventListener('click', async function(e){
+    const btn = e.target.closest('.message-btn');
+    if(btn){
+      e.preventDefault();
+      const userId = btn.dataset.user;
+      try{
+        const res = await fetch(`/messages/start/${userId}`, {method:'POST', headers:{'Accept':'application/json'}});
+        if(!res.ok){
+          const data = await res.json().catch(()=>({}));
+          alert(data.error || 'You can only message users who follow you back.');
+          return;
+        }
+        const data = await res.json();
+        loadModal(data.threadId);
+      }catch(err){
+        console.error(err);
+      }
+    }
+  });
+
+  modalEl.addEventListener('click', function(e){
+    const link = e.target.closest('.thread-link');
+    if(link){
+      e.preventDefault();
+      const id = link.dataset.thread;
+      loadModal(id);
+    }
+  });
+
+  modalEl.addEventListener('submit', async function(e){
+    if(e.target.id === 'messageForm'){
+      e.preventDefault();
+      const threadId = e.target.dataset.thread;
+      const input = modalEl.querySelector('#messageInput');
+      const content = input.value.trim();
+      if(!content) return;
+      try{
+        const res = await fetch(`/messages/${threadId}/send`, {
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded','Accept':'application/json'},
+          body: new URLSearchParams({content})
+        });
+        if(!res.ok){
+          const data = await res.json().catch(()=>({}));
+          alert(data.error || 'You can only message users who follow you back.');
+          return;
+        }
+        input.value = '';
+        loadModal(threadId);
+      }catch(err){console.error(err);}
+    }
+  });
+})();

--- a/views/messagesModal.ejs
+++ b/views/messagesModal.ejs
@@ -1,0 +1,42 @@
+<div class="modal-header border-0 pb-0">
+  <h5 class="modal-title">Messages</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body d-flex p-0" style="min-height:60vh;">
+  <div class="threads list-group flex-shrink-0" style="width:35%; max-height:60vh; overflow:auto;">
+    <% if (threads.length === 0) { %>
+      <div class="text-center text-white p-3">No Messages</div>
+    <% } else { %>
+      <% threads.forEach(function(t){ const other = t.participants.find(p=> String(p._id||p) !== loggedInUser.id); const last = t.messages[t.messages.length-1]; const unread = t.unreadBy.some(u=> String(u) === loggedInUser.id); %>
+        <a href="#" data-thread="<%= t._id %>" class="thread-link list-group-item list-group-item-action d-flex align-items-center position-relative <%= currentThread && String(currentThread._id)===String(t._id)?'active':'' %>">
+          <img src="<%= other.uploadedPic ? ('/uploads/profilePics/' + other.uploadedPic) : (other.profileImage || 'https://via.placeholder.com/40') %>" class="avatar avatar-sm me-2">
+          <div class="flex-grow-1">
+            <div class="fw-bold"><%= other.username %></div>
+            <% if (last) { %><small class="text-muted"><%= last.content.slice(0,40) %></small><% } %>
+          </div>
+          <% if(unread){ %><span class="position-absolute top-0 end-0 translate-middle p-1 bg-danger border border-light rounded-circle"></span><% } %>
+        </a>
+      <% }) %>
+    <% } %>
+  </div>
+  <div class="conversation flex-grow-1 d-flex flex-column" style="background-color:rgba(255,255,255,0.2);">
+    <% if(currentThread){ %>
+      <div class="flex-grow-1 overflow-auto p-3" id="msgContainer">
+        <% currentThread.messages.forEach(function(m){ const isMine = String(m.sender._id||m.sender) === loggedInUser.id; %>
+          <div class="d-flex mb-2 <%= isMine ? 'justify-content-end' : 'justify-content-start' %>">
+            <div class="p-2 rounded" style="max-width:70%; background-color:<%= isMine ? '#d1e7ff' : '#f1f1f1' %>">
+              <%= m.content %><br>
+              <small class="text-muted"><%= new Date(m.timestamp).toLocaleString() %></small>
+            </div>
+          </div>
+        <% }) %>
+      </div>
+      <form id="messageForm" data-thread="<%= currentThread._id %>" class="d-flex p-2 border-top">
+        <input type="text" id="messageInput" class="form-control me-2" autocomplete="off" required>
+        <button class="btn btn-primary">Send</button>
+      </form>
+    <% } else { %>
+      <div class="flex-grow-1 d-flex align-items-center justify-content-center text-white">Select a conversation</div>
+    <% } %>
+  </div>
+</div>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -13,7 +13,7 @@
     </ul>
     <div class="text-nowrap d-flex align-items-center">
       <% if (loggedInUser) { %>
-        <a href="/messages" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
+        <a href="/messages" id="navMessages" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
           <i class="bi bi-envelope-fill fs-4"></i>
           <% if(hasUnreadMessages){ %>
             <span class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
@@ -30,3 +30,9 @@
     </div>
   </nav>
 </header>
+<div class="modal fade messages-modal" id="messagesModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content"></div>
+  </div>
+</div>
+<script src="/js/messagesModal.js"></script>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -148,9 +148,11 @@
                     <div class="d-flex flex-column flex-md-row align-items-center">
                         <h2 class="fw-bold mb-1 me-md-3"><%= user.username %></h2>
                         <% if(!isCurrentUser){ %>
-                        <form method="post" action="/messages/start/<%= user._id %>">
-                            <button type="submit" class="btn btn-outline-light btn-sm ms-md-2">Message</button>
-                        </form>
+                            <% if(canMessage){ %>
+                                <button class="btn btn-outline-light btn-sm ms-md-2 message-btn" data-user="<%= user._id %>">Message</button>
+                            <% } else { %>
+                                <button class="btn btn-outline-light btn-sm ms-md-2" disabled title="Messaging requires a mutual follow">Message</button>
+                            <% } %>
                         <% } %>
                     </div>
                     <p class="mb-2">@<%= user.email %></p>


### PR DESCRIPTION
## Summary
- only allow messages for mutually following users
- disable message button when mutual follow missing
- serve messaging interface as a modal
- add responsive modal styles and client script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e616f502c8326bdffb680238cf2e0