### PR TITLE
Enhance messaging UI

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -328,7 +328,7 @@
 }
 
 /* Messaging modal styles */
-.messages-modal .modal-dialog{ max-width:60vw; }
+.messages-modal .modal-dialog{ max-width:50vw; }
 @media (max-width:768px){
   .messages-modal .modal-dialog{ max-width:90vw; }
   .messages-modal .modal-body{ flex-direction:column; }
@@ -342,4 +342,10 @@
   border:1px solid rgba(255,255,255,0.2);
   color:#fff;
   backdrop-filter: blur(10px);
+}
+
+/* Timestamp styling */
+.message-timestamp{
+  font-size:0.7em;
+  color:rgba(255,255,255,0.6);
 }

--- a/views/messages.ejs
+++ b/views/messages.ejs
@@ -29,7 +29,7 @@
                             <small class="text-muted"><%= last.content.slice(0,40) %></small>
                         <% } %>
                     </div>
-                    <% if(last){ %><small class="text-nowrap ms-2"><%= new Date(last.timestamp).toLocaleString() %></small><% } %>
+                    <% if(last){ %><small class="text-nowrap ms-2 message-timestamp"><%= new Date(last.timestamp).toLocaleString() %></small><% } %>
                     <% if(unread){ %>
                         <span class="position-absolute top-0 end-0 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
                     <% } %>

--- a/views/messagesModal.ejs
+++ b/views/messagesModal.ejs
@@ -26,13 +26,13 @@
           <div class="d-flex mb-2 <%= isMine ? 'justify-content-end' : 'justify-content-start' %>">
             <div class="p-2 rounded" style="max-width:70%; background-color:<%= isMine ? '#d1e7ff' : '#f1f1f1' %>">
               <%= m.content %><br>
-              <small class="text-muted"><%= new Date(m.timestamp).toLocaleString() %></small>
+              <small class="text-muted message-timestamp"><%= new Date(m.timestamp).toLocaleString() %></small>
             </div>
           </div>
         <% }) %>
       </div>
       <form id="messageForm" data-thread="<%= currentThread._id %>" class="d-flex p-2 border-top">
-        <input type="text" id="messageInput" class="form-control me-2" autocomplete="off" required>
+        <input type="text" id="messageInput" class="form-control me-2" autocomplete="off" required placeholder="Type message here">
         <button class="btn btn-primary">Send</button>
       </form>
     <% } else { %>

--- a/views/thread.ejs
+++ b/views/thread.ejs
@@ -15,13 +15,13 @@
                 <div class="d-flex mb-2 <%= isMine ? 'justify-content-end' : 'justify-content-start' %>">
                     <div class="p-2 rounded" style="max-width:70%; background-color:<%= isMine ? '#d1e7ff' : '#f1f1f1' %>">
                         <%= m.content %><br>
-                        <small class="text-muted"><%= new Date(m.timestamp).toLocaleString() %></small>
+                        <small class="text-muted message-timestamp"><%= new Date(m.timestamp).toLocaleString() %></small>
                     </div>
                 </div>
             <% }) %>
         </div>
         <form method="POST" action="/messages/<%= thread._id %>/send" class="d-flex">
-            <input type="text" name="content" class="form-control me-2" autocomplete="off" required>
+            <input type="text" name="content" class="form-control me-2" autocomplete="off" required placeholder="Type message here">
             <button type="submit" class="btn btn-primary">Send</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- update messaging modal widths for desktop and mobile
- add placeholder text to message inputs
- style timestamps with smaller font and lighter color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e65fd72c48326baf6677fa72fba44