### PR TITLE
Refactor profile picture storage

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -68,7 +68,7 @@ exports.listGames = async (req, res, next) => {
     if(req.user){
       const User = require('../models/users');
       const viewer = await User.findById(req.user.id)
-        .populate({path:'following', select:'username uploadedPic profileImage wishlist'});
+        .populate({path:'following', select:'username profilePic wishlist'});
       userWishlist = new Set((viewer.wishlist || []).map(g=>String(g)));
       followed = viewer.following || [];
     }
@@ -161,7 +161,7 @@ exports.showGame = async (req, res, next) => {
     if(req.user){
       const User = require('../models/users');
       const viewer = await User.findById(req.user.id)
-        .populate({path:'followers', select:'username uploadedPic profileImage wishlist'});
+        .populate({path:'followers', select:'username profilePic wishlist'});
       followerWishers = (viewer.followers || []).filter(u => (u.wishlist || []).some(w => String(w) === String(game._id)));
     }
 

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ const express = require("express"),
     venuesController = require('./controllers/venuesController'),
     messagesController = require('./controllers/messagesController'),
     Message = require('./models/Message'),
+    User = require('./models/users'),
     layouts = require('express-ejs-layouts'),
     mongoose = require('mongoose'),
     cookieParser = require('cookie-parser'),
@@ -31,7 +32,6 @@ db.once("open", () => {
 app.set('port', process.env.PORT || 3000);
 app.set('view engine', 'ejs');
 app.use(express.static('public'));
-app.use('/uploads/profilePics', express.static(path.join(__dirname, 'public/uploads/profilePics')));
 app.use(layouts);
 app.use(cookieParser());
 app.use(express.urlencoded({
@@ -47,7 +47,18 @@ app.use(async (req, res, next) => {
     if (token) {
         try {
             const decoded = jwt.verify(token, 'secret');
-            req.user = decoded;
+            const userDoc = await User.findById(decoded.id).lean();
+            if (userDoc) {
+                req.user = {
+                    id: String(userDoc._id),
+                    username: userDoc.username,
+                    email: userDoc.email,
+                    phoneNumber: userDoc.phoneNumber,
+                    profilePic: userDoc.profilePic
+                };
+            } else {
+                req.user = null;
+            }
         } catch (err) {
             req.user = null;
         }

--- a/views/editProfile.ejs
+++ b/views/editProfile.ejs
@@ -16,7 +16,8 @@
             <div class="col-md-6">
                 <form action="/profile/edit" method="post">
                     <div class="mb-3 text-center">
-                        <img id="profilePreview" src="<%= user.uploadedPic ? ('/uploads/profilePics/' + user.uploadedPic) : (user.profileImage || 'https://via.placeholder.com/150') %>" class="avatar avatar-md profile-photo-preview" alt="Profile Photo">
+                        <% const previewImg = user.profilePic && user.profilePic.data ? ('data:'+user.profilePic.contentType+';base64,'+user.profilePic.data.toString('base64')) : 'https://via.placeholder.com/150'; %>
+                        <img id="profilePreview" src="<%= previewImg %>" class="avatar avatar-md profile-photo-preview" alt="Profile Photo">
                         <input type="file" id="profileImageInput" accept=".jpg,.jpeg,.png" class="form-control mt-2">
                         <div class="text-danger" id="uploadError"></div>
                     </div>
@@ -135,7 +136,8 @@
             const res = await fetch('/profile/photo', { method: 'POST', body: fd });
             if(!res.ok) throw new Error('Upload failed');
             const data = await res.json();
-            console.log('Uploaded:', data.imageUrl);
+            console.log('Uploaded:', data.imageData);
+            preview.src = data.imageData;
             cropModal.hide();
         } catch (err) {
             errorMsg.textContent = err.message;

--- a/views/followList.ejs
+++ b/views/followList.ejs
@@ -14,7 +14,8 @@
         <div class="list-group">
             <% users.forEach(function(u){ %>
                 <a href="/users/<%= u._id %>" class="list-group-item list-group-item-action d-flex align-items-center">
-                    <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/40') %>" class="avatar avatar-sm me-2">
+                    <% const img = u.profilePic && u.profilePic.data ? ('data:'+u.profilePic.contentType+';base64,'+(u.profilePic.data.toString ? u.profilePic.data.toString('base64') : u.profilePic.data)) : 'https://via.placeholder.com/40'; %>
+                    <img src="<%= img %>" class="avatar avatar-sm me-2">
                     <%= u.username %>
                 </a>
             <% }) %>

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -28,9 +28,9 @@
         </div>
         <% if(followerWishers && followerWishers.length){ const extra = followerWishers.length - 5; %>
         <div class="followers-row d-flex justify-content-center gap-2 mt-2 flex-wrap">
-          <% followerWishers.slice(0,5).forEach(function(u){ %>
+          <% followerWishers.slice(0,5).forEach(function(u){ const img = u.profilePic && u.profilePic.data ? ('data:'+u.profilePic.contentType+';base64,'+(u.profilePic.data.toString ? u.profilePic.data.toString('base64') : u.profilePic.data)) : 'https://via.placeholder.com/30'; %>
             <a href="/users/<%= u._id %>" title="<%= u.username %>">
-              <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/30') %>" class="avatar avatar-sm">
+              <img src="<%= img %>" class="avatar avatar-sm">
             </a>
           <% }); if(extra>0){ %>
             <div class="more-followers align-self-center">+<%= extra %></div>

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -42,9 +42,9 @@
                 <div class="wishlist-btn"><i class="bi <%= game.isWishlisted ? 'bi-heart-fill' : 'bi-heart' %>"></i></div>
                 <% if(game.followedWishers && game.followedWishers.length){ const extra = game.followedWishers.length - 4; %>
                 <div class="followers-col">
-                  <% game.followedWishers.slice(0,4).forEach(function(u){ %>
+                  <% game.followedWishers.slice(0,4).forEach(function(u){ const img = u.profilePic && u.profilePic.data ? ('data:'+u.profilePic.contentType+';base64,'+u.profilePic.data.toString('base64')) : 'https://via.placeholder.com/30'; %>
                     <a href="/users/<%= u._id %>" class="follower-avatar" title="<%= u.username %>" onclick="event.stopPropagation();">
-                      <img src="<%= u.uploadedPic ? ('/uploads/profilePics/' + u.uploadedPic) : (u.profileImage || 'https://via.placeholder.com/30') %>" class="avatar avatar-sm">
+                      <img src="<%= img %>" class="avatar avatar-sm">
                     </a>
                   <% }); if(extra>0){ %>
                     <div class="more-followers">+<%= extra %></div>

--- a/views/messages.ejs
+++ b/views/messages.ejs
@@ -22,7 +22,8 @@
                     const unread = t.unreadBy.some(u=> String(u) === locals.loggedInUser.id);
                 %>
                 <a href="/messages/<%= t._id %>" class="list-group-item list-group-item-action d-flex align-items-center position-relative">
-                    <img src="<%= other.uploadedPic ? ('/uploads/profilePics/' + other.uploadedPic) : (other.profileImage || 'https://via.placeholder.com/40') %>" class="avatar avatar-sm me-2">
+                    <% const oimg = other.profilePic && other.profilePic.data ? ('data:'+other.profilePic.contentType+';base64,'+(other.profilePic.data.toString ? other.profilePic.data.toString('base64') : other.profilePic.data)) : 'https://via.placeholder.com/40'; %>
+                    <img src="<%= oimg %>" class="avatar avatar-sm me-2">
                     <div class="flex-grow-1">
                         <div class="fw-bold"><%= other.username %></div>
                         <% if (last) { %>

--- a/views/messagesModal.ejs
+++ b/views/messagesModal.ejs
@@ -9,7 +9,8 @@
     <% } else { %>
       <% threads.forEach(function(t){ const other = t.participants.find(p=> String(p._id||p) !== loggedInUser.id); const last = t.messages[t.messages.length-1]; const unread = t.unreadBy.some(u=> String(u) === loggedInUser.id); %>
         <a href="#" data-thread="<%= t._id %>" class="thread-link list-group-item list-group-item-action d-flex align-items-center position-relative <%= currentThread && String(currentThread._id)===String(t._id)?'active':'' %>">
-          <img src="<%= other.uploadedPic ? ('/uploads/profilePics/' + other.uploadedPic) : (other.profileImage || 'https://via.placeholder.com/40') %>" class="avatar avatar-sm me-2">
+          <% const oimg = other.profilePic && other.profilePic.data ? ('data:'+other.profilePic.contentType+';base64,'+(other.profilePic.data.toString ? other.profilePic.data.toString('base64') : other.profilePic.data)) : 'https://via.placeholder.com/40'; %>
+          <img src="<%= oimg %>" class="avatar avatar-sm me-2">
           <div class="flex-grow-1">
             <div class="fw-bold"><%= other.username %></div>
             <% if (last) { %><small class="text-muted"><%= last.content.slice(0,40) %></small><% } %>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -20,7 +20,8 @@
           <% } %>
         </a>
         <a href="/profile" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">
-          <img src="<%= loggedInUser.uploadedPic ? ('/uploads/profilePics/' + loggedInUser.uploadedPic) : (loggedInUser.profileImage || 'https://via.placeholder.com/40') %>" alt="Profile" class="nav-profile-icon">
+          <% const navImg = loggedInUser.profilePic && loggedInUser.profilePic.data ? ('data:'+loggedInUser.profilePic.contentType+';base64,'+(loggedInUser.profilePic.data.toString ? loggedInUser.profilePic.data.toString('base64') : loggedInUser.profilePic.data)) : 'https://via.placeholder.com/40'; %>
+          <img src="<%= navImg %>" alt="Profile" class="nav-profile-icon">
         </a>
         <a href="/logout" class="btn btn-outline-secondary">Log Out</a>
       <% } else { %>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -131,7 +131,8 @@
             <div class="row align-items-center">
                 <div class="col-md-3 text-center mb-4 mb-md-0">
                     <div class="profile-avatar-wrapper d-inline-block">
-                        <img src="<%= user.uploadedPic ? ('/uploads/profilePics/' + user.uploadedPic) : (user.profileImage || 'https://via.placeholder.com/150') %>"
+                        <% const avatar = user.profilePic && user.profilePic.data ? ('data:'+user.profilePic.contentType+';base64,'+user.profilePic.data.toString('base64')) : 'https://via.placeholder.com/150'; %>
+                        <img src="<%= avatar %>"
      class="avatar avatar-lg profile-avatar"
      alt="Profile Photo">
                         
@@ -322,7 +323,7 @@
                 const currentId = '<%= viewer ? viewer.id : "" %>';
                 resultsEl.innerHTML = data.map(u=>{
                     const following = u.followers && u.followers.includes(currentId);
-                    const imgUrl = u.uploadedPic ? '/uploads/profilePics/' + u.uploadedPic : (u.profileImage || 'https://via.placeholder.com/40');
+                    const imgUrl = u.profilePic && u.profilePic.data ? `data:${u.profilePic.contentType};base64,${u.profilePic.data.toString ? u.profilePic.data.toString('base64') : u.profilePic.data}` : 'https://via.placeholder.com/40';
                     return `<div class="col-md-4"><div class="card p-2 d-flex flex-row align-items-center gap-2">`+
                         `<img src="${imgUrl}" class="avatar avatar-sm">`+
                         `<div class="flex-grow-1"><a href="/users/${u._id}" class="text-decoration-none">${u.username}</a></div>`+


### PR DESCRIPTION
## Summary
- update `User` schema to store profilePic (binary) and use string phone numbers
- switch profile photo upload to memory storage and save buffer in MongoDB
- fetch logged in user from DB for each request
- display profile pics directly from stored data
- adjust controllers and views to stop referencing old uploadedPic/profileImage fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ecfa5dd1c832688cd1781e427b0f4