### PR TITLE
Add follower notifications and signup enhancements

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,7 +54,8 @@ app.use(async (req, res, next) => {
                     username: userDoc.username,
                     email: userDoc.email,
                     phoneNumber: userDoc.phoneNumber,
-                    profileImage: userDoc.profileImage
+                    profileImage: userDoc.profileImage,
+                    newFollowers: userDoc.newFollowers || []
                 };
             } else {
                 req.user = null;
@@ -70,17 +71,20 @@ app.use(async (req, res, next) => {
     if (req.user) {
         const hasUnread = await Message.exists({ participants: req.user.id, unreadBy: req.user.id });
         res.locals.hasUnreadMessages = !!hasUnread;
+        res.locals.newFollowers = req.user.newFollowers || [];
+        res.locals.hasNewFollowers = res.locals.newFollowers.length > 0;
     } else {
         res.locals.hasUnreadMessages = false;
+        res.locals.hasNewFollowers = false;
+        res.locals.newFollowers = [];
     }
     next();
 });
 
-app.use(async (req, res, next) => {
+app.use((req, res, next) => {
     if (req.user) {
-        const user = await User.findById(req.user.id).select('profileImage');
-        res.locals.navImg = user && user.profileImage && user.profileImage.data
-            ? `/users/${user._id}/profile-image`
+        res.locals.navImg = req.user.profileImage && req.user.profileImage.data
+            ? `/users/${req.user.id}/profile-image`
             : '/images/default-profile.png';
     } else {
         res.locals.navImg = '/images/default-profile.png';

--- a/models/users.js
+++ b/models/users.js
@@ -14,6 +14,7 @@ const userSchema = new mongoose.Schema({
     favoriteTeams: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Team', required: true }],
     followers: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     following: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    newFollowers: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     wishlist: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }],
     gamesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }], default: [] },
     teamsList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Team' }], default: [] },

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -669,3 +669,23 @@
   pointer-events:none;
   transition:left .3s;
 }
+
+.inbox-follower-badge{
+  width:0.5rem;
+  height:0.5rem;
+}
+
+.gradient-input{
+  background:linear-gradient(to right,#14b8a6,#7e22ce);
+  color:#fff;
+  font-weight:bold;
+  border:1px solid rgba(255,255,255,0.3);
+  backdrop-filter:blur(8px);
+  border-radius:.5rem;
+}
+.gradient-input::placeholder{color:#fff;font-weight:bold;}
+.gradient-input:focus{
+  color:#fff;
+  background:linear-gradient(to right,#14b8a6,#7e22ce);
+  box-shadow:0 0 0 0.2rem rgba(255,255,255,0.3);
+}

--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -14,20 +14,21 @@
 <body class="d-flex justify-content-center align-items-center min-vh-100">
     <div class="card shadow p-4" style="max-width: 450px; width: 100%;">
         <h1 class="text-center mb-4">Create Account</h1>
-        <form action="/signup" method="post">
+        <form action="/signup" method="post" enctype="multipart/form-data">
             <% if (typeof error !== 'undefined') { %>
                 <div class="alert alert-danger"><%= error %></div>
             <% } %>
-            <input type="text" name="username" placeholder="Username" class="form-control mb-3" maxlength="20" pattern="^[a-zA-Z0-9_]+$" required>
-            <input type="email" name="email" placeholder="Email" class="form-control mb-3" required>
-            <input type="password" name="password" placeholder="Password" class="form-control mb-3" required>
-            <input type="text" name="phoneNumber" placeholder="Phone Number" pattern="[0-9]{10}" class="form-control mb-3" required>
-            <select name="favoriteTeams" class="form-control mb-3 favoriteTeams-select" multiple required>
+            <input type="text" name="username" placeholder="Username" class="form-control gradient-input mb-3" maxlength="20" pattern="^[a-zA-Z0-9_]+$" required>
+            <input type="email" name="email" placeholder="Email" class="form-control gradient-input mb-3" required>
+            <input type="password" name="password" placeholder="Password" class="form-control gradient-input mb-3" required>
+            <input type="text" name="phoneNumber" placeholder="Phone Number" pattern="[0-9]{10}" class="form-control gradient-input mb-3" required>
+            <input type="file" name="profileImage" accept="image/*" class="form-control gradient-input mb-3" required>
+            <select name="favoriteTeams" class="favoriteTeams-select mb-4" multiple required>
                 <% teams.forEach(t => { %>
                     <option value="<%= t._id %>" data-logo="<%= t.logos && t.logos[0] ? t.logos[0] : '' %>"><%= t.school %> <%= t.mascot %></option>
                 <% }); %>
             </select>
-            <button type="submit" class="btn w-100 text-white" style="background-color:#14b8a6;">Sign Up</button>
+            <button type="submit" class="btn w-100 text-white gradient-glass-btn">Sign Up</button>
         </form>
         <div class="text-center mt-3">
             <a href="/login" class="text-decoration-none">Already have an account? Sign in</a>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -12,10 +12,13 @@
     </ul>
     <div class="text-nowrap d-flex align-items-center">
       <% if (loggedInUser) { %>
-        <a href="/messages" id="navMessages" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
+        <a href="<%= hasNewFollowers ? ('/users/' + newFollowers[0]) : '/messages' %>" id="navMessages" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
           <i class="bi bi-envelope-fill fs-4"></i>
           <% if(hasUnreadMessages){ %>
             <span class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
+          <% } %>
+          <% if(hasNewFollowers){ %>
+            <span class="position-absolute bottom-0 start-100 translate-middle-x p-1 bg-info border border-light rounded-circle inbox-follower-badge"></span>
           <% } %>
         </a>
         <a href="/profile" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">


### PR DESCRIPTION
## Summary
- integrate follower notifications via `newFollowers` field
- redirect inbox icon to new follower profiles when there are notifications
- require profile photo upload on sign up and style registration inputs
- show follower notification badge in navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881704ed2b08326954bb937ad575e01