### PR TITLE
Split profile view per route

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,12 +109,12 @@ app.get('/logout', (req, res) => {
     res.clearCookie('token');
     res.redirect('/login');
 });
-app.get('/thanks', requireAuth, (req, res) => { res.redirect('/profile/badges'); });
-app.get('/profile', requireAuth, (req, res) => { res.redirect('/profile/badges'); });
-app.get('/profile/badges', requireAuth, profileController.profileBadges);
-app.get('/profile/games', requireAuth, profileController.profileGames);
-app.get('/profile/stats', requireAuth, profileController.profileStats);
-app.get('/profile/waitlist', requireAuth, profileController.profileWaitlist);
+app.get('/thanks', requireAuth, (req, res) => { res.redirect('/profileBadges/' + req.user.id); });
+app.get('/profile', requireAuth, (req, res) => { res.redirect('/profileBadges/' + req.user.id); });
+app.get('/profileBadges/:user?', requireAuth, profileController.profileBadges);
+app.get('/profileGames/:user?', requireAuth, profileController.profileGames);
+app.get('/profileStats/:user?', requireAuth, profileController.profileStats);
+app.get('/profileWaitlist/:user?', requireAuth, profileController.profileWaitlist);
 app.get('/profile/edit', requireAuth, profileController.getEditProfile);
 app.post('/profile/edit', requireAuth, profileController.updateProfile);
 app.post('/profile/photo', requireAuth, profileController.uploadProfilePhoto);
@@ -130,7 +130,9 @@ app.get('/users/:id/profile-image', profileController.getProfileImage);
 app.post('/users/:id/follow', requireAuth, profileController.followUser);
 app.post('/users/:id/unfollow', requireAuth, profileController.unfollowUser);
 app.post('/users/clear-new-followers', requireAuth, profileController.clearNewFollowers);
-app.get('/users/:id', requireAuth, profileController.viewUser);
+app.get('/users/:id', requireAuth, (req, res) => {
+    res.redirect('/profileBadges/' + req.params.id);
+});
 app.get('/users/:id/followers', requireAuth, profileController.viewFollowers);
 app.get('/users/:id/following', requireAuth, profileController.viewFollowing);
 

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -52,16 +52,16 @@
     <div class="container mt-4 pb-0">
         <ul class="nav nav-tabs profile-tabs" id="profileTabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <a href="/profile/badges" class="nav-link profile-tab <%= activeTab==='badges' ? 'active' : '' %>">Badges</a>
+                <a href="/profileBadges/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='badges' ? 'active' : '' %>">Badges</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a href="/profile/games" class="nav-link profile-tab <%= activeTab==='games' ? 'active' : '' %>">Games</a>
+                <a href="/profileGames/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='games' ? 'active' : '' %>">Games</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a href="/profile/stats" class="nav-link profile-tab <%= activeTab==='stats' ? 'active' : '' %>">Stats</a>
+                <a href="/profileStats/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='stats' ? 'active' : '' %>">Stats</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a href="/profile/waitlist" class="nav-link profile-tab <%= activeTab==='waitlist' ? 'active' : '' %>">Waitlist</a>
+                <a href="/profileWaitlist/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='waitlist' ? 'active' : '' %>">Waitlist</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Summary
- create dynamic profile routes and update controllers
- redirect generic profile requests to the new URLs
- keep Add Game and Edit Profile flows working with new routes
- update profile tab navigation for new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68827d38a82c8326b49b3c6162a525c4