### PR TITLE
Improve top rated games display

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -298,6 +298,17 @@ exports.profileStats = async (req, res, next) => {
 
         const enrichedEntries = await enrichGameEntries(profileUser.gameEntries || []);
 
+        const topRatedGames = enrichedEntries.map(e => {
+            const game = e.game || {};
+            const rating = typeof e.rating === 'number' ? e.rating : 0;
+            const gameDate = game.startDate || game.StartDate || null;
+            const awayLogo = (game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0]) ?
+                game.awayTeam.logos[0] : '/images/placeholder.jpg';
+            const homeLogo = (game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0]) ?
+                game.homeTeam.logos[0] : '/images/placeholder.jpg';
+            return { gameDate, awayTeamLogoUrl: awayLogo, homeTeamLogoUrl: homeLogo, rating };
+        }).sort((a,b) => b.rating - a.rating).slice(0,3);
+
         const uniqueTeamIds = [...new Set((profileUser.teamsList || []).map(t => String(t._id || t)))];
         const uniqueVenueIds = [...new Set((profileUser.venuesList || []).map(v => String(v._id || v)))];
 
@@ -332,6 +343,7 @@ exports.profileStats = async (req, res, next) => {
             viewer: req.user,
             activeTab: 'stats',
             gameEntries: enrichedEntries,
+            topRatedGames,
             teamsList: profileUser.teamsList || [],
             venuesList: profileUser.venuesList || [],
             teamsCount,

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -182,6 +182,7 @@
 
     <script>
         const gameEntries = <%- JSON.stringify(gameEntries || []) %>;
+        const topRatedGames = <%- JSON.stringify(topRatedGames || []) %>;
         const venuesList = <%- JSON.stringify(venuesList || []) %>;
         const teamsList = <%- JSON.stringify(teamsList || []) %>;
         const teamsCount = <%= typeof teamsCount !== 'undefined' ? teamsCount : 0 %>;
@@ -193,14 +194,30 @@
             return n+(s[(v-20)%10]||s[v]||s[0]);
         }
 
+        function formatGameDate(d){
+            if(!d) return '';
+            const date = new Date(d);
+            return new Intl.DateTimeFormat(navigator.language,{dateStyle:'medium'}).format(date);
+        }
+
         function renderStats(){
             document.getElementById('gamesCount').textContent = gameEntries.length;
             const gamesTopEl = document.getElementById('gamesTop');
-            const sortedGames = gameEntries.slice().sort((a,b)=>(b.rating||0)-(a.rating||0)).slice(0,3);
-            gamesTopEl.innerHTML = sortedGames.map((e,i)=>{
-                const g = e.game || {};
-                const name = g.awayTeamName && g.homeTeamName ? `${g.awayTeamName} @ ${g.homeTeamName}` : (g.name||'Game');
-                return `<div class="top-list-item">${ordinal(i+1)}. ${name} - ${e.rating ?? ''}</div>`;
+            let prevRating, prevRank;
+            gamesTopEl.innerHTML = topRatedGames.map((g,i)=>{
+                let rank = i+1, prefix='';
+                if(i>0 && g.rating===prevRating){ rank=prevRank; prefix='T-'; } else { prevRank=rank; }
+                prevRating = g.rating;
+                return `<div class="top-game-item">`+
+                    `<div class="gradient-text small fw-light">${formatGameDate(g.gameDate)}</div>`+
+                    `<div class="d-flex align-items-center justify-content-center flex-wrap gap-1">`+
+                    `<span class="gradient-text fw-semibold">${prefix}${ordinal(rank)}</span>`+
+                    `<img src="${g.awayTeamLogoUrl}" class="game-logo-sm">`+
+                    `<span class="gradient-text">@</span>`+
+                    `<img src="${g.homeTeamLogoUrl}" class="game-logo-sm">`+
+                    `<span class="gradient-text fw-semibold">${g.rating}</span>`+
+                    `</div>`+
+                    `</div>`;
             }).join('');
 
             const venueMap = {};


### PR DESCRIPTION
## Summary
- fetch game/team logo info in controller
- pass `topRatedGames` to profileStats view
- update `renderStats()` to show top rated games with logos and dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b4d57220832686a837004d3228e9