### PR TITLE
Refactor profile layout

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -438,7 +438,23 @@
 .profile-tab:hover{color:#fff;}
 .profile-tab.active{
   color:#fff;
-  background:linear-gradient(to right,#7e22ce,#14b8a6);
+  background-color:rgba(255,255,255,0.25);
   box-shadow:0 0 0.5rem rgba(20,184,166,0.6);
+  position:relative;
+}
+.profile-tab.active::after{
+  content:'';
+  position:absolute;
+  left:0;
+  right:0;
+  bottom:0;
+  height:3px;
+  background:linear-gradient(to right,#14b8a6,#7e22ce);
+  border-radius:2px;
+}
+.profile-tab-content{
+  background-color:rgba(255,255,255,0.15);
+  backdrop-filter:blur(8px);
+  border-radius:.5rem;
 }
 .empty-tab-message{color:rgba(255,255,255,0.8);}

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -203,7 +203,11 @@
                 <button class="nav-link profile-tab" id="wishlist-tab" data-bs-toggle="tab" data-bs-target="#wishlist" type="button" role="tab" aria-controls="wishlist" aria-selected="false">Wishlist</button>
             </li>
         </ul>
-        <div class="tab-content py-4">
+    </div>
+</div>
+
+    <div class="container my-4">
+        <div class="tab-content py-4 profile-tab-content">
             <div class="tab-pane fade show active" id="badges" role="tabpanel" aria-labelledby="badges-tab">
                 <p class="empty-tab-message text-center">No content yet for this tab.</p>
             </div>
@@ -249,7 +253,6 @@
             </div>
         </div>
     </div>
-</div>
 
     <% if (isCurrentUser) { %>
     <div class="modal fade user-search-modal" id="userSearchModal" tabindex="-1" aria-hidden="true">
@@ -271,21 +274,7 @@
     </div>
     <% } %>
 
-    <div class="container my-4">
-        <h4>Favorite Teams</h4>
-        <% if (user.favoriteTeams && user.favoriteTeams.length > 0) { %>
-            <div class="d-flex flex-wrap gap-2">
-                <% user.favoriteTeams.forEach(function(t){ %>
-                    <img src="<%= t.logos && t.logos[0] ? t.logos[0] : '' %>"
-     alt="<%= t.school %>"
-     class="avatar avatar-sm"
-     style="width:60px;height:60px;">
-                <% }) %>
-            </div>
-        <% } else { %>
-            <p>No favorite teams selected.</p>
-        <% } %>
-    </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- move profile tabs to bottom of gradient header
- show tab content below the header
- remove Favorite Teams block
- tweak active tab style and add glassy panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eba1e07c883268ba1da58c0081446