### PR TITLE
Fix past game logo layout

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -902,10 +902,19 @@
 
 /* Enlarged logo container for past games */
 .past-game-page .logo-wrapper {
-  width: 216px;
+  width: 100%;
+}
+
+.past-game-page .logo-wrapper .team-diagonal-square {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 
 .past-game-page .team-logo-detail {
-  width: 45%;
-  height: 45%;
+  width: 90%;
+  height: 90%;
+}
+
+.past-game-page .row.g-4.align-items-start {
+  align-items: center;
 }


### PR DESCRIPTION
## Summary
- adjust past-game page logo square to align like game.ejs
- ensure vertical centering and consistent sizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68841783d8e083269bd1650a9687318f