### PR TITLE
Update signup UI

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -682,6 +682,12 @@
   border:1px solid rgba(255,255,255,0.3);
   backdrop-filter:blur(8px);
   border-radius:.5rem;
+  padding:.375rem .75rem;
+  width:100%;
+  display:block;
+}
+.file-input-label{
+  cursor:pointer;
 }
 .gradient-input::placeholder{color:#fff;font-weight:bold;}
 .gradient-input:focus{

--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign Up</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/custom.css">
     <style>
         body {
             background: linear-gradient(to right, #7e22ce, #14b8a6);
@@ -22,7 +23,8 @@
             <input type="email" name="email" placeholder="Email" class="form-control gradient-input mb-3" required>
             <input type="password" name="password" placeholder="Password" class="form-control gradient-input mb-3" required>
             <input type="text" name="phoneNumber" placeholder="Phone Number" pattern="[0-9]{10}" class="form-control gradient-input mb-3" required>
-            <input type="file" name="profileImage" accept="image/*" class="form-control gradient-input mb-3" required>
+            <input type="file" name="profileImage" id="profileImageInput" accept="image/*" class="d-none" required>
+            <label for="profileImageInput" id="profileImageLabel" class="gradient-input file-input-label mb-3 text-center d-block">Profile Image</label>
             <select name="favoriteTeams" class="favoriteTeams-select mb-4" multiple required>
                 <% teams.forEach(t => { %>
                     <option value="<%= t._id %>" data-logo="<%= t.logos && t.logos[0] ? t.logos[0] : '' %>"><%= t.school %> <%= t.mascot %></option>
@@ -53,6 +55,11 @@
                 templateResult: formatTeam,
                 templateSelection: formatTeam
             });
+        });
+        const fileInput = document.getElementById('profileImageInput');
+        const fileLabel = document.getElementById('profileImageLabel');
+        fileInput.addEventListener('change', function(){
+            fileLabel.textContent = this.files[0] ? this.files[0].name : 'Profile Image';
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- style signup form with custom gradient inputs
- add custom profile image upload label
- keep signup page linked to shared CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688174ce1a488326a806ce2802d1fbe6