### PR TITLE
Implement inbox modal and glassy select style

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -472,6 +472,16 @@ exports.viewFollowing = async (req, res, next) => {
     }
 };
 
+exports.clearNewFollowers = async (req, res, next) => {
+    try {
+        await User.findByIdAndUpdate(req.user.id, { newFollowers: [] });
+        req.user.newFollowers = [];
+        res.json({ success: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
 exports.setLocation = async (req, res, next) => {
     try {
         if(!req.user) return res.status(401).json({ error: 'Unauthorized' });

--- a/main.js
+++ b/main.js
@@ -129,12 +129,14 @@ app.get('/users/search', requireAuth, profileController.searchUsers);
 app.get('/users/:id/profile-image', profileController.getProfileImage);
 app.post('/users/:id/follow', requireAuth, profileController.followUser);
 app.post('/users/:id/unfollow', requireAuth, profileController.unfollowUser);
+app.post('/users/clear-new-followers', requireAuth, profileController.clearNewFollowers);
 app.get('/users/:id', requireAuth, profileController.viewUser);
 app.get('/users/:id/followers', requireAuth, profileController.viewFollowers);
 app.get('/users/:id/following', requireAuth, profileController.viewFollowing);
 
 app.get('/messages', requireAuth, messagesController.listThreads);
 app.get('/messages/modal', requireAuth, messagesController.renderModal);
+app.get('/inbox/modal', requireAuth, messagesController.renderInboxModal);
 app.get('/messages/:id', requireAuth, messagesController.viewThread);
 app.post('/messages/start/:id', requireAuth, messagesController.startThread);
 app.post('/messages/:id/send', requireAuth, messagesController.sendMessage);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -695,3 +695,19 @@
   background:linear-gradient(to right,#14b8a6,#7e22ce);
   box-shadow:0 0 0 0.2rem rgba(255,255,255,0.3);
 }
+
+/* Glass style for Select2 multi select choices */
+.select2-container--default .select2-selection--multiple{
+  background:linear-gradient(to right,#14b8a6,#7e22ce);
+  border:1px solid rgba(255,255,255,0.3);
+  backdrop-filter:blur(8px);
+  border-radius:.5rem;
+  padding:.25rem;
+}
+.select2-container--default .select2-selection__choice{
+  background-color:rgba(255,255,255,0.2) !important;
+  border:1px solid rgba(255,255,255,0.4) !important;
+  backdrop-filter:blur(6px);
+  color:#fff !important;
+  font-weight:bold;
+}

--- a/public/js/inboxModal.js
+++ b/public/js/inboxModal.js
@@ -1,0 +1,76 @@
+(function(){
+  const modalEl = document.getElementById('inboxModal');
+  const trigger = document.getElementById('navInbox');
+  if(!modalEl || !trigger) return;
+  const bsModal = new bootstrap.Modal(modalEl);
+  let messagesSeen = !trigger.dataset.unread;
+  let followersSeen = !trigger.dataset.newFollowers;
+
+  function updateBadge(){
+    if(messagesSeen && followersSeen){
+      const dot = trigger.querySelector('.inbox-dot');
+      if(dot) dot.remove();
+    }
+  }
+
+  async function loadModal(threadId){
+    try{
+      const res = await fetch(`/inbox/modal${threadId?`?thread=${threadId}`:''}`);
+      const html = await res.text();
+      modalEl.querySelector('.modal-content').innerHTML = html;
+      bsModal.show();
+      const msgContainer = modalEl.querySelector('#msgContainer');
+      if(msgContainer) msgContainer.scrollTop = msgContainer.scrollHeight;
+    }catch(err){console.error(err);}
+  }
+
+  trigger.addEventListener('click', function(e){
+    e.preventDefault();
+    loadModal();
+  });
+
+  modalEl.addEventListener('shown.bs.tab', async function(e){
+    if(e.target.id === 'followers-tab' && !followersSeen){
+      followersSeen = true;
+      updateBadge();
+      fetch('/users/clear-new-followers',{method:'POST'}).catch(()=>{});
+    }
+    if(e.target.id === 'messages-tab' && !messagesSeen){
+      messagesSeen = true;
+      updateBadge();
+    }
+  });
+
+  modalEl.addEventListener('click', function(e){
+    const link = e.target.closest('.thread-link');
+    if(link){
+      e.preventDefault();
+      const id = link.dataset.thread;
+      loadModal(id);
+    }
+  });
+
+  modalEl.addEventListener('submit', async function(e){
+    if(e.target.id === 'messageForm'){
+      e.preventDefault();
+      const threadId = e.target.dataset.thread;
+      const input = modalEl.querySelector('#messageInput');
+      const content = input.value.trim();
+      if(!content) return;
+      try{
+        const res = await fetch(`/messages/${threadId}/send`, {
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded','Accept':'application/json'},
+          body: new URLSearchParams({content})
+        });
+        if(!res.ok){
+          const data = await res.json().catch(()=>({}));
+          alert(data.error || 'You can only message users who follow you back.');
+          return;
+        }
+        input.value = '';
+        loadModal(threadId);
+      }catch(err){console.error(err);}
+    }
+  });
+})();

--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -94,7 +94,7 @@
             <input type="text" name="phoneNumber" placeholder="Phone Number" pattern="[0-9]{10}" class="form-control gradient-input mb-3" required>
             <input type="file" name="profileImage" id="profileImageInput" accept="image/*" class="d-none" required>
             <label for="profileImageInput" id="profileImageLabel" class="gradient-input file-input-label mb-3  d-block">Click to add Profile Image</label>
-            <select name="favoriteTeams" class="favoriteTeams-select mb-4" multiple required>
+            <select name="favoriteTeams" class="favoriteTeams-select gradient-input mb-4" multiple required>
                 <% teams.forEach(t => { %>
                     <option value="<%= t._id %>" data-logo="<%= t.logos && t.logos[0] ? t.logos[0] : '' %>"><%= t.school %> <%= t.mascot %></option>
                 <% }); %>

--- a/views/editProfile.ejs
+++ b/views/editProfile.ejs
@@ -35,7 +35,7 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Favorite Teams</label>
-                        <select name="favoriteTeams" class="form-control favoriteTeams-select" multiple required>
+                        <select name="favoriteTeams" class="form-control favoriteTeams-select gradient-input" multiple required>
                             <% teams.forEach(t => { %>
                                 <option value="<%= t._id %>" data-logo="<%= t.logos && t.logos[0] ? t.logos[0] : '' %>" <%= user.favoriteTeams.some(ft => String(ft._id) === String(t._id)) ? 'selected' : '' %>><%= t.school %> <%= t.mascot %></option>
                             <% }); %>

--- a/views/inboxModal.ejs
+++ b/views/inboxModal.ejs
@@ -1,0 +1,69 @@
+<div class="modal-header border-0 pb-0">
+  <ul class="nav nav-tabs" id="inboxTab" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="followers-tab" data-bs-toggle="tab" data-bs-target="#followersPane" type="button" role="tab">Followers</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="messages-tab" data-bs-toggle="tab" data-bs-target="#messagesPane" type="button" role="tab">Messages</button>
+    </li>
+  </ul>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body p-0" style="min-height:60vh;">
+  <div class="tab-content h-100">
+    <div class="tab-pane fade show active h-100" id="followersPane" role="tabpanel">
+      <div class="list-group" style="max-height:60vh; overflow:auto;">
+        <% if (followers.length === 0) { %>
+          <div class="text-center text-white p-3">No New Followers</div>
+        <% } else { %>
+          <% followers.forEach(function(f){ %>
+            <a href="/users/<%= f._id %>" class="list-group-item list-group-item-action d-flex align-items-center follower-link">
+              <img src="/users/<%= f._id %>/profile-image" class="avatar avatar-sm me-2">
+              <%= f.username %> followed you
+            </a>
+          <% }) %>
+        <% } %>
+      </div>
+    </div>
+    <div class="tab-pane fade h-100" id="messagesPane" role="tabpanel">
+      <div class="d-flex h-100">
+        <div class="threads list-group flex-shrink-0" style="width:35%; max-height:60vh; overflow:auto;">
+          <% if (threads.length === 0) { %>
+            <div class="text-center text-white p-3">No Messages</div>
+          <% } else { %>
+            <% threads.forEach(function(t){ const other = t.participants.find(p=> String(p._id||p) !== loggedInUser.id); const last = t.messages[t.messages.length-1]; const unread = t.unreadBy.some(u=> String(u) === loggedInUser.id); %>
+              <a href="#" data-thread="<%= t._id %>" class="thread-link list-group-item list-group-item-action d-flex align-items-center position-relative <%= currentThread && String(currentThread._id)===String(t._id)?'active':'' %>">
+                <img src="/users/<%= other._id %>/profile-image" class="avatar avatar-sm me-2">
+                <div class="flex-grow-1">
+                  <div class="fw-bold"><%= other.username %></div>
+                  <% if (last) { %><small class="text-muted"><%= last.content.slice(0,40) %></small><% } %>
+                </div>
+                <% if(unread){ %><span class="position-absolute top-0 end-0 translate-middle p-1 bg-danger border border-light rounded-circle"></span><% } %>
+              </a>
+            <% }) %>
+          <% } %>
+        </div>
+        <div class="conversation flex-grow-1 d-flex flex-column" style="background-color:rgba(255,255,255,0.2);">
+          <% if(currentThread){ %>
+            <div class="flex-grow-1 overflow-auto p-3" id="msgContainer">
+              <% currentThread.messages.forEach(function(m){ const isMine = String(m.sender._id||m.sender) === loggedInUser.id; %>
+                <div class="d-flex mb-2 <%= isMine ? 'justify-content-end' : 'justify-content-start' %>">
+                  <div class="p-2 rounded" style="max-width:70%; background-color:<%= isMine ? '#d1e7ff' : '#f1f1f1' %>">
+                    <%= m.content %><br>
+                    <small class="text-muted message-timestamp"><%= new Date(m.timestamp).toLocaleString() %></small>
+                  </div>
+                </div>
+              <% }) %>
+            </div>
+            <form id="messageForm" data-thread="<%= currentThread._id %>" class="d-flex p-2 border-top">
+              <input type="text" id="messageInput" class="form-control me-2" autocomplete="off" required placeholder="Type message here">
+              <button class="btn btn-primary">Send</button>
+            </form>
+          <% } else { %>
+            <div class="flex-grow-1 d-flex align-items-center justify-content-center text-white">Select a conversation</div>
+          <% } %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -12,13 +12,10 @@
     </ul>
     <div class="text-nowrap d-flex align-items-center">
       <% if (loggedInUser) { %>
-        <a href="<%= hasNewFollowers ? ('/users/' + newFollowers[0]) : '/messages' %>" id="navMessages" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
+        <a href="#" id="navInbox" data-unread="<%= hasUnreadMessages ? '1' : '' %>" data-new-followers="<%= hasNewFollowers ? '1' : '' %>" class="me-3 position-relative <%= currentPath.startsWith('/messages') ? 'text-primary' : 'text-body' %>">
           <i class="bi bi-envelope-fill fs-4"></i>
-          <% if(hasUnreadMessages){ %>
-            <span class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
-          <% } %>
-          <% if(hasNewFollowers){ %>
-            <span class="position-absolute bottom-0 start-100 translate-middle-x p-1 bg-info border border-light rounded-circle inbox-follower-badge"></span>
+          <% if(hasUnreadMessages || hasNewFollowers){ %>
+            <span class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle inbox-dot"></span>
           <% } %>
         </a>
         <a href="/profile" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">
@@ -33,10 +30,10 @@
     </div>
   </nav>
 </header>
-<div class="modal fade messages-modal" id="messagesModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="inboxModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content"></div>
   </div>
 </div>
-<script src="/js/messagesModal.js"></script>
+<script src="/js/inboxModal.js"></script>
 <script>window.loggedInUser = <%- JSON.stringify(loggedInUser || null) %>;</script>


### PR DESCRIPTION
## Summary
- add unified inbox modal with tabs for follower and message notifications
- create script to load and manage modal notifications
- clear new follower data via new route
- show single red notification dot on inbox icon
- style Select2 multi-select choices with glass overlay
- apply gradient style to favorite teams selects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688180bd0ff48326ad632e689355513b