### PR TITLE
Refactor profile tabs into separate pages

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,8 +105,12 @@ app.get('/logout', (req, res) => {
     res.clearCookie('token');
     res.redirect('/login');
 });
-app.get('/thanks', requireAuth, profileController.getProfile);
-app.get('/profile', requireAuth, profileController.getProfile);
+app.get('/thanks', requireAuth, (req, res) => { res.redirect('/profile/badges'); });
+app.get('/profile', requireAuth, (req, res) => { res.redirect('/profile/badges'); });
+app.get('/profile/badges', requireAuth, profileController.profileBadges);
+app.get('/profile/games', requireAuth, profileController.profileGames);
+app.get('/profile/stats', requireAuth, profileController.profileStats);
+app.get('/profile/waitlist', requireAuth, profileController.profileWaitlist);
 app.get('/profile/edit', requireAuth, profileController.getEditProfile);
 app.post('/profile/edit', requireAuth, profileController.updateProfile);
 app.post('/profile/photo', requireAuth, profileController.uploadProfilePhoto);

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -1,0 +1,131 @@
+<div class="profile-header pt-5 pb-0 text-white">
+    <div class="container">
+        <div class="row align-items-center">
+            <div class="col-md-3 text-center mb-4 mb-md-0">
+                <div class="profile-avatar-wrapper d-inline-block">
+                    <img src="/users/<%= user._id %>/profile-image" class="avatar avatar-lg profile-avatar" alt="Profile Photo">
+                    <% if (user.favoriteTeams && user.favoriteTeams.length > 0) { %>
+                        <% user.favoriteTeams.forEach(function(t){ %>
+                            <a href="/teams/<%= t._id %>" class="chain-logo">
+                                <img src="<%= t.logos && t.logos[0] ? t.logos[0] : '' %>" alt="<%= t.school %>">
+                            </a>
+                        <% }) %>
+                    <% } %>
+                </div>
+            </div>
+            <div class="col-md-6 text-center text-md-start">
+                <div class="d-flex flex-column flex-md-row align-items-center">
+                    <h2 class="fw-bold mb-1 me-md-3">@<%= user.username %></h2>
+                    <% if(!isCurrentUser){ %>
+                        <% if(canMessage){ %>
+                            <button class="btn btn-outline-light btn-sm ms-md-2 message-btn" data-user="<%= user._id %>">Message</button>
+                        <% } else { %>
+                            <button class="btn btn-outline-light btn-sm ms-md-2" disabled title="Messaging requires a mutual follow">Message</button>
+                        <% } %>
+                    <% } %>
+                </div>
+                <div class="d-flex justify-content-center justify-content-md-start pb-2">
+                    <div class="me-4">
+                        <a href="/users/<%= user._id %>/followers" class="text-decoration-none text-white">
+                            <div id="followersCount" class="fw-bold text-primary"><%= user.followersCount %></div>
+                            <small class="text-white-50">Followers</small>
+                        </a>
+                    </div>
+                    <div>
+                        <a href="/users/<%= user._id %>/following" class="text-decoration-none text-white">
+                            <div class="fw-bold text-info"><%= user.followingCount %></div>
+                            <small class="text-white-50">Following</small>
+                        </a>
+                    </div>
+                </div>
+                <% if (isCurrentUser) { %>
+                <div class="mt-3">
+                    <button id="openUserModal" class="btn btn-primary rounded-pill follow-users-btn px-4" data-bs-toggle="modal" data-bs-target="#userSearchModal">Follow Users</button>
+                </div>
+                <% } %>
+            </div>
+            <div class="col-md-3 text-center text-md-end">
+                <% if (isCurrentUser) { %>
+                    <a href="/profile/edit" class="btn btn-primary rounded-pill px-4 mb-2">Edit Profile</a>
+                    <button id="addGameBtn" type="button" class="btn gradient-glass-btn mb-2" data-bs-toggle="modal" data-bs-target="#addGameModal">+ Game</button>
+                <% } else if (viewer) { %>
+                    <button id="followBtn" data-user="<%= user._id %>" class="btn btn-<%= isFollowing ? 'secondary' : 'primary' %> rounded-pill px-4 follow-btn mb-2"><%= isFollowing ? 'Following' : 'Follow' %></button>
+                <% } %>
+            </div>
+        </div>
+    </div>
+    <div class="container mt-4 pb-0">
+        <ul class="nav nav-tabs profile-tabs" id="profileTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <a href="/profile/badges" class="nav-link profile-tab <%= activeTab==='badges' ? 'active' : '' %>">Badges</a>
+            </li>
+            <li class="nav-item" role="presentation">
+                <a href="/profile/games" class="nav-link profile-tab <%= activeTab==='games' ? 'active' : '' %>">Games</a>
+            </li>
+            <li class="nav-item" role="presentation">
+                <a href="/profile/stats" class="nav-link profile-tab <%= activeTab==='stats' ? 'active' : '' %>">Stats</a>
+            </li>
+            <li class="nav-item" role="presentation">
+                <a href="/profile/waitlist" class="nav-link profile-tab <%= activeTab==='waitlist' ? 'active' : '' %>">Waitlist</a>
+            </li>
+        </ul>
+    </div>
+</div>
+
+<% if (isCurrentUser) { %>
+<div class="modal fade user-search-modal" id="userSearchModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content p-3">
+            <div class="modal-header border-0">
+                <h5 class="modal-title">Find Users</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="position-relative mb-3 profile-search-wrapper w-100">
+                    <i class="bi bi-search search-icon"></i>
+                    <input type="text" id="searchInput" class="form-control profile-search">
+                </div>
+                <div id="searchResults" class="row g-3" style="max-height:300px;overflow:auto;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade user-search-modal" id="addGameModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content p-3">
+            <form action="/profile/games" method="post" enctype="multipart/form-data">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title">Add Game</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Season</label>
+                        <select id="seasonSelect" class="form-select glass-control"></select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Game</label>
+                        <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Rating: <span id="ratingValue">5</span></label>
+                        <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Photo</label>
+                        <input type="file" name="photo" class="form-control glass-control">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Comment</label>
+                        <textarea class="form-control glass-control" name="comment" rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer border-0">
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<% } %>

