### PR TITLE
Fix profile past game links

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,6 +157,7 @@ app.get('/games/searchGames', gamesController.searchGames);
 app.get('/pastGames/seasons', gamesController.listPastGameSeasons);
 app.get('/pastGames/teams', gamesController.listPastGameTeams);
 app.get('/pastGames/search', gamesController.searchPastGames);
+app.get('/pastGames/:id', gamesController.showPastGame);
 app.get('/games/:id', gamesController.showGame);
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -240,7 +240,7 @@
                         </div>
                         <div class="d-flex flex-wrap flex-md-nowrap align-items-center justify-content-between">
                             <div class="position-relative flex-grow-1">
-                                <a href="/games/<%= game._id %>" class="game-link d-block">
+                                <a href="/pastGames/<%= game._id %>" class="game-link d-block">
                                     <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                         <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                                             <div class="logo-wrapper me-3">

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -98,7 +98,7 @@
                 </div>
                 <div class="d-flex align-items-center">
                     <div class="position-relative flex-grow-1">
-                        <a href="/games/<%= game._id %>" class="game-link d-block">
+                        <a href="/pastGames/<%= game._id %>" class="game-link d-block">
                             <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                 <div class="venue-overlay"><%= game.Venue || game.venue %></div>
                                 <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">


### PR DESCRIPTION
## Summary
- link past game entries to dedicated endpoint
- support viewing past games
- route `/pastGames/:id` to controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d60e570c83269b44a6f7af38e197