### PR TITLE
Update Add Game modal for past games

### DIFF
--- a/main.js
+++ b/main.js
@@ -142,6 +142,8 @@ app.get('/newProject', requireAuth, projectsController.getNewProject);
 app.get('/games', gamesController.listGames);
 app.get('/teams/search', gamesController.searchTeams);
 app.get('/games/searchGames', gamesController.searchGames);
+app.get('/pastGames/seasons', gamesController.listPastGameSeasons);
+app.get('/pastGames/search', gamesController.searchPastGames);
 app.get('/games/:id', gamesController.showGame);
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -481,3 +481,34 @@
   color: #3dd5f3;
   text-decoration: underline;
 }
+
+/* Glass style range input */
+.glass-control[type=range]{
+  -webkit-appearance:none;
+  width:100%;
+  height:.5rem;
+  background:rgba(255,255,255,0.2);
+  border:1px solid rgba(255,255,255,0.3);
+  border-radius:.5rem;
+  backdrop-filter:blur(8px);
+}
+.glass-control[type=range]:focus{
+  outline:none;
+  box-shadow:0 0 0 0.2rem rgba(255,255,255,0.3);
+}
+.glass-control[type=range]::-webkit-slider-thumb{
+  -webkit-appearance:none;
+  width:1rem;
+  height:1rem;
+  background:#fff;
+  border-radius:50%;
+  cursor:pointer;
+}
+.glass-control[type=range]::-moz-range-thumb{
+  width:1rem;
+  height:1rem;
+  background:#fff;
+  border:none;
+  border-radius:50%;
+  cursor:pointer;
+}

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -344,23 +344,23 @@
                     <div class="modal-body">
                         <div class="mb-3">
                             <label class="form-label">Season</label>
-                            <input type="number" id="seasonInput" class="form-control" min="2000" step="1">
+                            <select id="seasonSelect" class="form-select glass-control"></select>
                         </div>
                         <div class="mb-3">
                             <label class="form-label">Game</label>
-                            <select id="gameSelect" name="gameId" class="form-control" required></select>
+                            <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
                         </div>
                         <div class="mb-3">
                             <label class="form-label">Rating: <span id="ratingValue">5</span></label>
-                            <input type="range" id="ratingRange" name="rating" class="form-range" min="1" max="10" step="0.5" value="5" required>
+                            <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
                         </div>
                         <div class="mb-3">
                             <label class="form-label">Photo</label>
-                            <input type="file" name="photo" class="form-control">
+                            <input type="file" name="photo" class="form-control glass-control">
                         </div>
                         <div class="mb-3">
                             <label class="form-label">Comment</label>
-                            <textarea class="form-control" name="comment" rows="3"></textarea>
+                            <textarea class="form-control glass-control" name="comment" rows="3"></textarea>
                         </div>
                     </div>
                     <div class="modal-footer border-0">
@@ -537,19 +537,60 @@
         formatGames();
 
         $(function(){
-            $('#gameSelect').select2({
+            const gameSelect = $('#gameSelect');
+            function formatGame(option){
+                if(!option.id) return option.text;
+                const homeLogo = option.homeLogo || 'https://via.placeholder.com/30';
+                const awayLogo = option.awayLogo || 'https://via.placeholder.com/30';
+                return $(
+                    `<div class="d-flex align-items-center">`+
+                    `<img src="${homeLogo}" style="width:30px;height:30px;border-radius:50%;" class="me-2">`+
+                    `<span>${option.homeTeamName}</span>`+
+                    `<span class="mx-1">vs</span>`+
+                    `<span>${option.awayTeamName}</span>`+
+                    `<img src="${awayLogo}" style="width:30px;height:30px;border-radius:50%;" class="ms-2">`+
+                    `<span class="ms-2 text-muted">(${option.score})</span>`+
+                    `</div>`
+                );
+            }
+
+            gameSelect.select2({
                 dropdownParent: $('#addGameModal'),
                 placeholder:'Search game',
                 width:'100%',
+                templateResult: formatGame,
+                templateSelection: formatGame,
                 ajax:{
-                    url:'/games/searchGames',
+                    url:'/pastGames/search',
                     dataType:'json',
                     delay:250,
-                    data:function(params){ return { q: params.term, season: $('#seasonInput').val() }; },
+                    data:function(params){ return { q: params.term, season: $('#seasonSelect').val() }; },
                     processResults:function(data){
-                        return { results: data.map(g=>({id:g._id,text:`${g.awayTeamName} @ ${g.homeTeamName} (${g.season})`})) };
+                        return { results: data.map(g=>({
+                            id:g.id,
+                            homeTeamName:g.homeTeamName,
+                            awayTeamName:g.awayTeamName,
+                            homeLogo:g.homeLogo,
+                            awayLogo:g.awayLogo,
+                            score:g.score,
+                            text:`${g.homeTeamName} vs ${g.awayTeamName}`
+                        })) };
                     }
                 }
+            });
+
+            $('#addGameModal').on('shown.bs.modal', function(){
+                if(!$('#seasonSelect option').length){
+                    fetch('/pastGames/seasons').then(r=>r.json()).then(data=>{
+                        const opts = data.map(s=>`<option value="${s}">${s}</option>`).join('');
+                        $('#seasonSelect').append('<option value="">Select season</option>'+opts);
+                    });
+                }
+            });
+
+            $('#seasonSelect').on('change', function(){
+                const val = $(this).val();
+                gameSelect.prop('disabled', !val).val(null).trigger('change');
             });
         });
         const ratingRange=document.getElementById('ratingRange');


### PR DESCRIPTION
## Summary
- style Add Game modal inputs with glassy motif
- populate season dropdown dynamically from past games
- enable searching past games with team logos and scores
- allow range slider to use glass styles
- expose API endpoints for past game seasons and search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ffa5fd02083269c3bfd24186c37b3