### PR TITLE
Update addGame to store user ratings

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -632,7 +632,17 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
         user.gameEntries.push(entry);
 
         // Look up the past game to infer teams and venue
-        const pastGame = await PastGame.findById(gameId).lean();
+        const pastGameDoc = await PastGame.findById(gameId);
+
+        if (pastGameDoc) {
+            const rated = pastGameDoc.ratings.some(r => String(r.userId) === String(user._id));
+            if (!rated) {
+                pastGameDoc.ratings.push({ userId: user._id, rating: parseFloat(rating) });
+                await pastGameDoc.save();
+            }
+        }
+
+        const pastGame = pastGameDoc ? pastGameDoc.toObject() : null;
 
         const teamsToAdd = [];
         const venuesToAdd = [];

--- a/models/PastGame.js
+++ b/models/PastGame.js
@@ -25,7 +25,15 @@ const pastGameSchema = new mongoose.Schema({
   AwayPoints: Number,
   awayLeagueId: Number,
   homeLeagueId: Number,
-  ratings: { type: [Number], default: [] }
+  ratings: {
+    type: [
+      {
+        userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        rating: Number
+      }
+    ],
+    default: []
+  }
 });
 
 module.exports = mongoose.model('PastGame', pastGameSchema);


### PR DESCRIPTION
## Summary
- store per-user ratings in PastGame documents
- push user's rating to PastGame when adding a game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883c3a4a584832686d4e11d56d96973