### PR TITLE
Use venue coordinates for distance

### DIFF
--- a/views/game.ejs
+++ b/views/game.ejs
@@ -42,7 +42,7 @@
         <h2 class="fw-bold mb-2" id="gameStart"></h2>
         <h3 class="mb-3"><%= game.awayTeamName %> @ <%= game.homeTeamName %></h3>
         <p class="mb-1">(<%= game.awayRecord || '0-0' %>) vs (<%= game.homeRecord || '0-0' %>)</p>
-        <p class="mb-3"><%= game.venue %> - <%= game.homeTeam && game.homeTeam.location ? game.homeTeam.location.city : '' %></p>
+        <p class="mb-3"><%= game.venue %> - <%= venue && venue.city ? venue.city : '' %></p>
         <form method="post" action="/games/<%= game._id %>/checkin" class="d-inline w-100">
           <button type="submit" class="btn checkin-btn w-100">Check-In</button>
         </form>


### PR DESCRIPTION
## Summary
- fetch venue data when listing games
- compute distances using venue coordinates instead of team locations
- load the venue on the single game page and display its city

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ec16d40948326957c61139e151e4b