--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profile - Badges</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <style>
+        .profile-header { background: linear-gradient(to right, #7e22ce, #14b8a6); }
+        .trophy-panel { background-color: rgba(255,255,255,0.15); }
+        .follow-btn { transition: background-color 0.3s, color 0.3s; }
+        .avatar { border-radius: 50%; object-fit: cover; border: 2px solid rgba(255, 255, 255, 0.8); display: inline-block; }
+        .profile-avatar { display: block; margin-left: auto; margin-right: auto; }
+        .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; border-radius: 8px !important; padding: 0.5rem 1rem !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; }
+        .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        .user-search-modal .modal-content { background: linear-gradient(to right, #7e22ce, #14b8a6); background-clip: padding-box; border-radius: 1rem; border: 1px solid rgba(255, 255, 255, 0.2); box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3); color: #fff; backdrop-filter: blur(10px); font-family: inherit; }
+        .user-search-modal .modal-title { font-family: inherit; font-weight: bold; font-size: 1.5rem; color: #fff; }
+        .user-search-modal .btn-close { filter: invert(1); }
+        .user-search-modal .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; border-radius: 8px !important; padding: 0.5rem 1rem 0.5rem 2.5rem !important; transition: box-shadow 0.2s ease, border-color 0.2s ease; }
+        .user-search-modal .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .user-search-modal .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        @media (min-width: 768px) { .profile-avatar { margin-left: 0; margin-right: 0; } }
+        .avatar-lg { width: clamp(80px, 20vw, 300px); height: clamp(80px, 20vw, 300px); }
+        .avatar-sm { width: clamp(40px, 10vw, 60px); height: clamp(40px, 10vw, 60px); }
+    </style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <%- include('partials/header') %>
+    <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'badges' }) %>
+    <div class="container my-4 flex-grow-1">
+        <p class="empty-tab-message text-center">No content yet</p>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        const searchInput = document.getElementById('searchInput');
+        const resultsEl = document.getElementById('searchResults');
+        const followBtn = document.getElementById('followBtn');
+        const userSearchModal = document.getElementById('userSearchModal');
+        if(followBtn){
+            followBtn.addEventListener('click', async function(){
+                const targetId = this.dataset.user;
+                const isFollowing = this.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                this.disabled = true;
+                try {
+                    const res = await fetch(`/users/${targetId}/${action}`, { method: 'POST' });
+                    if(!res.ok) throw new Error();
+                    const countEl = document.querySelector('#followersCount');
+                    if(isFollowing){
+                        this.classList.remove('btn-secondary');
+                        this.classList.add('btn-primary');
+                        this.textContent = 'Follow';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) - 1;
+                    } else {
+                        this.classList.remove('btn-primary');
+                        this.classList.add('btn-secondary');
+                        this.textContent = 'Following';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) + 1;
+                    }
+                } catch (err) {
+                    alert('Action failed');
+                } finally {
+                    this.disabled = false;
+                }
+            });
+        }
+        if(searchInput){
+            searchInput.addEventListener('input', async function(){
+                const q = this.value.trim();
+                if(!q){ resultsEl.innerHTML=''; return; }
+                const res = await fetch('/users/search?q='+encodeURIComponent(q));
+                if(!res.ok) return;
+                const data = await res.json();
+                const currentId = '<%= viewer ? viewer.id : "" %>';
+                resultsEl.innerHTML = data.map(u=>{
+                    const following = u.followers && u.followers.includes(currentId);
+                    const imgUrl = `/users/${u._id}/profile-image`;
+                    return `<div class="col-md-4"><div class="card p-2 d-flex flex-row align-items-center gap-2">`+
+                        `<img src="${imgUrl}" class="avatar avatar-sm">`+
+                        `<div class="flex-grow-1"><a href="/users/${u._id}" class="text-decoration-none">${u.username}</a></div>`+
+                        (currentId && u._id !== currentId ? `<button data-id="${u._id}" class="btn btn-${following?'secondary':'primary'} btn-sm follow-toggle">${following?'Following':'Follow'}</button>`:'')+
+                        `</div></div>`; }).join('');
+            });
+            resultsEl.addEventListener('click', async function(e){
+                const btn = e.target.closest('.follow-toggle');
+                if(!btn) return;
+                const targetId = btn.dataset.id;
+                const isFollowing = btn.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                btn.disabled = true;
+                try{
+                    const res = await fetch(`/users/${targetId}/${action}`, {method:'POST'});
+                    if(!res.ok) throw new Error();
+                    if(isFollowing){
+                        btn.classList.remove('btn-secondary');
+                        btn.classList.add('btn-primary');
+                        btn.textContent = 'Follow';
+                    }else{
+                        btn.classList.remove('btn-primary');
+                        btn.classList.add('btn-secondary');
+                        btn.textContent = 'Following';
+                    }
+                }catch(err){
+                    alert('Action failed');
+                }finally{
+                    btn.disabled = false;
+                }
+            });
+        }
+        if(userSearchModal){
+            userSearchModal.addEventListener('hidden.bs.modal', () => {
+                if(searchInput){
+                    searchInput.value = '';
+                    resultsEl.innerHTML = '';
+                }
+            });
+        }
+        const wrapper = document.querySelector('.profile-avatar-wrapper');
+        if(wrapper){
+            const logos = wrapper.querySelectorAll('.chain-logo');
+            if(logos.length){
+                const radius = wrapper.offsetWidth * 0.6;
+                const centerX = wrapper.offsetWidth / 2;
+                const centerY = wrapper.offsetHeight / 2;
+                const angleStep = Math.PI / (logos.length + 1);
+                logos.forEach((logo, idx) => {
+                    const angle = Math.PI - angleStep * (idx + 1);
+                    const x = centerX + radius * Math.cos(angle) - logo.offsetWidth / 2;
+                    const y = centerY + radius * Math.sin(angle) - logo.offsetHeight / 2;
+                    logo.style.left = x + 'px';
+                    logo.style.top = y + 'px';
+                });
+            }
+        }
+        const addGameBtn = document.getElementById('addGameBtn');
+        if(addGameBtn){
+            addGameBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('addGameModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        const openUserModalBtn = document.getElementById('openUserModal');
+        if(openUserModalBtn){
+            openUserModalBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('userSearchModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        $(function(){
+            const gameSelect = $('#gameSelect');
+            function formatGame(option){
+                if(!option.id) return option.text;
+                const homeLogo = option.homeLogo || '/images/placeholder.jpg';
+                const awayLogo = option.awayLogo || '/images/placeholder.jpg';
+                return $(
+                    `<div class="d-flex align-items-center">`+
+                    `<img src="${homeLogo}" style="width:30px;height:30px;border-radius:50%;" class="me-2">`+
+                    `<span>${option.homeTeamName}</span>`+
+                    `<span class="mx-1">vs</span>`+
+                    `<span>${option.awayTeamName}</span>`+
+                    `<img src="${awayLogo}" style="width:30px;height:30px;border-radius:50%;" class="ms-2">`+
+                    `<span class="ms-2 text-muted">(${option.score})</span>`+
+                    `</div>`
+                );
+            }
+            gameSelect.select2({
+                dropdownParent: $('#addGameModal'),
+                placeholder:'Search game',
+                width:'100%',
+                templateResult: formatGame,
+                templateSelection: formatGame,
+                ajax:{
+                    url:'/pastGames/search',
+                    dataType:'json',
+                    delay:250,
+                    data:function(params){ return { q: params.term, season: $('#seasonSelect').val() }; },
+                    processResults:function(data){
+                        return { results: data.map(g=>({
+                            id:g.id,
+                            homeTeamName:g.homeTeamName,
+                            awayTeamName:g.awayTeamName,
+                            homeLogo:g.homeLogo,
+                            awayLogo:g.awayLogo,
+                            score:g.score,
+                            text:`${g.homeTeamName} vs ${g.awayTeamName}`
+                        })) };
+                    }
+                }
+            });
+            $('#addGameModal').on('shown.bs.modal', function(){
+                if(!$('#seasonSelect option').length){
+                    fetch('/pastGames/seasons').then(r=>r.json()).then(data=>{
+                        const opts = data.map(s=>`<option value="${s}">${s}</option>`).join('');
+                        $('#seasonSelect').append('<option value="">Select season</option>'+opts);
+                    });
+                }
+            });
+            $('#seasonSelect').on('change', function(){
+                const val = $(this).val();
+                gameSelect.prop('disabled', !val).val(null).trigger('change');
+            });
+        });
+        const ratingRange=document.getElementById('ratingRange');
+        const ratingValue=document.getElementById('ratingValue');
+        if(ratingRange){
+            ratingValue.textContent=ratingRange.value;
+            ratingRange.addEventListener('input',()=>{ratingValue.textContent=ratingRange.value;});
+        }
+    </script>
+</body>
+</html>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profile - Games</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <style>
+        .profile-header { background: linear-gradient(to right, #7e22ce, #14b8a6); }
+        .trophy-panel { background-color: rgba(255,255,255,0.15); }
+        .follow-btn { transition: background-color 0.3s, color 0.3s; }
+        .avatar { border-radius: 50%; object-fit: cover; border: 2px solid rgba(255, 255, 255, 0.8); display: inline-block; }
+        .profile-avatar { display: block; margin-left: auto; margin-right: auto; }
+        .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; border-radius: 8px !important; padding: 0.5rem 1rem !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; }
+        .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        .user-search-modal .modal-content { background: linear-gradient(to right, #7e22ce, #14b8a6); background-clip: padding-box; border-radius: 1rem; border: 1px solid rgba(255, 255, 255, 0.2); box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3); color: #fff; backdrop-filter: blur(10px); font-family: inherit; }
+        .user-search-modal .modal-title { font-family: inherit; font-weight: bold; font-size: 1.5rem; color: #fff; }
+        .user-search-modal .btn-close { filter: invert(1); }
+        .user-search-modal .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; border-radius: 8px !important; padding: 0.5rem 1rem 0.5rem 2.5rem !important; transition: box-shadow 0.2s ease, border-color 0.2s ease; }
+        .user-search-modal .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .user-search-modal .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        @media (min-width: 768px) { .profile-avatar { margin-left: 0; margin-right: 0; } }
+        .avatar-lg { width: clamp(80px, 20vw, 300px); height: clamp(80px, 20vw, 300px); }
+        .avatar-sm { width: clamp(40px, 10vw, 60px); height: clamp(40px, 10vw, 60px); }
+    </style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <%- include('partials/header') %>
+    <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'games' }) %>
+    <div class="container my-4 flex-grow-1">
+        <% if (gameEntries && gameEntries.length > 0) { %>
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="profileGamesContainer">
+            <% gameEntries.forEach(function(entry){
+                 const game = entry.game;
+                 if(!game){ return; }
+                 const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
+                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
+            <div class="col">
+                <div class="position-relative">
+                    <a href="/games/<%= game._id %>" class="game-link d-block">
+                        <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                            <div class="game-date mb-2" data-start="<%= (game.startDate || game.StartDate) ? (game.startDate || game.StartDate).toISOString() : '' %>"></div>
+                            <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                                <div class="logo-wrapper me-3">
+                                    <div class="team-logo-container">
+                                        <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
+                                    </div>
+                                    <span class="team-name"><%= game.awayTeamName %></span>
+                                </div>
+                                <div class="logo-wrapper ms-3">
+                                    <div class="team-logo-container">
+                                        <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
+                                    </div>
+                                    <span class="team-name"><%= game.homeTeamName %></span>
+                                </div>
+                                <div class="position-absolute top-50 start-50 translate-middle fw-bold score-text text-white"><%= game.AwayPoints %> – <%= game.HomePoints %></div>
+                            </div>
+                            <% if(entry.rating){ %>
+                                <div class="mt-2 text-center text-white">Rated: <%= entry.rating %>/10</div>
+                            <% } %>
+                        </div>
+                    </a>
+                </div>
+            </div>
+            <% }); %>
+        </div>
+        <% } else { %>
+        <p class="empty-tab-message text-center text-black">No games yet</p>
+        <% } %>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        const searchInput = document.getElementById('searchInput');
+        const resultsEl = document.getElementById('searchResults');
+        const followBtn = document.getElementById('followBtn');
+        const userSearchModal = document.getElementById('userSearchModal');
+        if(followBtn){
+            followBtn.addEventListener('click', async function(){
+                const targetId = this.dataset.user;
+                const isFollowing = this.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                this.disabled = true;
+                try {
+                    const res = await fetch(`/users/${targetId}/${action}`, { method: 'POST' });
+                    if(!res.ok) throw new Error();
+                    const countEl = document.querySelector('#followersCount');
+                    if(isFollowing){
+                        this.classList.remove('btn-secondary');
+                        this.classList.add('btn-primary');
+                        this.textContent = 'Follow';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) - 1;
+                    } else {
+                        this.classList.remove('btn-primary');
+                        this.classList.add('btn-secondary');
+                        this.textContent = 'Following';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) + 1;
+                    }
+                } catch (err) {
+                    alert('Action failed');
+                } finally {
+                    this.disabled = false;
+                }
+            });
+        }
+        if(searchInput){
+            searchInput.addEventListener('input', async function(){
+                const q = this.value.trim();
+                if(!q){ resultsEl.innerHTML=''; return; }
+                const res = await fetch('/users/search?q='+encodeURIComponent(q));
+                if(!res.ok) return;
+                const data = await res.json();
+                const currentId = '<%= viewer ? viewer.id : "" %>';
+                resultsEl.innerHTML = data.map(u=>{
+                    const following = u.followers && u.followers.includes(currentId);
+                    const imgUrl = `/users/${u._id}/profile-image`;
+                    return `<div class="col-md-4"><div class="card p-2 d-flex flex-row align-items-center gap-2">`+
+                        `<img src="${imgUrl}" class="avatar avatar-sm">`+
+                        `<div class="flex-grow-1"><a href="/users/${u._id}" class="text-decoration-none">${u.username}</a></div>`+
+                        (currentId && u._id !== currentId ? `<button data-id="${u._id}" class="btn btn-${following?'secondary':'primary'} btn-sm follow-toggle">${following?'Following':'Follow'}</button>`:'')+
+                        `</div></div>`; }).join('');
+            });
+            resultsEl.addEventListener('click', async function(e){
+                const btn = e.target.closest('.follow-toggle');
+                if(!btn) return;
+                const targetId = btn.dataset.id;
+                const isFollowing = btn.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                btn.disabled = true;
+                try{
+                    const res = await fetch(`/users/${targetId}/${action}`, {method:'POST'});
+                    if(!res.ok) throw new Error();
+                    if(isFollowing){
+                        btn.classList.remove('btn-secondary');
+                        btn.classList.add('btn-primary');
+                        btn.textContent = 'Follow';
+                    }else{
+                        btn.classList.remove('btn-primary');
+                        btn.classList.add('btn-secondary');
+                        btn.textContent = 'Following';
+                    }
+                }catch(err){
+                    alert('Action failed');
+                }finally{
+                    btn.disabled = false;
+                }
+            });
+        }
+        if(userSearchModal){
+            userSearchModal.addEventListener('hidden.bs.modal', () => {
+                if(searchInput){
+                    searchInput.value = '';
+                    resultsEl.innerHTML = '';
+                }
+            });
+        }
+        const wrapper = document.querySelector('.profile-avatar-wrapper');
+        if(wrapper){
+            const logos = wrapper.querySelectorAll('.chain-logo');
+            if(logos.length){
+                const radius = wrapper.offsetWidth * 0.6;
+                const centerX = wrapper.offsetWidth / 2;
+                const centerY = wrapper.offsetHeight / 2;
+                const angleStep = Math.PI / (logos.length + 1);
+                logos.forEach((logo, idx) => {
+                    const angle = Math.PI - angleStep * (idx + 1);
+                    const x = centerX + radius * Math.cos(angle) - logo.offsetWidth / 2;
+                    const y = centerY + radius * Math.sin(angle) - logo.offsetHeight / 2;
+                    logo.style.left = x + 'px';
+                    logo.style.top = y + 'px';
+                });
+            }
+        }
+        const addGameBtn = document.getElementById('addGameBtn');
+        if(addGameBtn){
+            addGameBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('addGameModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        const openUserModalBtn = document.getElementById('openUserModal');
+        if(openUserModalBtn){
+            openUserModalBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('userSearchModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        $(function(){
+            const gameSelect = $('#gameSelect');
+            function formatGame(option){
+                if(!option.id) return option.text;
+                const homeLogo = option.homeLogo || '/images/placeholder.jpg';
+                const awayLogo = option.awayLogo || '/images/placeholder.jpg';
+                return $(
+                    `<div class="d-flex align-items-center">`+
+                    `<img src="${homeLogo}" style="width:30px;height:30px;border-radius:50%;" class="me-2">`+
+                    `<span>${option.homeTeamName}</span>`+
+                    `<span class="mx-1">vs</span>`+
+                    `<span>${option.awayTeamName}</span>`+
+                    `<img src="${awayLogo}" style="width:30px;height:30px;border-radius:50%;" class="ms-2">`+
+                    `<span class="ms-2 text-muted">(${option.score})</span>`+
+                    `</div>`
+                );
+            }
+            gameSelect.select2({
+                dropdownParent: $('#addGameModal'),
+                placeholder:'Search game',
+                width:'100%',
+                templateResult: formatGame,
+                templateSelection: formatGame,
+                ajax:{
+                    url:'/pastGames/search',
+                    dataType:'json',
+                    delay:250,
+                    data:function(params){ return { q: params.term, season: $('#seasonSelect').val() }; },
+                    processResults:function(data){
+                        return { results: data.map(g=>({
+                            id:g.id,
+                            homeTeamName:g.homeTeamName,
+                            awayTeamName:g.awayTeamName,
+                            homeLogo:g.homeLogo,
+                            awayLogo:g.awayLogo,
+                            score:g.score,
+                            text:`${g.homeTeamName} vs ${g.awayTeamName}`
+                        })) };
+                    }
+                }
+            });
+            $('#addGameModal').on('shown.bs.modal', function(){
+                if(!$('#seasonSelect option').length){
+                    fetch('/pastGames/seasons').then(r=>r.json()).then(data=>{
+                        const opts = data.map(s=>`<option value="${s}">${s}</option>`).join('');
+                        $('#seasonSelect').append('<option value="">Select season</option>'+opts);
+                    });
+                }
+            });
+            $('#seasonSelect').on('change', function(){
+                const val = $(this).val();
+                gameSelect.prop('disabled', !val).val(null).trigger('change');
+            });
+        });
+        const ratingRange=document.getElementById('ratingRange');
+        const ratingValue=document.getElementById('ratingValue');
+        if(ratingRange){
+            ratingValue.textContent=ratingRange.value;
+            ratingRange.addEventListener('input',()=>{ratingValue.textContent=ratingRange.value;});
+        }
+    </script>
+</body>
+</html>

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profile - Stats</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <style>
+        .profile-header { background: linear-gradient(to right, #7e22ce, #14b8a6); }
+        .trophy-panel { background-color: rgba(255,255,255,0.15); }
+        .follow-btn { transition: background-color 0.3s, color 0.3s; }
+        .avatar { border-radius: 50%; object-fit: cover; border: 2px solid rgba(255, 255, 255, 0.8); display: inline-block; }
+        .profile-avatar { display: block; margin-left: auto; margin-right: auto; }
+        .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; border-radius: 8px !important; padding: 0.5rem 1rem !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; }
+        .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        .user-search-modal .modal-content { background: linear-gradient(to right, #7e22ce, #14b8a6); background-clip: padding-box; border-radius: 1rem; border: 1px solid rgba(255, 255, 255, 0.2); box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3); color: #fff; backdrop-filter: blur(10px); font-family: inherit; }
+        .user-search-modal .modal-title { font-family: inherit; font-weight: bold; font-size: 1.5rem; color: #fff; }
+        .user-search-modal .btn-close { filter: invert(1); }
+        .user-search-modal .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; border-radius: 8px !important; padding: 0.5rem 1rem 0.5rem 2.5rem !important; transition: box-shadow 0.2s ease, border-color 0.2s ease; }
+        .user-search-modal .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .user-search-modal .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        @media (min-width: 768px) { .profile-avatar { margin-left: 0; margin-right: 0; } }
+        .avatar-lg { width: clamp(80px, 20vw, 300px); height: clamp(80px, 20vw, 300px); }
+        .avatar-sm { width: clamp(40px, 10vw, 60px); height: clamp(40px, 10vw, 60px); }
+    </style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <%- include('partials/header') %>
+    <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'stats' }) %>
+    <div class="container my-4 flex-grow-1">
+        <p class="empty-tab-message text-center">No content yet</p>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        const searchInput = document.getElementById('searchInput');
+        const resultsEl = document.getElementById('searchResults');
+        const followBtn = document.getElementById('followBtn');
+        const userSearchModal = document.getElementById('userSearchModal');
+        if(followBtn){
+            followBtn.addEventListener('click', async function(){
+                const targetId = this.dataset.user;
+                const isFollowing = this.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                this.disabled = true;
+                try {
+                    const res = await fetch(`/users/${targetId}/${action}`, { method: 'POST' });
+                    if(!res.ok) throw new Error();
+                    const countEl = document.querySelector('#followersCount');
+                    if(isFollowing){
+                        this.classList.remove('btn-secondary');
+                        this.classList.add('btn-primary');
+                        this.textContent = 'Follow';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) - 1;
+                    } else {
+                        this.classList.remove('btn-primary');
+                        this.classList.add('btn-secondary');
+                        this.textContent = 'Following';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) + 1;
+                    }
+                } catch (err) {
+                    alert('Action failed');
+                } finally {
+                    this.disabled = false;
+                }
+            });
+        }
+        if(searchInput){
+            searchInput.addEventListener('input', async function(){
+                const q = this.value.trim();
+                if(!q){ resultsEl.innerHTML=''; return; }
+                const res = await fetch('/users/search?q='+encodeURIComponent(q));
+                if(!res.ok) return;
+                const data = await res.json();
+                const currentId = '<%= viewer ? viewer.id : "" %>';
+                resultsEl.innerHTML = data.map(u=>{
+                    const following = u.followers && u.followers.includes(currentId);
+                    const imgUrl = `/users/${u._id}/profile-image`;
+                    return `<div class="col-md-4"><div class="card p-2 d-flex flex-row align-items-center gap-2">`+
+                        `<img src="${imgUrl}" class="avatar avatar-sm">`+
+                        `<div class="flex-grow-1"><a href="/users/${u._id}" class="text-decoration-none">${u.username}</a></div>`+
+                        (currentId && u._id !== currentId ? `<button data-id="${u._id}" class="btn btn-${following?'secondary':'primary'} btn-sm follow-toggle">${following?'Following':'Follow'}</button>`:'')+
+                        `</div></div>`; }).join('');
+            });
+            resultsEl.addEventListener('click', async function(e){
+                const btn = e.target.closest('.follow-toggle');
+                if(!btn) return;
+                const targetId = btn.dataset.id;
+                const isFollowing = btn.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                btn.disabled = true;
+                try{
+                    const res = await fetch(`/users/${targetId}/${action}`, {method:'POST'});
+                    if(!res.ok) throw new Error();
+                    if(isFollowing){
+                        btn.classList.remove('btn-secondary');
+                        btn.classList.add('btn-primary');
+                        btn.textContent = 'Follow';
+                    }else{
+                        btn.classList.remove('btn-primary');
+                        btn.classList.add('btn-secondary');
+                        btn.textContent = 'Following';
+                    }
+                }catch(err){
+                    alert('Action failed');
+                }finally{
+                    btn.disabled = false;
+                }
+            });
+        }
+        if(userSearchModal){
+            userSearchModal.addEventListener('hidden.bs.modal', () => {
+                if(searchInput){
+                    searchInput.value = '';
+                    resultsEl.innerHTML = '';
+                }
+            });
+        }
+        const wrapper = document.querySelector('.profile-avatar-wrapper');
+        if(wrapper){
+            const logos = wrapper.querySelectorAll('.chain-logo');
+            if(logos.length){
+                const radius = wrapper.offsetWidth * 0.6;
+                const centerX = wrapper.offsetWidth / 2;
+                const centerY = wrapper.offsetHeight / 2;
+                const angleStep = Math.PI / (logos.length + 1);
+                logos.forEach((logo, idx) => {
+                    const angle = Math.PI - angleStep * (idx + 1);
+                    const x = centerX + radius * Math.cos(angle) - logo.offsetWidth / 2;
+                    const y = centerY + radius * Math.sin(angle) - logo.offsetHeight / 2;
+                    logo.style.left = x + 'px';
+                    logo.style.top = y + 'px';
+                });
+            }
+        }
+        const addGameBtn = document.getElementById('addGameBtn');
+        if(addGameBtn){
+            addGameBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('addGameModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        const openUserModalBtn = document.getElementById('openUserModal');
+        if(openUserModalBtn){
+            openUserModalBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('userSearchModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        $(function(){
+            const gameSelect = $('#gameSelect');
+            function formatGame(option){
+                if(!option.id) return option.text;
+                const homeLogo = option.homeLogo || '/images/placeholder.jpg';
+                const awayLogo = option.awayLogo || '/images/placeholder.jpg';
+                return $(
+                    `<div class="d-flex align-items-center">`+
+                    `<img src="${homeLogo}" style="width:30px;height:30px;border-radius:50%;" class="me-2">`+
+                    `<span>${option.homeTeamName}</span>`+
+                    `<span class="mx-1">vs</span>`+
+                    `<span>${option.awayTeamName}</span>`+
+                    `<img src="${awayLogo}" style="width:30px;height:30px;border-radius:50%;" class="ms-2">`+
+                    `<span class="ms-2 text-muted">(${option.score})</span>`+
+                    `</div>`
+                );
+            }
+            gameSelect.select2({
+                dropdownParent: $('#addGameModal'),
+                placeholder:'Search game',
+                width:'100%',
+                templateResult: formatGame,
+                templateSelection: formatGame,
+                ajax:{
+                    url:'/pastGames/search',
+                    dataType:'json',
+                    delay:250,
+                    data:function(params){ return { q: params.term, season: $('#seasonSelect').val() }; },
+                    processResults:function(data){
+                        return { results: data.map(g=>({
+                            id:g.id,
+                            homeTeamName:g.homeTeamName,
+                            awayTeamName:g.awayTeamName,
+                            homeLogo:g.homeLogo,
+                            awayLogo:g.awayLogo,
+                            score:g.score,
+                            text:`${g.homeTeamName} vs ${g.awayTeamName}`
+                        })) };
+                    }
+                }
+            });
+            $('#addGameModal').on('shown.bs.modal', function(){
+                if(!$('#seasonSelect option').length){
+                    fetch('/pastGames/seasons').then(r=>r.json()).then(data=>{
+                        const opts = data.map(s=>`<option value="${s}">${s}</option>`).join('');
+                        $('#seasonSelect').append('<option value="">Select season</option>'+opts);
+                    });
+                }
+            });
+            $('#seasonSelect').on('change', function(){
+                const val = $(this).val();
+                gameSelect.prop('disabled', !val).val(null).trigger('change');
+            });
+        });
+        const ratingRange=document.getElementById('ratingRange');
+        const ratingValue=document.getElementById('ratingValue');
+        if(ratingRange){
+            ratingValue.textContent=ratingRange.value;
+            ratingRange.addEventListener('input',()=>{ratingValue.textContent=ratingRange.value;});
+        }
+    </script>
+</body>
+</html>

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profile - Waitlist</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <style>
+        .profile-header { background: linear-gradient(to right, #7e22ce, #14b8a6); }
+        .trophy-panel { background-color: rgba(255,255,255,0.15); }
+        .follow-btn { transition: background-color 0.3s, color 0.3s; }
+        .avatar { border-radius: 50%; object-fit: cover; border: 2px solid rgba(255, 255, 255, 0.8); display: inline-block; }
+        .profile-avatar { display: block; margin-left: auto; margin-right: auto; }
+        .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; border-radius: 8px !important; padding: 0.5rem 1rem !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; }
+        .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        .user-search-modal .modal-content { background: linear-gradient(to right, #7e22ce, #14b8a6); background-clip: padding-box; border-radius: 1rem; border: 1px solid rgba(255, 255, 255, 0.2); box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3); color: #fff; backdrop-filter: blur(10px); font-family: inherit; }
+        .user-search-modal .modal-title { font-family: inherit; font-weight: bold; font-size: 1.5rem; color: #fff; }
+        .user-search-modal .btn-close { filter: invert(1); }
+        .user-search-modal .profile-search.form-control { background-color: rgba(255, 255, 255, 0.2) !important; border: 1px solid #ccc !important; color: #fff !important; font-family: inherit !important; font-weight: bold !important; font-size: 1.1rem !important; border-radius: 8px !important; padding: 0.5rem 1rem 0.5rem 2.5rem !important; transition: box-shadow 0.2s ease, border-color 0.2s ease; }
+        .user-search-modal .profile-search.form-control::placeholder { color: rgba(255, 255, 255, 0.7) !important; font-style: italic; }
+        .user-search-modal .profile-search.form-control:focus { outline: none !important; box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important; border-color: #bbb !important; }
+        @media (min-width: 768px) { .profile-avatar { margin-left: 0; margin-right: 0; } }
+        .avatar-lg { width: clamp(80px, 20vw, 300px); height: clamp(80px, 20vw, 300px); }
+        .avatar-sm { width: clamp(40px, 10vw, 60px); height: clamp(40px, 10vw, 60px); }
+    </style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <%- include('partials/header') %>
+    <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'waitlist' }) %>
+    <div class="container my-4 flex-grow-1">
+        <div class="info-banner d-flex flex-wrap align-items-center justify-content-between mb-3">
+            <div class="d-flex align-items-center flex-grow-1 mb-2 mb-md-0">
+                <i class="bi bi-info-circle fs-5 me-2"></i>
+                <span>Click the heart icon on games you plan to attend to let your friends know!</span>
+            </div>
+            <a href="/games" class="go-games-link d-inline-flex align-items-center">
+                Go to games <i class="bi bi-arrow-right ms-1"></i>
+            </a>
+        </div>
+        <% if (wishlistGames && wishlistGames.length > 0) { %>
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="wishlistContainer">
+            <% wishlistGames.forEach(function(game){
+                 const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
+                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
+            <div class="col">
+                <div class="position-relative">
+                    <a href="/games/<%= game._id %>" class="game-link d-block">
+                        <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                            <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+                            <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                                <div class="logo-wrapper me-3">
+                                    <div class="team-logo-container">
+                                        <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
+                                    </div>
+                                    <span class="team-name"><%= game.awayTeamName %></span>
+                                </div>
+                                <div class="logo-wrapper ms-3">
+                                    <div class="team-logo-container">
+                                        <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
+                                    </div>
+                                    <span class="team-name"><%= game.homeTeamName %></span>
+                                </div>
+                                <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            </div>
+            <% }); %>
+        </div>
+        <% } else { %>
+        <p class="empty-tab-message text-center">No games wishlisted.</p>
+        <% } %>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        const searchInput = document.getElementById('searchInput');
+        const resultsEl = document.getElementById('searchResults');
+        const followBtn = document.getElementById('followBtn');
+        const userSearchModal = document.getElementById('userSearchModal');
+        if(followBtn){
+            followBtn.addEventListener('click', async function(){
+                const targetId = this.dataset.user;
+                const isFollowing = this.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                this.disabled = true;
+                try {
+                    const res = await fetch(`/users/${targetId}/${action}`, { method: 'POST' });
+                    if(!res.ok) throw new Error();
+                    const countEl = document.querySelector('#followersCount');
+                    if(isFollowing){
+                        this.classList.remove('btn-secondary');
+                        this.classList.add('btn-primary');
+                        this.textContent = 'Follow';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) - 1;
+                    } else {
+                        this.classList.remove('btn-primary');
+                        this.classList.add('btn-secondary');
+                        this.textContent = 'Following';
+                        if(countEl) countEl.textContent = parseInt(countEl.textContent) + 1;
+                    }
+                } catch (err) {
+                    alert('Action failed');
+                } finally {
+                    this.disabled = false;
+                }
+            });
+        }
+        if(searchInput){
+            searchInput.addEventListener('input', async function(){
+                const q = this.value.trim();
+                if(!q){ resultsEl.innerHTML=''; return; }
+                const res = await fetch('/users/search?q='+encodeURIComponent(q));
+                if(!res.ok) return;
+                const data = await res.json();
+                const currentId = '<%= viewer ? viewer.id : "" %>';
+                resultsEl.innerHTML = data.map(u=>{
+                    const following = u.followers && u.followers.includes(currentId);
+                    const imgUrl = `/users/${u._id}/profile-image`;
+                    return `<div class="col-md-4"><div class="card p-2 d-flex flex-row align-items-center gap-2">`+
+                        `<img src="${imgUrl}" class="avatar avatar-sm">`+
+                        `<div class="flex-grow-1"><a href="/users/${u._id}" class="text-decoration-none">${u.username}</a></div>`+
+                        (currentId && u._id !== currentId ? `<button data-id="${u._id}" class="btn btn-${following?'secondary':'primary'} btn-sm follow-toggle">${following?'Following':'Follow'}</button>`:'')+
+                        `</div></div>`; }).join('');
+            });
+            resultsEl.addEventListener('click', async function(e){
+                const btn = e.target.closest('.follow-toggle');
+                if(!btn) return;
+                const targetId = btn.dataset.id;
+                const isFollowing = btn.classList.contains('btn-secondary');
+                const action = isFollowing ? 'unfollow' : 'follow';
+                btn.disabled = true;
+                try{
+                    const res = await fetch(`/users/${targetId}/${action}`, {method:'POST'});
+                    if(!res.ok) throw new Error();
+                    if(isFollowing){
+                        btn.classList.remove('btn-secondary');
+                        btn.classList.add('btn-primary');
+                        btn.textContent = 'Follow';
+                    }else{
+                        btn.classList.remove('btn-primary');
+                        btn.classList.add('btn-secondary');
+                        btn.textContent = 'Following';
+                    }
+                }catch(err){
+                    alert('Action failed');
+                }finally{
+                    btn.disabled = false;
+                }
+            });
+        }
+        if(userSearchModal){
+            userSearchModal.addEventListener('hidden.bs.modal', () => {
+                if(searchInput){
+                    searchInput.value = '';
+                    resultsEl.innerHTML = '';
+                }
+            });
+        }
+        const wrapper = document.querySelector('.profile-avatar-wrapper');
+        if(wrapper){
+            const logos = wrapper.querySelectorAll('.chain-logo');
+            if(logos.length){
+                const radius = wrapper.offsetWidth * 0.6;
+                const centerX = wrapper.offsetWidth / 2;
+                const centerY = wrapper.offsetHeight / 2;
+                const angleStep = Math.PI / (logos.length + 1);
+                logos.forEach((logo, idx) => {
+                    const angle = Math.PI - angleStep * (idx + 1);
+                    const x = centerX + radius * Math.cos(angle) - logo.offsetWidth / 2;
+                    const y = centerY + radius * Math.sin(angle) - logo.offsetHeight / 2;
+                    logo.style.left = x + 'px';
+                    logo.style.top = y + 'px';
+                });
+            }
+        }
+        const addGameBtn = document.getElementById('addGameBtn');
+        if(addGameBtn){
+            addGameBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('addGameModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        const openUserModalBtn = document.getElementById('openUserModal');
+        if(openUserModalBtn){
+            openUserModalBtn.addEventListener('click', () => {
+                const modalEl = document.getElementById('userSearchModal');
+                if(modalEl){
+                    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+            });
+        }
+        $(function(){
+            const gameSelect = $('#gameSelect');
+            function formatGame(option){
+                if(!option.id) return option.text;
+                const homeLogo = option.homeLogo || '/images/placeholder.jpg';
+                const awayLogo = option.awayLogo || '/images/placeholder.jpg';
+                return $(
+                    `<div class="d-flex align-items-center">`+
+                    `<img src="${homeLogo}" style="width:30px;height:30px;border-radius:50%;" class="me-2">`+
+                    `<span>${option.homeTeamName}</span>`+
+                    `<span class="mx-1">vs</span>`+
+                    `<span>${option.awayTeamName}</span>`+
+                    `<img src="${awayLogo}" style="width:30px;height:30px;border-radius:50%;" class="ms-2">`+
+                    `<span class="ms-2 text-muted">(${option.score})</span>`+
+                    `</div>`
+                );
+            }
+            gameSelect.select2({
+                dropdownParent: $('#addGameModal'),
+                placeholder:'Search game',
+                width:'100%',
+                templateResult: formatGame,
+                templateSelection: formatGame,
+                ajax:{
+                    url:'/pastGames/search',
+                    dataType:'json',
+                    delay:250,
+                    data:function(params){ return { q: params.term, season: $('#seasonSelect').val() }; },
+                    processResults:function(data){
+                        return { results: data.map(g=>({
+                            id:g.id,
+                            homeTeamName:g.homeTeamName,
+                            awayTeamName:g.awayTeamName,
+                            homeLogo:g.homeLogo,
+                            awayLogo:g.awayLogo,
+                            score:g.score,
+                            text:`${g.homeTeamName} vs ${g.awayTeamName}`
+                        })) };
+                    }
+                }
+            });
+            $('#addGameModal').on('shown.bs.modal', function(){
+                if(!$('#seasonSelect option').length){
+                    fetch('/pastGames/seasons').then(r=>r.json()).then(data=>{
+                        const opts = data.map(s=>`<option value="${s}">${s}</option>`).join('');
+                        $('#seasonSelect').append('<option value="">Select season</option>'+opts);
+                    });
+                }
+            });
+            $('#seasonSelect').on('change', function(){
+                const val = $(this).val();
+                gameSelect.prop('disabled', !val).val(null).trigger('change');
+            });
+        });
+        const ratingRange=document.getElementById('ratingRange');
+        const ratingValue=document.getElementById('ratingValue');
+        if(ratingRange){
+            ratingValue.textContent=ratingRange.value;
+            ratingRange.addEventListener('input',()=>{ratingValue.textContent=ratingRange.value;});
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split monolithic profile page into dedicated sub-pages
- add routes `/profile/badges`, `/profile/games`, `/profile/stats`, `/profile/waitlist`
- move the header/banner into new partial `profileHeader.ejs`
- show the `+ Game` modal button in the header so it appears on every profile page
- implement new controller actions for each sub-page
- update redirects to point to the new routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811ac0be4c8326aa224818d68ebc8c