### PR TITLE
Enlarge past game logo container

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -899,3 +899,13 @@
 .past-game-page .rating-value {
   font-size: 1.25em;
 }
+
+/* Enlarged logo container for past games */
+.past-game-page .logo-wrapper {
+  width: 216px;
+}
+
+.past-game-page .team-logo-detail {
+  width: 45%;
+  height: 45%;
+}


### PR DESCRIPTION
## Summary
- scale up the logo wrapper for past games without affecting text or logos
- keep logo images the same size by adjusting `.team-logo-detail`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688411f0d5048326a6e8904ad8f42e73