### PR TITLE
Unify profile tab layouts

### DIFF
--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -222,47 +222,50 @@
                 <p class="empty-tab-message text-center">No content yet for this tab.</p>
             </div>
             <div class="tab-pane fade" id="gamesTab" role="tabpanel" aria-labelledby="games-tab">
-                
+                <% if(isCurrentUser){ %>
+                <div class="info-banner d-flex flex-wrap align-items-center justify-content-between mb-3">
+                    <div class="d-flex align-items-center flex-grow-1 mb-2 mb-md-0">
+                        <i class="bi bi-info-circle fs-5 me-2"></i>
+                        <span style="font-size: 12px">Press the +Game button to add a game from the past. Games added from the past will contribute toward stats but not toward badges and rankings.</span>
+                    </div>
+                </div>
+                <% } %>
                 <% if (gameEntries && gameEntries.length > 0) { %>
-                    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="profileGamesContainer">
-                    <% gameEntries.forEach(function(entry){
-                         const game = entry.game;
-                         if(!game){
-                             console.log('Missing game for entry', entry);
-                             return;
-                         }
-                         const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
-                         const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
+                <div class="row row-cols-1 row-cols-md-1 row-cols-lg-1 g-4" id="profileGamesContainer">
+                    <% gameEntries.forEach(function(entry){ const game = entry.game; if(!game){ return; } const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff'; const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
                     <div class="col">
-                        <div class="position-relative">
-                            <a href="/games/<%= game._id %>" class="game-link d-block">
-                                <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-                                    <div class="game-date mb-2" data-start="<%= (game.startDate || game.StartDate) ? (game.startDate || game.StartDate).toISOString() : '' %>"></div>
-                                    <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
-                                    <div class="logo-wrapper me-3">
-                                        <div class="team-logo-container">
-                                            <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
+                        <div class="game-date-banner mb-1">
+                            <% const dateObj = new Date(game.startDate || game.StartDate); %>
+                            <%= (dateObj.getMonth() + 1).toString().padStart(2, '0') %>/<%= dateObj.getDate().toString().padStart(2, '0') %>/<%= dateObj.getFullYear() %>
+                        </div>
+                        <div class="d-flex flex-wrap flex-md-nowrap align-items-center justify-content-between">
+                            <div class="position-relative flex-grow-1">
+                                <a href="/games/<%= game._id %>" class="game-link d-block">
+                                    <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                                        <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                                            <div class="logo-wrapper me-3">
+                                                <div class="team-logo-container">
+                                                    <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
+                                                </div>
+                                                <span class="team-name"><%= game.awayTeamName %></span>
+                                            </div>
+                                            <div class="logo-wrapper ms-3">
+                                                <div class="team-logo-container">
+                                                    <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
+                                                </div>
+                                                <span class="team-name"><%= game.homeTeamName %></span>
+                                            </div>
+                                            <div class="position-absolute top-50 start-50 translate-middle fw-bold score-text text-white"><%= game.AwayPoints %> – <%= game.HomePoints %></div>
                                         </div>
-                                        <span class="team-name"><%= game.awayTeamName %></span>
                                     </div>
-                                    <div class="logo-wrapper ms-3">
-                                        <div class="team-logo-container">
-                                            <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
-                                        </div>
-                                        <span class="team-name"><%= game.homeTeamName %></span>
-                                    </div>
-                                    <div class="position-absolute top-50 start-50 translate-middle fw-bold score-text text-white"><%= game.AwayPoints %> – <%= game.HomePoints %></div>
-                                </div>
-                                <% if(entry.rating){ %>
-                                    <div class="mt-2 text-center text-white">Rated: <%= entry.rating %>/10</div>
-                                <% } %>
-                                <% if(entry.comment){ %>
-                                    <div class="text-center text-white"><%= entry.comment %></div>
-                                <% } %>
-                                <% if(entry.image){ %>
-                                    <div class="text-center"><img src="<%= entry.image %>" alt="Game photo" style="max-width:80px;max-height:80px;border-radius:4px;" class="mt-1"></div>
-                                <% } %>
-                            </a>
+                                </a>
+                            </div>
+                            <% if(entry.rating){ %>
+                            <div class="rating-wrapper ms-md-4">
+                                <span class="rating-number"><%= entry.rating %>/10</span>
+                                <% if(entry.comment){ %><span class="rating-comment"><%= entry.comment %></span><% } %>
+                            </div>
+                            <% } %>
                         </div>
                     </div>
                     <% }); %>
@@ -270,6 +273,7 @@
                 <% } else { %>
                 <p class="empty-tab-message text-center text-black">No games yet</p>
                 <% } %>
+            </div>
             </div>
             <div class="tab-pane fade" id="stats" role="tabpanel" aria-labelledby="stats-tab">
                 <p class="empty-tab-message text-center">No content yet for this tab.</p>

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -47,7 +47,7 @@
         </div>
         <% } %>
         <% if (wishlistGames && wishlistGames.length > 0) { %>
-            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="gamesContainer">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center" id="gamesContainer">
             <% wishlistGames.forEach(function(game){
                  const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
                  const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>


### PR DESCRIPTION
## Summary
- align Games tab markup with dedicated page layout
- keep info banner conditional with isCurrentUser
- apply same grid classes in Waitlist view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818d4e99888326aab04bc8a097d164