### PR TITLE
Fix profile view conditions and header spacing

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -192,13 +192,12 @@ exports.viewUser = async (req, res, next) => {
             const followsBack = user.following.some(f => String(f) === String(viewer._id));
             canMessage = isFollowing && followsBack;
         }
-        res.render('profile', { 
-            user, 
-            isCurrentUser: true, 
-            isFollowing: false, 
-            viewer: req.user, 
-            wishlistGames: user.wishlist,
-            navImg: user.profileImage ? `/users/${user._id}/profile-image` : '/images/default-profile.png' // 👈 ADD THIS
+        res.render("profile", {
+            user,
+            isCurrentUser,
+            isFollowing,
+            viewer: req.user,
+            wishlistGames: user.wishlist
         });
     } catch (err) {
         next(err);

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -126,7 +126,7 @@
 <body class="d-flex flex-column min-vh-100">
     <%- include('partials/header') %>
 
-    <div class="profile-header py-5 text-white">
+    <div class="profile-header pt-5 pb-0 text-white">
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-md-3 text-center mb-4 mb-md-0">
@@ -186,7 +186,7 @@
             
     </div>
 
-    <div class="container mt-4">
+    <div class="container mt-4 pb-0">
         <ul class="nav nav-tabs profile-tabs" id="profileTabs" role="tablist">
             <li class="nav-item" role="presentation">
                 <button class="nav-link active profile-tab" id="badges-tab" data-bs-toggle="tab" data-bs-target="#badges" type="button" role="tab" aria-controls="badges" aria-selected="true">Badges</button>


### PR DESCRIPTION
## Summary
- pass correct variables when viewing another profile
- keep nav profile icon for the logged in user
- remove bottom padding on profile header
- prevent extra space below profile tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fcf56fd9c8326ac6881c2d7375058