### PR TITLE
Add tab interface to profile page

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -416,3 +416,29 @@
 }
 .wishlist-btn:hover .bi{color:#fff;}
 .wishlist-btn .bi{font-size:1.2rem;}
+
+/* Profile tabs */
+.profile-tabs{
+  border:none;
+  background-color:rgba(255,255,255,0.15);
+  backdrop-filter:blur(8px);
+  overflow-x:auto;
+  white-space:nowrap;
+  -ms-overflow-style:none;
+  scrollbar-width:none;
+}
+.profile-tabs::-webkit-scrollbar{display:none;}
+.profile-tab{
+  color:rgba(255,255,255,0.8);
+  border:none;
+  border-bottom:3px solid transparent;
+  margin-right:.5rem;
+  transition:color .3s, background-color .3s, box-shadow .3s;
+}
+.profile-tab:hover{color:#fff;}
+.profile-tab.active{
+  color:#fff;
+  background:linear-gradient(to right,#7e22ce,#14b8a6);
+  box-shadow:0 0 0.5rem rgba(20,184,166,0.6);
+}
+.empty-tab-message{color:rgba(255,255,255,0.8);}

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -188,44 +188,67 @@
             
     </div>
 
-    <% if (wishlistGames && wishlistGames.length > 0) { %>
-    <div class="container my-4" id="wishlistSection">
-        <h4>Wishlisted Games</h4>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="wishlistContainer">
-            <% wishlistGames.forEach(function(game){
-                 const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
-                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
-            <div class="col">
-                <a href="/games/<%= game._id %>" class="game-link">
-                    <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-                        <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
-                        <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
-                            <div class="logo-wrapper me-3">
-                                <div class="team-logo-container">
-                                    <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
-                                </div>
-                                <span class="team-name"><%= game.awayTeamName %></span>
-                            </div>
-                            <div class="logo-wrapper ms-3">
-                                <div class="team-logo-container">
-                                    <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
-                                </div>
-                                <span class="team-name"><%= game.homeTeamName %></span>
-                            </div>
-                            <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
-                        </div>
-                    </div>
-                </a>
+    <div class="container mt-4">
+        <ul class="nav nav-tabs profile-tabs" id="profileTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active profile-tab" id="badges-tab" data-bs-toggle="tab" data-bs-target="#badges" type="button" role="tab" aria-controls="badges" aria-selected="true">Badges</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link profile-tab" id="games-tab" data-bs-toggle="tab" data-bs-target="#gamesTab" type="button" role="tab" aria-controls="gamesTab" aria-selected="false">Games</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link profile-tab" id="stats-tab" data-bs-toggle="tab" data-bs-target="#stats" type="button" role="tab" aria-controls="stats" aria-selected="false">Stats</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link profile-tab" id="wishlist-tab" data-bs-toggle="tab" data-bs-target="#wishlist" type="button" role="tab" aria-controls="wishlist" aria-selected="false">Wishlist</button>
+            </li>
+        </ul>
+        <div class="tab-content py-4">
+            <div class="tab-pane fade show active" id="badges" role="tabpanel" aria-labelledby="badges-tab">
+                <p class="empty-tab-message text-center">No content yet for this tab.</p>
             </div>
-            <% }); %>
+            <div class="tab-pane fade" id="gamesTab" role="tabpanel" aria-labelledby="games-tab">
+                <p class="empty-tab-message text-center">No content yet for this tab.</p>
+            </div>
+            <div class="tab-pane fade" id="stats" role="tabpanel" aria-labelledby="stats-tab">
+                <p class="empty-tab-message text-center">No content yet for this tab.</p>
+            </div>
+            <div class="tab-pane fade" id="wishlist" role="tabpanel" aria-labelledby="wishlist-tab">
+                <% if (wishlistGames && wishlistGames.length > 0) { %>
+                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="wishlistContainer">
+                    <% wishlistGames.forEach(function(game){
+                         const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
+                         const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
+                    <div class="col">
+                        <a href="/games/<%= game._id %>" class="game-link">
+                            <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                                <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+                                <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                                    <div class="logo-wrapper me-3">
+                                        <div class="team-logo-container">
+                                            <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                                        </div>
+                                        <span class="team-name"><%= game.awayTeamName %></span>
+                                    </div>
+                                    <div class="logo-wrapper ms-3">
+                                        <div class="team-logo-container">
+                                            <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                                        </div>
+                                        <span class="team-name"><%= game.homeTeamName %></span>
+                                    </div>
+                                    <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                    <% }); %>
+                </div>
+                <% } else { %>
+                <p class="empty-tab-message text-center">No games wishlisted.</p>
+                <% } %>
+            </div>
         </div>
     </div>
-    <% } else { %>
-    <div class="container my-4" id="wishlistSection">
-        <h4>Wishlisted Games</h4>
-        <p>No games wishlisted.</p>
-    </div>
-    <% } %>
 </div>
 
     <% if (isCurrentUser) { %>
@@ -400,6 +423,10 @@
                 const color=chooseTextColor([away,home]);
                 card.querySelectorAll('.game-date, .team-name').forEach(e=>{e.style.color=color;});
             });
+        }
+        const wishlistTabEl = document.getElementById('wishlist-tab');
+        if(wishlistTabEl){
+            wishlistTabEl.addEventListener('shown.bs.tab', formatWishlist);
         }
         formatWishlist();
     </script>


### PR DESCRIPTION
## Summary
- overhaul profile layout to include tabs for Badges, Games, Stats and Wishlist
- style new tabs with glassy gradient look
- move wishlist games into Wishlist tab
- add JS tab behavior hook for wishlist formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb61321508326ba10cef3b0d3072f