### PR TITLE
Enhance past game rating display

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -762,3 +762,33 @@
 .past-game-page {
   font-size: 1.25rem;
 }
+
+/* Average rating layout on past game page */
+.avg-rating-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.avg-label {
+  font-size: 2rem;
+  white-space: nowrap;
+}
+
+.avg-number {
+  font-size: 4rem;
+  line-height: 1;
+}
+
+.avg-reviews-link {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 576px) {
+  .avg-label {
+    font-size: 1.5rem;
+  }
+  .avg-number {
+    font-size: 3rem;
+  }
+}

--- a/views/pastGame.ejs
+++ b/views/pastGame.ejs
@@ -25,7 +25,13 @@
           </div>
         </div>
         <div class="mt-3 text-white text-center text-md-start">
-          <p class="mb-1">Average Rating: <%= average %> <a href="#" id="toggleReviews" class="text-decoration-none text-white">(<%= reviewCount %> review<%= reviewCount===1?'':'s' %>)</a></p>
+          <div class="avg-rating-container d-flex justify-content-between align-items-center">
+            <div class="avg-label fw-bold">AVG Rating:</div>
+            <div class="text-end">
+              <div class="avg-number fw-bold"><%= average %></div>
+              <a href="#" id="toggleReviews" class="avg-reviews-link fw-bold text-decoration-none">(<%= reviewCount %> review<%= reviewCount===1?'':'s' %>)</a>
+            </div>
+          </div>
           <div id="reviewsSection" class="d-none">
             <div id="reviewList">
               <% if(reviews && reviews.length){ reviews.forEach(function(r, idx){ %>


### PR DESCRIPTION
## Summary
- style the average rating area on the past game page
- display rating number prominently with review link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883f54f7dcc8326b0bc62e117fb63e6