### PR TITLE
Add games tab with game log modal

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -140,6 +140,28 @@ exports.searchTeams = async (req, res, next) => {
   }
 };
 
+exports.searchGames = async (req, res, next) => {
+  try {
+    const q = req.query.q || '';
+    const season = parseInt(req.query.season);
+    const query = {};
+    if(q){
+      query.$or = [
+        { homeTeamName: { $regex: q, $options: 'i' } },
+        { awayTeamName: { $regex: q, $options: 'i' } }
+      ];
+    }
+    if(!isNaN(season)) query.season = season;
+    const games = await Game.find(query)
+      .sort({ startDate: -1 })
+      .limit(10)
+      .select('awayTeamName homeTeamName season');
+    res.json(games);
+  } catch(err){
+    next(err);
+  }
+};
+
 exports.showGame = async (req, res, next) => {
   try {
     const game = await Game.findById(req.params.id)

--- a/main.js
+++ b/main.js
@@ -111,6 +111,7 @@ app.get('/profile/edit', requireAuth, profileController.getEditProfile);
 app.post('/profile/edit', requireAuth, profileController.updateProfile);
 app.post('/profile/photo', requireAuth, profileController.uploadProfilePhoto);
 app.post('/profile/location', requireAuth, profileController.setLocation);
+app.post('/profile/games', requireAuth, profileController.addGame);
 app.get('/welcome', requireAuth, (req, res) => {
     res.redirect('/');
 });
@@ -140,6 +141,7 @@ app.get('/newProject', requireAuth, projectsController.getNewProject);
 
 app.get('/games', gamesController.listGames);
 app.get('/teams/search', gamesController.searchTeams);
+app.get('/games/searchGames', gamesController.searchGames);
 app.get('/games/:id', gamesController.showGame);
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);

--- a/models/Game.js
+++ b/models/Game.js
@@ -33,7 +33,8 @@ const gameSchema = new mongoose.Schema({
   awayPostgameElo: Number,
   excitementIndex: Number,
   highlights: String,
-  notes: String
+  notes: String,
+  ratings: { type: [Number], default: [] }
 });
 
 module.exports = mongoose.model('Game', gameSchema);

--- a/models/PastGame.js
+++ b/models/PastGame.js
@@ -24,7 +24,8 @@ const pastGameSchema = new mongoose.Schema({
   awayConferenceId: Number,
   AwayPoints: Number,
   awayLeagueId: Number,
-  homeLeagueId: Number
+  homeLeagueId: Number,
+  ratings: { type: [Number], default: [] }
 });
 
 module.exports = mongoose.model('PastGame', pastGameSchema);

--- a/models/users.js
+++ b/models/users.js
@@ -18,6 +18,15 @@ const userSchema = new mongoose.Schema({
     gamesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }], default: [] },
     teamsList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Team' }], default: [] },
     venuesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Venue' }], default: [] },
