### PR TITLE
Fix profile game link routing

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -229,17 +229,23 @@
 }
 
 /* Interactive game link */
-.game-link {
+.game-link,
+.past-game-link,
+.wishlist-game-link {
     display: inline-block;
     text-decoration: none;
     color: inherit;
 }
 
-.game-link .game-card {
+.game-link .game-card,
+.past-game-link .game-card,
+.wishlist-game-link .game-card {
     transition: transform 0.2s, box-shadow 0.2s, filter 0.2s;
 }
 
-.game-link:hover .game-card {
+.game-link:hover .game-card,
+.past-game-link:hover .game-card,
+.wishlist-game-link:hover .game-card {
     transform: scale(1.05);
     box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.3);
     filter: brightness(1.05);

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -240,7 +240,7 @@
                         </div>
                         <div class="d-flex flex-wrap flex-md-nowrap align-items-center justify-content-between">
                             <div class="position-relative flex-grow-1">
-                                <a href="/pastGames/<%= game._id %>" class="game-link d-block">
+                                <a href="/pastGames/<%= game._id %>" class="past-game-link d-block">
                                     <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                         <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                                             <div class="logo-wrapper me-3">
@@ -297,7 +297,7 @@
                          const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
                     <div class="col">
                         <div class="position-relative">
-                            <a href="/games/<%= game._id %>" class="game-link d-block">
+                            <a href="/games/<%= game._id %>" class="wishlist-game-link d-block">
                                 <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                     <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
                                     <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -98,7 +98,7 @@
                 </div>
                 <div class="d-flex align-items-center">
                     <div class="position-relative flex-grow-1">
-                        <a href="/pastGames/<%= game._id %>" class="game-link d-block">
+                        <a href="/pastGames/<%= game._id %>" class="past-game-link d-block">
                             <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                 <div class="venue-overlay"><%= game.Venue || game.venue %></div>
                                 <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -53,7 +53,7 @@
                  const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
             <div class="col">
                 <div class="position-relative">
-                    <a href="/games/<%= game._id %>" class="game-link d-block">
+                    <a href="/games/<%= game._id %>" class="wishlist-game-link d-block">
                         <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                             <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
                             <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">


### PR DESCRIPTION
## Summary
- differentiate classes for past vs wishlist games
- update profile pages to use the new link classes
- keep styling for new link classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e777fe348326973eb90ad66be54c