### PR TITLE
Improve profile grids and header buttons

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -521,6 +521,7 @@
 }
 
 /* Gradient glassy button used across the app */
+
 .gradient-glass-btn{
   background: linear-gradient(to right,#14b8a6,#7e22ce);
   color:#fff;
@@ -533,6 +534,18 @@
   filter:brightness(1.1);
 }
 
+/* Generic glass style button */
+.glassy-btn{
+  background:rgba(255,255,255,0.2);
+  color:#fff;
+  border:1px solid rgba(255,255,255,0.25);
+  backdrop-filter:blur(10px);
+  transition:filter .2s;
+}
+.glassy-btn:hover{
+  filter:brightness(1.1);
+}
+
 /* Profile games layouts */
 #profileGamesContainer,
 #wishlistContainer{
@@ -540,7 +553,7 @@
 }
 #profileGamesContainer .game-card,
 #wishlistContainer .game-card{
-  width:100%;
+  width:95%;
 }
 
 .modal {

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -18,9 +18,9 @@
                     <h2 class="fw-bold mb-1 me-md-3">@<%= user.username %></h2>
                     <% if(!isCurrentUser){ %>
                         <% if(canMessage){ %>
-                            <button class="btn btn-outline-light btn-sm ms-md-2 message-btn" data-user="<%= user._id %>">Message</button>
+                            <button class="btn glassy-btn btn-sm ms-md-2 message-btn" data-user="<%= user._id %>">Message</button>
                         <% } else { %>
-                            <button class="btn btn-outline-light btn-sm ms-md-2" disabled title="Messaging requires a mutual follow">Message</button>
+                            <button class="btn glassy-btn btn-sm ms-md-2" disabled title="Messaging requires a mutual follow">Message</button>
                         <% } %>
                     <% } %>
                 </div>
@@ -40,16 +40,16 @@
                 </div>
                 <% if (isCurrentUser) { %>
                 <div class="mt-3">
-                    <button id="openUserModal" class="btn btn-primary rounded-pill follow-users-btn px-4" data-bs-toggle="modal" data-bs-target="#userSearchModal">Follow Users</button>
+                    <button id="openUserModal" class="btn glassy-btn rounded-pill follow-users-btn px-4" data-bs-toggle="modal" data-bs-target="#userSearchModal">Follow Users</button>
                 </div>
                 <% } %>
             </div>
             <div class="col-md-3 text-center text-md-end">
                 <% if (isCurrentUser) { %>
-                    <a href="/profile/edit" class="btn btn-primary rounded-pill px-4 mb-2">Edit Profile</a>
-                    <button id="addGameBtn" type="button" class="btn gradient-glass-btn mb-2" data-bs-toggle="modal" data-bs-target="#addGameModal">+ Game</button>
+                    <a href="/profile/edit" class="btn glassy-btn rounded-pill px-4 mb-2">Edit Profile</a>
+                    <button id="addGameBtn" type="button" class="btn glassy-btn mb-2" data-bs-toggle="modal" data-bs-target="#addGameModal">+ Game</button>
                 <% } else if (viewer) { %>
-                    <button id="followBtn" data-user="<%= user._id %>" class="btn btn-<%= isFollowing ? 'secondary' : 'primary' %> rounded-pill px-4 follow-btn mb-2"><%= isFollowing ? 'Following' : 'Follow' %></button>
+                    <button id="followBtn" data-user="<%= user._id %>" class="btn glassy-btn rounded-pill px-4 follow-btn mb-2"><%= isFollowing ? 'Following' : 'Follow' %></button>
                 <% } %>
             </div>
         </div>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -32,8 +32,14 @@
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'games' }) %>
     <div class="container my-4 flex-grow-1">
+        <div class="info-banner d-flex flex-wrap align-items-center justify-content-between mb-3">
+            <div class="d-flex align-items-center flex-grow-1 mb-2 mb-md-0">
+                <i class="bi bi-info-circle fs-5 me-2"></i>
+                <span>Press the +Games button to add a game from the past. Games added from the past will contribute toward stats but not toward badges and rankings.</span>
+            </div>
+        </div>
         <% if (gameEntries && gameEntries.length > 0) { %>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="profileGamesContainer">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 justify-content-center" id="profileGamesContainer">
             <% gameEntries.forEach(function(entry){
                  const game = entry.game;
                  if(!game){ return; }

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -45,7 +45,7 @@
             </a>
         </div>
         <% if (wishlistGames && wishlistGames.length > 0) { %>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="wishlistContainer">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 justify-content-center" id="wishlistContainer">
             <% wishlistGames.forEach(function(game){
                  const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
                  const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>


### PR DESCRIPTION
## Summary
- restyle profile header buttons with a glassy look
- adjust game and waitlist grids for better responsive layout
- add informational banner on the profile games tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688121afccfc832692dce5a4498908bf