+    gameEntries: [{
+        game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
+        rating: Number,
+        comment: String,
+        photo: {
+            data: Buffer,
+            contentType: String
+        }
+    }],
     profileImage: {
         data: Buffer,
         contentType: String

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/custom.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <style>
         .profile-header {
             background: linear-gradient(to right, #7e22ce, #14b8a6);
@@ -121,6 +122,11 @@
     width: clamp(40px, 10vw, 60px); /* Min 40px, Max 60px, scales up to 10% of viewport width */
     height: clamp(40px, 10vw, 60px);
 }
+
+.score-text {
+    font-size: 2rem;
+    font-weight: bold;
+}
     </style>
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -213,7 +219,47 @@
                 <p class="empty-tab-message text-center">No content yet for this tab.</p>
             </div>
             <div class="tab-pane fade" id="gamesTab" role="tabpanel" aria-labelledby="games-tab">
-                <p class="empty-tab-message text-center">No content yet for this tab.</p>
+                <div class="d-flex justify-content-end mb-3">
+                    <% if(isCurrentUser){ %>
+                        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addGameModal">+Game</button>
+                    <% } %>
+                </div>
+                <% if (gamesList && gamesList.length > 0) { %>
+                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="gamesContainer">
+                    <% gamesList.forEach(function(game){
+                         const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
+                         const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
+                    <div class="col">
+                        <div class="position-relative">
+                            <a href="/games/<%= game._id %>" class="game-link d-block">
+                                <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                                    <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+                                    <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                                    <div class="logo-wrapper me-3">
+                                        <div class="team-logo-container">
+                                            <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                                        </div>
+                                        <span class="team-name"><%= game.awayTeamName %></span>
+                                    </div>
+                                    <div class="logo-wrapper ms-3">
+                                        <div class="team-logo-container">
+                                            <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                                        </div>
+                                        <span class="team-name"><%= game.homeTeamName %></span>
+                                    </div>
+                                    <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-3 score-text text-white"><%= game.awayPoints %>-<%= game.homePoints %></div>
+                                </div>
+                                <% if(game.userRating){ %>
+                                    <div class="mt-2 text-center text-white">Rated: <%= game.userRating %>/10</div>
+                                <% } %>
+                            </a>
+                        </div>
+                    </div>
+                    <% }); %>
+                </div>
+                <% } else { %>
+                <p class="empty-tab-message text-center">No games yet</p>
+                <% } %>
             </div>
             <div class="tab-pane fade" id="stats" role="tabpanel" aria-labelledby="stats-tab">
                 <p class="empty-tab-message text-center">No content yet for this tab.</p>
@@ -286,9 +332,51 @@
     </div>
     <% } %>
 
+    <% if (isCurrentUser) { %>
+    <div class="modal fade user-search-modal" id="addGameModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content p-3">
+                <form action="/profile/games" method="post" enctype="multipart/form-data">
+                    <div class="modal-header border-0">
+                        <h5 class="modal-title">Add Game</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">Season</label>
+                            <input type="number" id="seasonInput" class="form-control" min="2000" step="1">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Game</label>
+                            <select id="gameSelect" name="gameId" class="form-control" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Rating: <span id="ratingValue">5</span></label>
+                            <input type="range" id="ratingRange" name="rating" class="form-range" min="1" max="10" step="0.5" value="5" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Photo</label>
+                            <input type="file" name="photo" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Comment</label>
+                            <textarea class="form-control" name="comment" rows="3"></textarea>
+                        </div>
+                    </div>
+                    <div class="modal-footer border-0">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <% } %>
+
 
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         const searchInput = document.getElementById('searchInput');
         const resultsEl = document.getElementById('searchResults');
@@ -430,6 +518,46 @@
             wishlistTabEl.addEventListener('shown.bs.tab', formatWishlist);
         }
         formatWishlist();
+
+        function formatGames(){
+            document.querySelectorAll('#gamesContainer .game-date').forEach(el=>{
+                const d=new Date(el.dataset.start);
+                el.textContent = new Intl.DateTimeFormat(navigator.language,{dateStyle:'medium',timeStyle:'short'}).format(d);
+            });
+            document.querySelectorAll('#gamesContainer .game-card').forEach(card=>{
+                const away=card.dataset.awayColor; const home=card.dataset.homeColor;
+                const color=chooseTextColor([away,home]);
+                card.querySelectorAll('.game-date, .team-name, .score-text, .text-white').forEach(e=>{e.style.color=color;});
+            });
+        }
+        const gamesTabEl = document.getElementById('games-tab');
+        if(gamesTabEl){
+            gamesTabEl.addEventListener('shown.bs.tab', formatGames);
+        }
+        formatGames();
+
+        $(function(){
+            $('#gameSelect').select2({
+                dropdownParent: $('#addGameModal'),
+                placeholder:'Search game',
+                width:'100%',
+                ajax:{
+                    url:'/games/searchGames',
+                    dataType:'json',
+                    delay:250,
+                    data:function(params){ return { q: params.term, season: $('#seasonInput').val() }; },
+                    processResults:function(data){
+                        return { results: data.map(g=>({id:g._id,text:`${g.awayTeamName} @ ${g.homeTeamName} (${g.season})`})) };
+                    }
+                }
+            });
+        });
+        const ratingRange=document.getElementById('ratingRange');
+        const ratingValue=document.getElementById('ratingValue');
+        if(ratingRange){
+            ratingValue.textContent=ratingRange.value;
+            ratingRange.addEventListener('input',()=>{ratingValue.textContent=ratingRange.value;});
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support storing game ratings on `Game` and `PastGame`
- keep user specific game data in `gameEntries`
- add profile controller method to record games
- expose new routes for searching games and posting new game entries
- enhance profile page with a new Games tab and modal form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ff640ad388326819089ea20e53ed2