### PR TITLE
Improve inbox empty states and profile banner logic

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -573,6 +573,16 @@
   filter:brightness(1.1);
 }
 
+/* Reusable gradient text style */
+.gradient-text{
+  background: linear-gradient(to right,#14b8a6,#7e22ce);
+  -webkit-background-clip:text;
+  -webkit-text-fill-color:transparent;
+  background-clip:text; /* for Firefox */
+  color:transparent;
+  font-weight:bold;
+}
+
 /* Generic glass style button */
 .glassy-btn{
   background:rgba(255,255,255,0.2);

--- a/views/inboxModal.ejs
+++ b/views/inboxModal.ejs
@@ -25,7 +25,7 @@
     <div class="tab-pane fade show active h-100" id="followersPane" role="tabpanel">
       <div class="list-group" style="max-height:60vh; overflow:auto;">
         <% if (followers.length === 0) { %>
-          <div class="text-center text-white p-3">No New Followers</div>
+          <div class="text-center p-3 gradient-text fw-bold">No Notifications</div>
         <% } else { %>
           <% followers.forEach(function(f){ %>
             <a href="/users/<%= f._id %>" class="list-group-item list-group-item-action d-flex align-items-center follower-link">
@@ -40,7 +40,7 @@
       <% if(!currentThread){ %>
         <div class="threads list-group list-group-flush w-100" style="max-height:60vh; overflow:auto;">
           <% if (threads.length === 0) { %>
-            <div class="text-center text-white p-3">No Messages</div>
+            <div class="text-center p-3 gradient-text fw-bold">No Messages Yet</div>
           <% } else { %>
             <% threads.forEach(function(t){ const other = t.participants.find(p=> String(p._id||p) !== loggedInUser.id); const last = t.messages[t.messages.length-1]; const unread = t.unreadBy.some(u=> String(u) === loggedInUser.id); %>
               <a href="#" data-thread="<%= t._id %>" class="thread-link list-group-item list-group-item-action d-flex align-items-center position-relative">
@@ -58,7 +58,7 @@
         <div class="d-flex h-100">
           <div class="threads list-group list-group-flush flex-shrink-0" style="width:35%; max-height:60vh; overflow:auto;">
             <% if (threads.length === 0) { %>
-              <div class="text-center text-white p-3">No Messages</div>
+              <div class="text-center p-3 gradient-text fw-bold">No Messages Yet</div>
             <% } else { %>
               <% threads.forEach(function(t){ const other = t.participants.find(p=> String(p._id||p) !== loggedInUser.id); const last = t.messages[t.messages.length-1]; const unread = t.unreadBy.some(u=> String(u) === loggedInUser.id); %>
                 <a href="#" data-thread="<%= t._id %>" class="thread-link list-group-item list-group-item-action d-flex align-items-center position-relative <%= currentThread && String(currentThread._id)===String(t._id)?'active':'' %>">

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -76,12 +76,14 @@
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'games' }) %>
     <div class="container my-4 flex-grow-1">
+        <% if(isCurrentUser){ %>
         <div class="info-banner d-flex flex-wrap align-items-center justify-content-between mb-3">
             <div class="d-flex align-items-center flex-grow-1 mb-2 mb-md-0">
                 <i class="bi bi-info-circle fs-5 me-2"></i>
                 <span style="font-size: 12px">Press the +Game button to add a game from the past. Games added from the past will contribute toward stats but not toward badges and rankings.</span>
             </div>
         </div>
+        <% } %>
         <% if (gameEntries && gameEntries.length > 0) { %>
         <div class="row row-cols-1 row-cols-md-1 row-cols-lg-1 g-4 " id="profileGamesContainer">
             <% gameEntries.forEach(function(entry){

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -35,6 +35,7 @@
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'waitlist' }) %>
     <div class="container my-4 flex-grow-1">
+        <% if(isCurrentUser){ %>
         <div class="info-banner d-flex flex-wrap align-items-center justify-content-between mb-3">
             <div class="d-flex align-items-center flex-grow-1 mb-2 mb-md-0">
                 <i class="bi bi-info-circle fs-5 me-2"></i>
@@ -44,6 +45,7 @@
                 Go to games <i class="bi bi-arrow-right ms-1"></i>
             </a>
         </div>
+        <% } %>
         <% if (wishlistGames && wishlistGames.length > 0) { %>
             <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="gamesContainer">
             <% wishlistGames.forEach(function(game){


### PR DESCRIPTION
## Summary
- show bold gradient message for empty inbox lists
- add reusable `.gradient-text` style
- hide info banners on other users' profile tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818a01e21483269bc28e4f1ab7b9d5