### PR TITLE
Add past game page and venue overlay

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -254,6 +254,36 @@
     font-weight: bold;
 }
 
+/* Venue label overlay for profile games */
+.venue-overlay{
+  position:absolute;
+  top:0.25rem;
+  left:50%;
+  transform:translateX(-50%);
+  font-size:0.75rem;
+  color:#fff;
+  text-align:center;
+  width:100%;
+  pointer-events:none;
+}
+
+/* Past game score grid */
+.game-score-grid{
+  display:grid;
+  grid-template-columns:1fr auto 1fr;
+  grid-template-rows:auto auto auto;
+  gap:0.25rem;
+  align-items:center;
+}
+
+.game-score-grid img{
+  width:60px;
+  height:60px;
+  object-fit:cover;
+  border-radius:50%;
+  border:2px solid rgba(255,255,255,0.8);
+}
+
 /* Game listing diagonal logos */
 .game-diagonal-square {
     position: relative;

--- a/views/pastGame.ejs
+++ b/views/pastGame.ejs
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Past Game Details</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/custom.css">
+</head>
+<body class="d-flex flex-column min-vh-100 gradient-bg">
+  <%- include('partials/header') %>
+  <div class="container my-4 flex-grow-1">
+    <div class="row g-4 align-items-center">
+      <div class="col-md-5">
+        <div class="team-diagonal-square mx-auto" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>">
+          <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);">
+            <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>"
+                 alt="<%= game.AwayTeam || game.awayTeamName %>" class="team-logo-detail away-logo">
+          </div>
+          <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);">
+            <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>"
+                 alt="<%= game.HomeTeam || game.homeTeamName %>" class="team-logo-detail home-logo">
+          </div>
+        </div>
+      </div>
+      <div class="col-md-7 text-white text-center text-md-start">
+        <% const awayLogo = (game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0]) ? game.awayTeam.logos[0] : '/images/placeholder.jpg'; %>
+        <% const homeLogo = (game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0]) ? game.homeTeam.logos[0] : '/images/placeholder.jpg'; %>
+        <% const average = (game.ratings && game.ratings.length ? (game.ratings.reduce((s,r)=>s+(r.rating||r),0)/game.ratings.length).toFixed(1) : 'N/A'); %>
+        <div class="game-score-grid mb-3">
+          <div><img src="<%= awayLogo %>" alt="<%= game.AwayTeam || game.awayTeamName %>"></div>
+          <div></div>
+          <div><img src="<%= homeLogo %>" alt="<%= game.HomeTeam || game.homeTeamName %>"></div>
+          <div class="fw-bold"><%= game.AwayTeam || game.awayTeamName %></div>
+          <div class="at-symbol">@</div>
+          <div class="fw-bold"><%= game.HomeTeam || game.homeTeamName %></div>
+          <div class="fs-4 fw-bold"><%= game.AwayPoints ?? game.awayPoints %></div>
+          <div></div>
+          <div class="fs-4 fw-bold"><%= game.HomePoints ?? game.homePoints %></div>
+        </div>
+        <p class="mb-1"><%= game.Venue || game.venue %></p>
+        <% const reviewCount = reviews ? reviews.length : 0; %>
+        <p class="mb-3">Average Rating: <%= average %> <a href="#" id="toggleReviews" class="text-decoration-none text-white">(<%= reviewCount %> review<%= reviewCount===1?'':'s' %>)</a></p>
+        <div id="reviewsSection" class="d-none">
+          <div id="reviewList">
+            <% if(reviews && reviews.length){ reviews.forEach(function(r, idx){ %>
+              <div class="row review-item <%= idx>=3 ? 'd-none' : '' %> align-items-center mb-3">
+                <div class="col-3 col-md-2 text-center">
+                  <img src="/users/<%= r.userId %>/profile-image" class="avatar avatar-sm mb-1">
+                  <div><%= r.username %></div>
+                </div>
+                <div class="col-6 col-md-8"><%= r.comment %></div>
+                <div class="col-3 col-md-2 fw-bold text-end"><%= r.rating %></div>
+              </div>
+            <% }) } else { %>
+              <p class="text-white">No reviews yet.</p>
+            <% } %>
+          </div>
+          <% if(reviews && reviews.length > 3){ %>
+          <div class="text-center">
+            <button id="showMoreBtn" class="btn btn-link text-white">Show More</button>
+          </div>
+          <% } %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const reviews = <%- JSON.stringify(reviews || []) %>;
+    const reviewList = document.getElementById('reviewList');
+    const showMoreBtn = document.getElementById('showMoreBtn');
+    let shown = 3;
+    if(showMoreBtn){
+      showMoreBtn.addEventListener('click', function(){
+        const hidden = reviewList.querySelectorAll('.review-item.d-none');
+        for(let i=0;i<3 && i<hidden.length;i++){
+          hidden[i].classList.remove('d-none');
+        }
+        shown += 3;
+        if(shown >= reviews.length) this.style.display = 'none';
+      });
+    }
+    const toggle = document.getElementById('toggleReviews');
+    if(toggle){
+      toggle.addEventListener('click', function(e){
+        e.preventDefault();
+        document.getElementById('reviewsSection').classList.toggle('d-none');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -100,6 +100,7 @@
                     <div class="position-relative flex-grow-1">
                         <a href="/games/<%= game._id %>" class="game-link d-block">
                             <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                                <div class="venue-overlay"><%= game.Venue || game.venue %></div>
                                 <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                                     <div class="logo-wrapper me-3">
                                         <div class="team-logo-container">


### PR DESCRIPTION
## Summary
- show venue name overlay on game tiles in profile
- style overlay and create past game score grid
- implement new pastGame.ejs with review list functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d308f62c8326895a8b19515b075a