### PR TITLE
Add League model and CSV scripts

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/sportsapp';
+
+mongoose.connect(MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+});
+
+const db = mongoose.connection;
+
+module.exports = db;

--- a/importLeagues.js
+++ b/importLeagues.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const csv = require('csv-parser');
+const mongoose = require('mongoose');
+const db = require('./db');
+const League = require('./models/League');
+
+// Log connection events
+
+db.on('error', err => console.error('MongoDB connection error:', err));
+db.once('open', () => console.log('Connected to MongoDB'));
+
+function importLeagues(filePath) {
+  return new Promise((resolve, reject) => {
+    const leagues = [];
+    fs.createReadStream(filePath)
+      .pipe(csv())
+      .on('data', row => {
+        if (row.leagueId && row.leagueName) {
+          leagues.push({
+            leagueId: String(row.leagueId),
+            leagueName: row.leagueName
+          });
+        }
+      })
+      .on('end', async () => {
+        try {
+          for (const league of leagues) {
+            await League.findOneAndUpdate(
+              { leagueId: league.leagueId },
+              league,
+              { upsert: true, new: true }
+            );
+          }
+          console.log(`Imported ${leagues.length} leagues`);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      })
+      .on('error', reject);
+  });
+}
+
+const file = process.argv[2] || 'public/files/Leagues.csv';
+
+importLeagues(file)
+  .then(() => console.log('League import completed'))
+  .catch(err => {
+    console.error('Failed to import leagues:', err);
+  })
+  .finally(() => {
+    mongoose.disconnect();
+  });

--- a/models/League.js
+++ b/models/League.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const leagueSchema = new mongoose.Schema({
+  leagueId: { type: String, unique: true },
+  leagueName: String
+});
+
+module.exports = mongoose.model('League', leagueSchema);

--- a/models/Team.js
+++ b/models/Team.js
@@ -25,6 +25,7 @@ const teamSchema = new mongoose.Schema({
   alternateNames: [String],
   conference: String,
   division: String,
+  conferenceId: String,
   classification: String,
   color: String,
   alternateColor: String,

--- a/updateTeamsWithConference.js
+++ b/updateTeamsWithConference.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const csv = require('csv-parser');
+const mongoose = require('mongoose');
+const db = require('./db');
+const Team = require('./models/Team');
+
+db.on('error', err => console.error('MongoDB connection error:', err));
+db.once('open', () => console.log('Connected to MongoDB'));
+
+function updateTeams(filePath) {
+  return new Promise((resolve, reject) => {
+    const records = [];
+    fs.createReadStream(filePath)
+      .pipe(csv())
+      .on('data', row => {
+        const teamId = row.teamId ? Number(row.teamId) : undefined;
+        const conferenceId = row.conferenceId;
+        if (teamId && conferenceId) {
+          records.push({ teamId, conferenceId: String(conferenceId) });
+        }
+      })
+      .on('end', async () => {
+        try {
+          for (const rec of records) {
+            const result = await Team.updateOne({ teamId: rec.teamId }, { conferenceId: rec.conferenceId });
+            if (result.matchedCount === 0) {
+              console.warn(`Team with id ${rec.teamId} not found`);
+            }
+          }
+          console.log(`Updated ${records.length} teams`);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      })
+      .on('error', reject);
+  });
+}
+
+const file = process.argv[2] || 'public/files/TeamConference.csv';
+
+updateTeams(file)
+  .then(() => console.log('Team update completed'))
+  .catch(err => {
+    console.error('Failed to update teams:', err);
+  })
+  .finally(() => {
+    mongoose.disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a `League` mongoose model
- allow teams to store `conferenceId`
- connect to MongoDB via new `db.js`
- add scripts to import leagues and update teams from CSV files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd82d021c8326943807ce644f689e