### PR TITLE
Add lists to user model

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -200,3 +200,66 @@ exports.toggleWishlist = async (req, res, next) => {
     next(err);
   }
 };
+
+exports.toggleGameList = async (req, res, next) => {
+  try {
+    const User = require('../models/users');
+    const user = await User.findById(req.user.id);
+    const gameId = req.params.id;
+    const idx = user.gamesList.findIndex(g => String(g) === gameId);
+    let action;
+    if(idx >= 0){
+      user.gamesList.splice(idx,1);
+      action = 'removed';
+    } else {
+      user.gamesList.push(gameId);
+      action = 'added';
+    }
+    await user.save();
+    res.json({success:true, action});
+  } catch(err){
+    next(err);
+  }
+};
+
+exports.toggleTeamList = async (req, res, next) => {
+  try {
+    const User = require('../models/users');
+    const user = await User.findById(req.user.id);
+    const teamId = req.params.id;
+    const idx = user.teamsList.findIndex(t => String(t) === teamId);
+    let action;
+    if(idx >= 0){
+      user.teamsList.splice(idx,1);
+      action = 'removed';
+    } else {
+      user.teamsList.push(teamId);
+      action = 'added';
+    }
+    await user.save();
+    res.json({success:true, action});
+  } catch(err){
+    next(err);
+  }
+};
+
+exports.toggleVenueList = async (req, res, next) => {
+  try {
+    const User = require('../models/users');
+    const user = await User.findById(req.user.id);
+    const venueId = req.params.id;
+    const idx = user.venuesList.findIndex(v => String(v) === venueId);
+    let action;
+    if(idx >= 0){
+      user.venuesList.splice(idx,1);
+      action = 'removed';
+    } else {
+      user.venuesList.push(venueId);
+      action = 'added';
+    }
+    await user.save();
+    res.json({success:true, action});
+  } catch(err){
+    next(err);
+  }
+};

--- a/main.js
+++ b/main.js
@@ -119,6 +119,9 @@ app.get('/teams/search', gamesController.searchTeams);
 app.get('/games/:id', gamesController.showGame);
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);
+app.post('/games/:id/list', requireAuth, gamesController.toggleGameList);
+app.post('/teams/:id/list', requireAuth, gamesController.toggleTeamList);
+app.post('/venues/:id/list', requireAuth, gamesController.toggleVenueList);
 
 app.get('/venues', venuesController.listVenues);
 

--- a/models/users.js
+++ b/models/users.js
@@ -17,6 +17,9 @@ const userSchema = new mongoose.Schema({
     followers: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     following: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     wishlist: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }],
+    gamesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }], default: [] },
+    teamsList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Team' }], default: [] },
+    venuesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Venue' }], default: [] },
     uploadedPic: String,
     profileImage: {
         type: String,


### PR DESCRIPTION
## Summary
- support extra user lists for games, teams, and venues
- add endpoints for toggling membership in these lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eca182f888326933ae3e52bc769a0