### PR TITLE
Improve wishlist avatar hover and dynamic team names

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -193,7 +193,7 @@
     line-height: 1.1;
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
+    transition: font-size 0.2s;
 }
 
 .game-date {
@@ -388,7 +388,12 @@
   top:50%;
   left:0.25rem;
   transform:translateY(-50%);
+  transform-origin:left center;
+  transition:transform 0.2s;
   width:40px;
+}
+.position-relative:hover .followers-col{
+  transform:translateY(-50%) scale(1.05);
 }
 .follower-avatar img{ width:30px; height:30px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,0.8); }
 .followers-row a img{ width:30px; height:30px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,0.8); }

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -123,8 +123,20 @@
         });
       }
 
+      function adjustTeamNames(){
+        document.querySelectorAll('.team-name').forEach(el=>{
+          el.style.fontSize = '';
+          let size = parseFloat(getComputedStyle(el).fontSize);
+          while(el.scrollWidth > el.clientWidth && size > 8){
+            size -= 0.5;
+            el.style.fontSize = size + 'px';
+          }
+        });
+      }
+
       formatDates();
       applyTextColors();
+      adjustTeamNames();
 
       const GEO_KEY = 'userCoords';
       const latInput = document.getElementById('latInput');
@@ -237,6 +249,7 @@
           container.classList.remove('fading');
           formatDates();
           applyTextColors();
+          adjustTeamNames();
           attachWishlistHandlers();
         },150);
         history.replaceState(null,'',url);
@@ -281,6 +294,7 @@
       }
 
       attachWishlistHandlers();
+      window.addEventListener('resize', adjustTeamNames);
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- keep team names visible by shrinking text instead of truncating
- sync wishlist follower avatars with game card hover
- ensure avatars and team names update after filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eaa8f69648326bf2ea10f631bcfc3