### PR TITLE
Improve team search and styling

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -98,7 +98,13 @@ exports.searchTeams = async (req, res, next) => {
   try {
     const q = req.query.q || '';
     if (!q) return res.json([]);
-    const teams = await Team.find({ school: { $regex: q, $options: 'i' } })
+    const homeIds = await Game.distinct('homeTeam');
+    const awayIds = await Game.distinct('awayTeam');
+    const activeIds = [...new Set([...homeIds, ...awayIds])];
+    const teams = await Team.find({
+        _id: { $in: activeIds },
+        school: { $regex: q, $options: 'i' }
+      })
       .select('school logos _id')
       .limit(5);
     res.json(teams);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -365,6 +365,13 @@
   backdrop-filter: blur(8px);
   color: #fff;
   border-radius: .5rem;
+  font-weight: bold;
+}
+.glass-control:focus{
+  background-color: rgba(255,255,255,0.2);
+  color:#fff;
+  font-weight: bold;
+  box-shadow: 0 0 0 0.2rem rgba(255,255,255,0.3);
 }
 .glass-control::placeholder{color:#fff;}
 


### PR DESCRIPTION
## Summary
- keep glass appearance when search input is focused
- show typed text in bold white text
- restrict team search results to teams present in current games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e775f95b88326a0a874cffc24db9a