### PR TITLE
Add PastGame comment support with sanitization

### DIFF
--- a/models/PastGame.js
+++ b/models/PastGame.js
@@ -33,6 +33,15 @@ const pastGameSchema = new mongoose.Schema({
       }
     ],
     default: []
+  },
+  comments: {
+    type: [
+      {
+        userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        comment: String
+      }
+    ],
+    default: []
   }
 });
 


### PR DESCRIPTION
## Summary
- extend `PastGame` schema with `comments` array
- add comment sanitization helper in `profileController`
- store sanitized comments from users while preventing duplicates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883c708be308326aeb28c34d3e2415f