### PR TITLE
Improve profile games sorting and header layout

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -249,6 +249,11 @@ exports.profileGames = async (req, res, next) => {
         let enrichedEntries = [];
         if (gameEntriesRaw.length) {
             enrichedEntries = await enrichGameEntries(gameEntriesRaw);
+            enrichedEntries.sort((a, b) => {
+                const da = a.game && (a.game.startDate || a.game.StartDate);
+                const db = b.game && (b.game.startDate || b.game.StartDate);
+                return new Date(db) - new Date(da);
+            });
         }
         res.render('profileGames', {
             user,

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -109,6 +109,25 @@
 .follow-users-btn {
     transition: background-color 0.3s, color 0.3s;
 }
+
+.edit-profile-btn {
+    font-size: 0.8rem;
+    padding: 0.25rem 0.75rem;
+}
+
+.add-game-btn {
+    font-size: 1.05rem;
+    font-weight: 700;
+    background: linear-gradient(to right,#14b8a6,#7e22ce);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.25);
+    backdrop-filter: blur(8px);
+    border-radius: 0.5rem;
+    transition: filter 0.2s;
+}
+.add-game-btn:hover {
+    filter: brightness(1.1);
+}
 .cropper-view-box,
 .cropper-face {
     border-radius: 50%;
@@ -198,6 +217,14 @@
 
 .game-date {
     font-weight: 600;
+}
+
+.game-date-banner {
+    background: rgba(255, 255, 255, 0.8);
+    color: #222;
+    font-weight: 700;
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
 }
 
 /* Interactive game link */

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -16,7 +16,9 @@
             <div class="col-md-6 text-center text-md-start">
                 <div class="d-flex flex-column flex-md-row align-items-center">
                     <h2 class="fw-bold mb-1 me-md-3">@<%= user.username %></h2>
-                    <% if(!isCurrentUser){ %>
+                    <% if(isCurrentUser){ %>
+                        <a href="/profile/edit" class="btn glassy-btn btn-sm ms-md-2 edit-profile-btn">Edit Profile</a>
+                    <% } else { %>
                         <% if(canMessage){ %>
                             <button class="btn glassy-btn btn-sm ms-md-2 message-btn" data-user="<%= user._id %>">Message</button>
                         <% } else { %>
@@ -46,8 +48,7 @@
             </div>
             <div class="col-md-3 text-center text-md-end">
                 <% if (isCurrentUser) { %>
-                    <a href="/profile/edit" class="btn glassy-btn rounded-pill px-4 mb-2">Edit Profile</a>
-                    <button id="addGameBtn" type="button" class="btn glassy-btn mb-2" data-bs-toggle="modal" data-bs-target="#addGameModal">+ Game</button>
+                    <button id="addGameBtn" type="button" class="btn glassy-btn mb-2 add-game-btn" data-bs-toggle="modal" data-bs-target="#addGameModal">+ Game</button>
                 <% } else if (viewer) { %>
                     <button id="followBtn" data-user="<%= user._id %>" class="btn glassy-btn rounded-pill px-4 follow-btn mb-2"><%= isFollowing ? 'Following' : 'Follow' %></button>
                 <% } %>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -46,10 +46,10 @@
                  const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
                  const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
             <div class="col">
+                <div class="game-date-banner text-center mb-1"><%= (game.startDate || game.StartDate).toISOString().split('T')[0] %></div>
                 <div class="position-relative">
                     <a href="/games/<%= game._id %>" class="game-link d-block">
                         <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-                            <div class="game-date mb-2" data-start="<%= (game.startDate || game.StartDate) ? (game.startDate || game.StartDate).toISOString() : '' %>"></div>
                             <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                                 <div class="logo-wrapper me-3">
                                     <div class="team-logo-container">
@@ -261,6 +261,28 @@
             ratingValue.textContent=ratingRange.value;
             ratingRange.addEventListener('input',()=>{ratingValue.textContent=ratingRange.value;});
         }
+
+        function hexToRgb(hex){
+            if(!hex) return [255,255,255];
+            hex = hex.replace('#','');
+            if(hex.length===3) hex = hex.split('').map(c=>c+c).join('');
+            const num = parseInt(hex,16);
+            return [(num>>16)&255,(num>>8)&255,num&255];
+        }
+        function luminance(r,g,b){
+            const a=[r,g,b].map(v=>{ v/=255; return v<=0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4); });
+            return 0.2126*a[0] + 0.7152*a[1] + 0.0722*a[2];
+        }
+        function chooseTextColor(colors){
+            const lums = colors.map(c=>{ const [r,g,b]=hexToRgb(c); return luminance(r,g,b); });
+            const avg = lums.reduce((a,b)=>a+b,0)/lums.length;
+            return avg > 0.5 ? '#333333' : '#ffffff';
+        }
+        document.querySelectorAll('#profileGamesContainer .game-card').forEach(card=>{
+            const away=card.dataset.awayColor; const home=card.dataset.homeColor;
+            const color=chooseTextColor([away,home]);
+            card.querySelectorAll('.team-name, .score-text, .text-white').forEach(e=>{e.style.color=color;});
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- sort past games by most recent first
- move Edit Profile button beside username and restyle it
- highlight the +Game button
- show a dark date banner above each game
- tweak colors for game cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68812922ec948326ad597c9f03d827b6