### PR TITLE
Fix clickable games, move wishlist column

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -126,7 +126,7 @@
     flex-direction: column;
     justify-content: center;
     position: relative;
-    padding-right: 50px;
+    padding-left: 50px;
 }
 
 .team-logo {
@@ -386,7 +386,7 @@
 .followers-col{
   position:absolute;
   top:50%;
-  right:0.25rem;
+  left:0.25rem;
   transform:translateY(-50%);
   width:40px;
 }

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -35,18 +35,10 @@
            const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
       %>
       <div class="col" data-id="<%= game._id %>" data-distance="<%= typeof game.distance === 'number' ? game.distance.toFixed(1) : '' %>" data-start="<%= game.startDate.toISOString() %>">
-        <a href="/games/<%= game._id %>" class="game-link d-block">
-          <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-            <div class="wishlist-btn position-absolute"><i class="bi <%= game.isWishlisted ? 'bi-heart-fill' : 'bi-heart' %>"></i></div>
-            <div class="followers-col d-flex flex-column align-items-center">
-            <% if(game.followedWishers && game.followedWishers.length){ const extra = game.followedWishers.length - 4; game.followedWishers.slice(0,4).forEach(function(u){ %>
-              <a href="/users/<%= u._id %>" class="follower-avatar" title="<%= u.username %>" onclick="event.stopPropagation();">
-                <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/30') %>" class="avatar avatar-sm">
-              </a>
-            <% }); if(extra>0){ %>
-              <div class="more-followers">+<%= extra %></div>
-            <% } } %>
-            </div>
+        <div class="position-relative">
+          <a href="/games/<%= game._id %>" class="game-link d-block">
+            <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+              <div class="wishlist-btn position-absolute"><i class="bi <%= game.isWishlisted ? 'bi-heart-fill' : 'bi-heart' %>"></i></div>
               <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
               <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                 <div class="logo-wrapper me-3">
@@ -68,6 +60,18 @@
               <% } %>
               </div>
             </a>
+          <% if(game.followedWishers && game.followedWishers.length){ const extra = game.followedWishers.length - 4; %>
+          <div class="followers-col d-flex flex-column align-items-center">
+            <% game.followedWishers.slice(0,4).forEach(function(u){ %>
+              <a href="/users/<%= u._id %>" class="follower-avatar" title="<%= u.username %>" onclick="event.stopPropagation();">
+                <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/30') %>" class="avatar avatar-sm">
+              </a>
+            <% }); if(extra>0){ %>
+              <div class="more-followers">+<%= extra %></div>
+            <% } %>
+          </div>
+          <% } %>
+        </div>
         </div>
       <% }); %>
     </div>


### PR DESCRIPTION
## Summary
- keep game matchup containers clickable when wishlist avatars appear
- move wishlist follower avatars column to the left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ea7a586008326bc554197fdf31837