### PR TITLE
Refine wishlist followers display

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -146,7 +146,15 @@ exports.showGame = async (req, res, next) => {
       }
     }
 
-    res.render('game', { game, homeBgColor, awayBgColor });
+    let followerWishers = [];
+    if(req.user){
+      const User = require('../models/users');
+      const viewer = await User.findById(req.user.id)
+        .populate({path:'followers', select:'username uploadedPic profileImage wishlist'});
+      followerWishers = (viewer.followers || []).filter(u => (u.wishlist || []).some(w => String(w) === String(game._id)));
+    }
+
+    res.render('game', { game, homeBgColor, awayBgColor, followerWishers });
   } catch (err) {
     next(err);
   }

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -125,6 +125,8 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    position: relative;
+    padding-right: 50px;
 }
 
 .team-logo {
@@ -381,8 +383,16 @@
 }
 
 /* Wishlist and followers */
-.followers-col{ width:40px; }
+.followers-col{
+  position:absolute;
+  top:50%;
+  right:0.25rem;
+  transform:translateY(-50%);
+  width:40px;
+}
 .follower-avatar img{ width:30px; height:30px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,0.8); }
+.followers-row a img{ width:30px; height:30px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,0.8); }
+.followers-row .more-followers{margin-left:0.25rem;}
 .more-followers{ font-size:0.8rem; color:#fff; }
 .wishlist-btn{
   top:0.5rem;
@@ -399,4 +409,8 @@
   cursor:pointer;
   color:#e3342f;
 }
+.wishlist-btn:hover{
+  background: rgba(255,255,255,0.4);
+}
+.wishlist-btn:hover .bi{color:#fff;}
 .wishlist-btn .bi{font-size:1.2rem;}

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -26,6 +26,17 @@
                  alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
           </div>
         </div>
+        <% if(followerWishers && followerWishers.length){ const extra = followerWishers.length - 5; %>
+        <div class="followers-row d-flex justify-content-center gap-2 mt-2 flex-wrap">
+          <% followerWishers.slice(0,5).forEach(function(u){ %>
+            <a href="/users/<%= u._id %>" title="<%= u.username %>">
+              <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/30') %>" class="avatar avatar-sm">
+            </a>
+          <% }); if(extra>0){ %>
+            <div class="more-followers align-self-center">+<%= extra %></div>
+          <% } %>
+        </div>
+        <% } %>
       </div>
       <div class="col-md-7 text-white text-center text-md-start">
         <h2 class="fw-bold mb-2" id="gameStart"></h2>

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -35,19 +35,18 @@
            const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
       %>
       <div class="col" data-id="<%= game._id %>" data-distance="<%= typeof game.distance === 'number' ? game.distance.toFixed(1) : '' %>" data-start="<%= game.startDate.toISOString() %>">
-        <div class="d-flex">
-          <div class="followers-col d-flex flex-column align-items-center me-2">
+        <a href="/games/<%= game._id %>" class="game-link d-block">
+          <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+            <div class="wishlist-btn position-absolute"><i class="bi <%= game.isWishlisted ? 'bi-heart-fill' : 'bi-heart' %>"></i></div>
+            <div class="followers-col d-flex flex-column align-items-center">
             <% if(game.followedWishers && game.followedWishers.length){ const extra = game.followedWishers.length - 4; game.followedWishers.slice(0,4).forEach(function(u){ %>
-              <a href="/users/<%= u._id %>" class="follower-avatar" title="<%= u.username %>">
+              <a href="/users/<%= u._id %>" class="follower-avatar" title="<%= u.username %>" onclick="event.stopPropagation();">
                 <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/30') %>" class="avatar avatar-sm">
               </a>
             <% }); if(extra>0){ %>
               <div class="more-followers">+<%= extra %></div>
             <% } } %>
-          </div>
-          <a href="/games/<%= game._id %>" class="game-link flex-grow-1">
-            <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-              <div class="wishlist-btn position-absolute"><i class="bi <%= game.isWishlisted ? 'bi-heart-fill' : 'bi-heart' %>"></i></div>
+            </div>
               <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
               <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                 <div class="logo-wrapper me-3">
@@ -67,10 +66,9 @@
               <% if(typeof game.distance === 'number'){ %>
                 <span class="badge bg-success near-badge"><%= game.distance.toFixed(0) %> mi</span>
               <% } %>
-            </div>
-          </a>
+              </div>
+            </a>
         </div>
-      </div>
       <% }); %>
     </div>
   </div>
@@ -250,6 +248,20 @@
 
       function attachWishlistHandlers(){
         document.querySelectorAll('.wishlist-btn').forEach(btn=>{
+          const icon = btn.querySelector('i');
+          btn.dataset.saved = icon.classList.contains('bi-heart-fill') ? '1' : '0';
+          btn.addEventListener('mouseenter', ()=>{
+            if(btn.dataset.saved==='0'){
+              icon.classList.remove('bi-heart');
+              icon.classList.add('bi-heart-fill');
+            }
+          });
+          btn.addEventListener('mouseleave', ()=>{
+            if(btn.dataset.saved==='0'){
+              icon.classList.add('bi-heart');
+              icon.classList.remove('bi-heart-fill');
+            }
+          });
           btn.addEventListener('click',async function(e){
             e.preventDefault();
             e.stopPropagation();
@@ -258,8 +270,8 @@
             const res = await fetch(`/games/${gameId}/wishlist`,{method:'POST'});
             if(!res.ok) return;
             const data = await res.json();
-            const icon = btn.querySelector('i');
             icon.className = data.action==='added' ? 'bi bi-heart-fill' : 'bi bi-heart';
+            btn.dataset.saved = data.action==='added' ? '1' : '0';
           });
         });
       }


### PR DESCRIPTION
## Summary
- adjust layout of game cards to show followed users inside each card
- show followers who wishlisted a game on the game detail page
- compute follower wishers in the controller
- style wishlist and follower components
- provide hover fill feedback on wishlist heart and AJAX update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e90464a0883269c2c0c1c5c376503