### PR TITLE
Add league filter and searchable dropdowns for game modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -154,6 +154,7 @@ app.get('/newProject', requireAuth, projectsController.getNewProject);
 app.get('/games', gamesController.listGames);
 app.get('/teams/search', gamesController.searchTeams);
 app.get('/games/searchGames', gamesController.searchGames);
+app.get('/pastGames/leagues', gamesController.listPastGameLeagues);
 app.get('/pastGames/seasons', gamesController.listPastGameSeasons);
 app.get('/pastGames/teams', gamesController.listPastGameTeams);
 app.get('/pastGames/search', gamesController.searchPastGames);

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -96,8 +96,12 @@
                 </div>
                 <div class="modal-body">
                     <div class="mb-3">
+                        <label class="form-label">League</label>
+                        <select id="leagueSelect" class="form-select glass-control"></select>
+                    </div>
+                    <div class="mb-3">
                         <label class="form-label">Season</label>
-                        <select id="seasonSelect" class="form-select glass-control"></select>
+                        <select id="seasonSelect" class="form-select glass-control" disabled></select>
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Team</label>


### PR DESCRIPTION
## Summary
- support league-based filtering in game lookup APIs
- add `/pastGames/leagues` route
- allow cascading league → season → team → game selections
- make team dropdown searchable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688676ab6a6c832698ab9d71926570b3