### PR TITLE
Fix missing id in top games stats

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -312,16 +312,20 @@ exports.profileStats = async (req, res, next) => {
 
         const enrichedEntries = await enrichGameEntries(profileUser.gameEntries || []);
 
-        const topRatedGames = enrichedEntries.map(e => {
-            const game = e.game || {};
-            const rating = typeof e.rating === 'number' ? e.rating : 0;
-            const gameDate = game.startDate || game.StartDate || null;
-            const awayLogo = (game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0]) ?
-                game.awayTeam.logos[0] : '/images/placeholder.jpg';
-            const homeLogo = (game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0]) ?
-                game.homeTeam.logos[0] : '/images/placeholder.jpg';
-            return { gameDate, awayTeamLogoUrl: awayLogo, homeTeamLogoUrl: homeLogo, rating };
-        }).sort((a,b) => b.rating - a.rating).slice(0,3);
+        const topRatedGames = enrichedEntries
+            .filter(e => e.game && e.game._id)
+            .map(e => {
+                const game = e.game;
+                const rating = typeof e.rating === 'number' ? e.rating : 0;
+                const gameDate = game.startDate || game.StartDate || null;
+                const awayLogo = (game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0]) ?
+                    game.awayTeam.logos[0] : '/images/placeholder.jpg';
+                const homeLogo = (game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0]) ?
+                    game.homeTeam.logos[0] : '/images/placeholder.jpg';
+                return { _id: game._id, gameDate, awayTeamLogoUrl: awayLogo, homeTeamLogoUrl: homeLogo, rating };
+            })
+            .sort((a,b) => b.rating - a.rating)
+            .slice(0,3);
 
         const uniqueTeamIds = [...new Set((profileUser.teamsList || []).map(t => String(t._id || t)))];
         const uniqueVenueIds = [...new Set((profileUser.venuesList || []).map(v => String(v._id || v)))];

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -336,7 +336,7 @@
 
     const gamesTopEl = document.getElementById('gamesTop');
     const sortedGames = [...topRatedGames]
-        .filter(g => g && typeof g.rating === 'number')
+        .filter(g => g && g._id && typeof g.rating === 'number')
         .sort((a, b) => b.rating - a.rating)
         .slice(0, 3);
 


### PR DESCRIPTION
## Summary
- filter out invalid games when compiling top-rated games
- ensure client-side stats logic skips entries without ids

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68865d6169508326bf0b736573fe1f70