### PR TITLE
Fix profile route population and grid layout

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -99,14 +99,23 @@ exports.getProfile = async (req, res, next) => {
     try {
         const user = await User.findById(req.user.id)
             .populate('favoriteTeams')
-            .populate({ path: 'wishlist', populate: ['homeTeam','awayTeam'] })
+            .populate({
+                path: 'gameEntries.game',
+                populate: ['homeTeam', 'awayTeam']
+            })
+            .populate({
+                path: 'wishlist',
+                populate: ['homeTeam', 'awayTeam']
+            })
             .populate({ path: 'gamesList', populate: ['homeTeam','awayTeam'] });
             
         if (!user) return res.redirect('/login');
 
+        const wishlistGames = user.wishlist || [];
+        const gameEntriesRaw = user.gameEntries || [];
         let enrichedEntries = [];
-        if(user.gameEntries && user.gameEntries.length){
-            enrichedEntries = await enrichGameEntries(user.gameEntries);
+        if(gameEntriesRaw.length){
+            enrichedEntries = await enrichGameEntries(gameEntriesRaw);
         }
 
         const ratingMap = {};
@@ -121,7 +130,7 @@ exports.getProfile = async (req, res, next) => {
             isCurrentUser: true,
             isFollowing: false,
             viewer: req.user,
-            wishlistGames: user.wishlist,
+            wishlistGames,
             gamesList: user.gamesList,
             gameEntries: enrichedEntries
         });
@@ -229,13 +238,22 @@ exports.viewUser = async (req, res, next) => {
     try {
         const user = await User.findById(req.params.id)
             .populate('favoriteTeams')
-            .populate({ path: 'wishlist', populate: ['homeTeam','awayTeam'] })
+            .populate({
+                path: 'gameEntries.game',
+                populate: ['homeTeam','awayTeam']
+            })
+            .populate({
+                path: 'wishlist',
+                populate: ['homeTeam','awayTeam']
+            })
             .populate({ path: 'gamesList', populate: ['homeTeam','awayTeam'] });
         if (!user) return res.redirect('/profile');
 
+        const wishlistGames = user.wishlist || [];
+        const gameEntriesRaw = user.gameEntries || [];
         let enrichedEntries = [];
-        if(user.gameEntries && user.gameEntries.length){
-            enrichedEntries = await enrichGameEntries(user.gameEntries);
+        if(gameEntriesRaw.length){
+            enrichedEntries = await enrichGameEntries(gameEntriesRaw);
         }
         const isCurrentUser = req.user && String(req.user.id) === String(user._id);
         let isFollowing = false, canMessage = false;
@@ -258,7 +276,7 @@ exports.viewUser = async (req, res, next) => {
             isFollowing,
             canMessage,
             viewer: req.user,
-            wishlistGames: user.wishlist,
+            wishlistGames,
             gamesList: user.gamesList,
             gameEntries: enrichedEntries
         });

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -534,6 +534,11 @@
 }
 
 /* Profile games layouts */
-#profileGamesContainer .game-card{
+#profileGamesContainer,
+#wishlistContainer{
+  gap:5px;
+}
+#profileGamesContainer .game-card,
+#wishlistContainer .game-card{
   width:100%;
 }


### PR DESCRIPTION
## Summary
- populate `gameEntries.game` and `wishlist` with teams when viewing a profile
- always provide `wishlistGames` and `gameEntries` arrays to the template
- add consistent gap and width styles for game grids

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688110a27ef0832697db753ad5655598