### PR TITLE
Update past game matchup layout

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -275,10 +275,16 @@
 
 /* Past game score grid */
 .game-score-grid{
-  display:grid;
-  grid-template-columns:1fr auto 1fr;
-  grid-template-rows:auto auto auto;
-  gap:0.25rem;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:2rem;
+  flex-wrap:wrap;
+}
+
+.game-score-grid .team-column{
+  display:flex;
+  flex-direction:column;
   align-items:center;
 }
 

--- a/views/pastGame.ejs
+++ b/views/pastGame.ejs
@@ -57,26 +57,28 @@
           </div>
         </div>
       </div>
-      <div class="col-md-7 text-white text-center text-md-start">
+      <div class="col-md-7 text-white text-center text-md-start d-flex align-items-center">
         <% const awayLogo = (game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0]) ? game.awayTeam.logos[0] : '/images/placeholder.jpg'; %>
         <% const homeLogo = (game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0]) ? game.homeTeam.logos[0] : '/images/placeholder.jpg'; %>
         <% const dateObj = new Date(game.startDate || game.StartDate); %>
-        <div class="d-flex align-items-start mb-2">
+        <div class="d-flex align-items-center justify-content-center matchup-container mb-2 w-100">
           <div class="me-3 text-start venue-date">
             <div class="venue-name"><%= (venue && venue.name) ? venue.name : (game.Venue || game.venue) %></div>
             <div class="game-date"><%= (dateObj.getMonth() + 1).toString().padStart(2,'0') %>/<%= dateObj.getDate().toString().padStart(2,'0') %>/<%= dateObj.getFullYear() %></div>
           </div>
           <div class="flex-grow-1">
             <div class="game-score-grid mb-3">
-              <div><img class="score-logo" src="<%= awayLogo %>" alt="<%= game.AwayTeam || game.awayTeamName %>"></div>
-              <div></div>
-              <div><img class="score-logo" src="<%= homeLogo %>" alt="<%= game.HomeTeam || game.homeTeamName %>"></div>
-              <div class="team-name-large fw-bold"><%= game.AwayTeam || game.awayTeamName %></div>
-              <div class="at-symbol">@</div>
-              <div class="team-name-large fw-bold"><%= game.HomeTeam || game.homeTeamName %></div>
-              <div class="score-number fw-bold"><%= game.AwayPoints ?? game.awayPoints %></div>
-              <div></div>
-              <div class="score-number fw-bold"><%= game.HomePoints ?? game.homePoints %></div>
+              <div class="team-column text-center">
+                <img class="score-logo" src="<%= awayLogo %>" alt="<%= game.AwayTeam || game.awayTeamName %>">
+                <div class="team-name-large fw-bold"><%= game.AwayTeam || game.awayTeamName %></div>
+                <div class="score-number fw-bold"><%= game.AwayPoints ?? game.awayPoints %></div>
+              </div>
+              <div class="at-symbol d-flex align-items-center justify-content-center">@</div>
+              <div class="team-column text-center">
+                <img class="score-logo" src="<%= homeLogo %>" alt="<%= game.HomeTeam || game.homeTeamName %>">
+                <div class="team-name-large fw-bold"><%= game.HomeTeam || game.homeTeamName %></div>
+                <div class="score-number fw-bold"><%= game.HomePoints ?? game.homePoints %></div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- vertically center matchup info next to the main logo
- refactor matchup section to a simple 3-column layout
- update past-game CSS to use flexbox for the score grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68840526337083268173b013402bf08f