### PR TITLE
Fix wishlist overlay interfering with game link

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -395,6 +395,7 @@
   align-items:center;
   margin-left:0.25rem;
 }
+.follower-avatar{ cursor:pointer; }
 .follower-avatar img{ width:15px; height:15px; border-radius:50%; object-fit:cover; border:1px solid rgba(255,255,255,0.8); }
 .followers-row a img{ width:30px; height:30px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,0.8); }
 .followers-row .more-followers{margin-left:0.25rem;}

--- a/views/games.ejs
+++ b/views/games.ejs
@@ -42,9 +42,9 @@
                 <% if(game.followedWishers && game.followedWishers.length){ const extra = game.followedWishers.length - 4; %>
                 <div class="followers-col">
                   <% game.followedWishers.slice(0,4).forEach(function(u){ const img = u.profilePic && u.profilePic.data ? ('data:'+u.profilePic.contentType+';base64,'+u.profilePic.data.toString('base64')) : 'https://via.placeholder.com/30'; %>
-                    <a href="/users/<%= u._id %>" class="follower-avatar" title="<%= u.username %>" onclick="event.stopPropagation();">
+                    <div class="follower-avatar" title="<%= u.username %>" data-href="/users/<%= u._id %>">
                       <img src="<%= img %>" class="avatar avatar-sm">
-                    </a>
+                    </div>
                   <% }); if(extra>0){ %>
                     <div class="more-followers">+<%= extra %></div>
                   <% } %>
@@ -253,6 +253,7 @@
           applyTextColors();
           adjustTeamNames();
           attachWishlistHandlers();
+          attachFollowerAvatarHandlers();
         },150);
         history.replaceState(null,'',url);
       }
@@ -295,7 +296,17 @@
         });
       }
 
+      function attachFollowerAvatarHandlers(){
+        document.querySelectorAll('.follower-avatar[data-href]').forEach(div=>{
+          div.addEventListener('click', function(e){
+            e.stopPropagation();
+            window.location.href = div.dataset.href;
+          });
+        });
+      }
+
       attachWishlistHandlers();
+      attachFollowerAvatarHandlers();
       window.addEventListener('resize', adjustTeamNames);
 
     </script>


### PR DESCRIPTION
## Summary
- keep game cards clickable even when wishlist avatars are present
- add follower avatar click handler
- tweak styles for follower avatars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc832b0e08326aabd442e572321bc