### PR TITLE
Fix profile page grid layout and modal events

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -534,25 +534,6 @@
 }
 
 /* Profile games layouts */
-#profileGamesContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 5px;
-}
-
-#profileGamesContainer .col {
-  display: flex;
-  justify-content: center;
-}
-
-#profileGamesContainer .game-card {
-  width: 120%;
-  max-width: 600px;
-}
-
-@media(max-width:576px){
-  #profileGamesContainer .game-card{
-    width:100%;
-  }
+#profileGamesContainer .game-card{
+  width:100%;
 }

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -221,7 +221,8 @@
                     <% } %>
                 </div>
                 <% if (gameEntries && gameEntries.length > 0) { %>
-                    <div class="d-flex flex-column align-items-center gap-2" id="profileGamesContainer">                    <% gameEntries.forEach(function(entry){
+                    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="profileGamesContainer">
+                    <% gameEntries.forEach(function(entry){
                          const game = entry.game;
                          if(!game) return;
                          const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
@@ -537,6 +538,16 @@
         if(addGameBtn){
             addGameBtn.addEventListener('click', () => {
                 const modalEl = document.getElementById('addGameModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+
+        const openUserModalBtn = document.getElementById('openUserModal');
+        if(openUserModalBtn){
+            openUserModalBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('userSearchModal');
                 if(modalEl){
                     bootstrap.Modal.getOrCreateInstance(modalEl).show();
                 }


### PR DESCRIPTION
## Summary
- use bootstrap row layout for games on profile page
- keep games card widths consistent
- add explicit event handler for opening user search modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68810c701920832688c1b8c9494c19b8