### PR TITLE
Implement profile statistics grid

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -26,13 +26,162 @@
         @media (min-width: 768px) { .profile-avatar { margin-left: 0; margin-right: 0; } }
         .avatar-lg { width: clamp(80px, 20vw, 300px); height: clamp(80px, 20vw, 300px); }
         .avatar-sm { width: clamp(40px, 10vw, 60px); height: clamp(40px, 10vw, 60px); }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(280px, 1fr), 1fr));
+            gap: 1rem;
+        }
+
+        .stat-block {
+            display: flex;
+            min-height: clamp(8rem, 20vw, 10rem);
+            padding: 1rem;
+            border-radius: 1rem;
+            border: 3px solid;
+            border-image: linear-gradient(to right, #14b8a6, #7e22ce) 1;
+        }
+
+        .stat-left {
+            flex: 0 0 35%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: clamp(1.5rem, 6vw, 2.5rem);
+        }
+
+        .stat-right {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            padding-left: 1rem;
+        }
+
+        .stat-right ol {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .stat-right li {
+            font-size: clamp(0.85rem, 3vw, 1rem);
+            margin-bottom: 0.25rem;
+        }
+
+        .stat-right img {
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            object-fit: cover;
+            margin-right: 0.25rem;
+        }
     </style>
 </head>
 <body class="d-flex flex-column min-vh-100">
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'stats' }) %>
+
+    <%
+        function ordinal(n){
+            const s=['th','st','nd','rd'],v=n%100;
+            return n+(s[(v-20)%10]||s[v]||s[0]);
+        }
+
+        function rankItems(arr, valFn){
+            const result=[];
+            let last=null, base=0;
+            arr.forEach((item,i)=>{
+                const val=valFn(item);
+                if(last===null || val!==last){ base=i+1; }
+                result.push({ item, rank: base, tie: i>0 && val===last });
+                last=val;
+            });
+            return result;
+        }
+
+        const gameEntries = user.gameEntries || [];
+        const gamesSorted = [...gameEntries].sort((a,b)=>(b.rating||0)-(a.rating||0)).slice(0,3);
+        const gamesRanked = rankItems(gamesSorted,g=>g.rating||0);
+
+        const venueList = user.venuesList || [];
+        const venueMap={};
+        venueList.forEach(v=>{ if(v && v.name){ venueMap[v.name]=(venueMap[v.name]||0)+1; } });
+        const uniqueVenueCount = Object.keys(venueMap).length;
+        const venuesSorted = Object.entries(venueMap).map(([name,count])=>({name,count})).sort((a,b)=>b.count-a.count||a.name.localeCompare(b.name)).slice(0,3);
+        const venuesRanked = rankItems(venuesSorted,v=>v.count);
+
+        const teamList = user.teamsList || [];
+        const teamMap={};
+        teamList.forEach(t=>{ if(t){ const key=t._id||t.id||t.school||t.name||t; if(!teamMap[key]) teamMap[key]={team:t,count:0}; teamMap[key].count++; } });
+        const uniqueTeamCount = Object.keys(teamMap).length;
+        const teamsSorted = Object.values(teamMap).sort((a,b)=>b.count-a.count||(a.team.school||'').localeCompare(b.team.school||'')).slice(0,3);
+        const teamsRanked = rankItems(teamsSorted,t=>t.count);
+
+        const stateMap={};
+        venueList.forEach(v=>{ if(v && v.state){ stateMap[v.state]=(stateMap[v.state]||0)+1; } });
+        const uniqueStateCount = Object.keys(stateMap).length;
+        const statesSorted = Object.entries(stateMap).map(([state,count])=>({state,count})).sort((a,b)=>b.count-a.count||a.state.localeCompare(b.state)).slice(0,3);
+        const statesRanked = rankItems(statesSorted,s=>s.count);
+    %>
+
     <div class="container my-4 flex-grow-1">
-        <p class="empty-tab-message text-center">No content yet</p>
+        <div class="stats-grid">
+            <!-- Games -->
+            <div class="stat-block">
+                <div class="stat-left">
+                    <span class="gradient-text"><%= gameEntries.length %></span>
+                </div>
+                <div class="stat-right">
+                    <ol>
+                        <% gamesRanked.forEach(gr=>{ const g=gr.item.game||{}; const d=new Date(g.startDate||g.StartDate||''); %>
+                        <li class="gradient-text"><%= (gr.tie?'T-':'') + ordinal(gr.rank) %>. <%= d.toLocaleDateString() %> – <%= g.awayTeamName || g.AwayTeam %> vs <%= g.homeTeamName || g.HomeTeam %> – <%= gr.item.rating %></li>
+                        <% }) %>
+                    </ol>
+                </div>
+            </div>
+
+            <!-- Venues -->
+            <div class="stat-block">
+                <div class="stat-left">
+                    <span class="gradient-text"><%= uniqueVenueCount %></span>
+                </div>
+                <div class="stat-right">
+                    <ol>
+                        <% venuesRanked.forEach(vr=>{ %>
+                        <li class="gradient-text"><%= (vr.tie?'T-':'') + ordinal(vr.rank) %>. <%= vr.item.name %> – <%= vr.item.count %></li>
+                        <% }) %>
+                    </ol>
+                </div>
+            </div>
+
+            <!-- Teams -->
+            <div class="stat-block">
+                <div class="stat-left">
+                    <span class="gradient-text"><%= uniqueTeamCount %></span>
+                </div>
+                <div class="stat-right">
+                    <ol>
+                        <% teamsRanked.forEach(tr=>{ const t=tr.item.team; const logo=(t.logos&&t.logos[0])||''; %>
+                        <li class="gradient-text"><%= (tr.tie?'T-':'') + ordinal(tr.rank) %>. <img src="<%= logo %>" alt=""/> <%= t.school || t.name %> – <%= tr.item.count %></li>
+                        <% }) %>
+                    </ol>
+                </div>
+            </div>
+
+            <!-- States -->
+            <div class="stat-block">
+                <div class="stat-left">
+                    <span class="gradient-text"><%= uniqueStateCount %></span>
+                </div>
+                <div class="stat-right">
+                    <ol>
+                        <% statesRanked.forEach(sr=>{ %>
+                        <li class="gradient-text"><%= (sr.tie?'T-':'') + ordinal(sr.rank) %>. <%= sr.item.state %> – <%= sr.item.count %></li>
+                        <% }) %>
+                    </ol>
+                </div>
+            </div>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- add responsive stats grid layout and ranking logic
- show games, venues, teams and states stats on profileStats view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828cec18588326a300df1a8bb10f3e