### PR TITLE
Show venue images on profile stats

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -34,16 +34,16 @@
         #teamsModal .gradient-text,
         #statesModal .gradient-text,
         #gamesModal .top-list-item,
-        #gamesModal .venue-name,
+        #gamesModal .venue-name-text,
         #gamesModal .venue-count,
         #venuesModal .top-list-item,
-        #venuesModal .venue-name,
+        #venuesModal .venue-name-text,
         #venuesModal .venue-count,
         #teamsModal .top-list-item,
-        #teamsModal .venue-name,
+        #teamsModal .venue-name-text,
         #teamsModal .venue-count,
         #statesModal .top-list-item,
-        #statesModal .venue-name,
+        #statesModal .venue-name-text,
         #statesModal .venue-count {
             background: none !important;
             -webkit-background-clip: initial !important;
@@ -51,7 +51,7 @@
             color: #fff !important;
         }
 
-        #statesModal .venue-name {
+        #statesModal .venue-name-text {
             font-size: 1.75rem;
         }
         .stats-grid {
@@ -165,6 +165,23 @@
             border-radius: 50%;
             object-fit: cover;
         }
+
+        .venue-name {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .venue-name-text,
+        .venue-count {
+            background: linear-gradient(to right, #14b8a6, #7e22ce);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            color: transparent;
+            font-weight: 700;
+            font-size: 1.25rem;
+        }
         #venuesTop {
             display: grid;
             grid-template-columns: 1fr 3fr 1fr;
@@ -180,15 +197,6 @@
             margin-left: 1rem;
             font-size: 1.5rem;
         }
-        .venue-name,
-.venue-count {
-    background: linear-gradient(to right, #14b8a6, #7e22ce);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text; /* for Firefox */
-    color: transparent;
-    font-weight: 700;
-}
         #gamesTop {
     margin-top: 0.5rem;
     display: grid;
@@ -431,15 +439,18 @@
             let prevCount = null;
             let rank = 0;
             let displayVenueRank = 0;
-            return entries.map(([name,count]) => {
+            return entries.map(item => {
                 rank++;
-                if(count !== prevCount) displayVenueRank = rank;
-                const prefix = entries.filter(e => e[1] === count).length > 1 ? 'T-' : '';
-                prevCount = count;
+                if(item.count !== prevCount) displayVenueRank = rank;
+                const prefix = entries.filter(e => e.count === item.count).length > 1 ? 'T-' : '';
+                prevCount = item.count;
+                const v = item.venue || {};
+                const name = v.name || '';
+                const img = v.imgUrl || '/images/placeholder.jpg';
                 return `
                     <div class="top-list-item">${prefix}${displayVenueRank}.</div>
-                    <div class="venue-name">${name}</div>
-                    <div class="venue-count">${count}</div>
+                    <div class="venue-name"><img src="${img}" alt="${name}" class="avatar avatar-sm"><span class="venue-name-text">${name}</span></div>
+                    <div class="venue-count">${item.count}</div>
                 `;
             }).join('');
         }
@@ -459,7 +470,7 @@
                 return `
                     <div class="top-list-item">${prefix}${displayTeamRank}.</div>
                     <img src="${logo}" alt="${name}" class="game-logo-sm">
-                    <div class="venue-name">${name}</div>
+                    <div class="venue-name"><span class="venue-name-text">${name}</span></div>
                     <div class="venue-count">${item.count}</div>
                 `;
             }).join('');
@@ -476,7 +487,7 @@
                 prevCount = count;
                 return `
                     <div class="top-list-item">${prefix}${displayStateRank}.</div>
-                    <div class="venue-name">${name}</div>
+                    <div class="venue-name"><span class="venue-name-text">${name}</span></div>
                     <div class="venue-count">${count}</div>
                 `;
             }).join('');
@@ -531,11 +542,11 @@
     // Venues section
     const venueMap = {};
     venuesList.forEach(v => {
-        const n = v.name || v;
-        if (!n) return;
-        venueMap[n] = (venueMap[n] || 0) + 1;
+        if (!v || !v.name) return;
+        if (!venueMap[v.name]) venueMap[v.name] = { count: 0, venue: v };
+        venueMap[v.name].count++;
     });
-    const venueEntries = Object.entries(venueMap).sort((a, b) => b[1] - a[1]);
+    const venueEntries = Object.values(venueMap).sort((a, b) => b.count - a.count);
     window.allRankedVenues = venueEntries;
     document.getElementById('venuesCount').textContent = venuesCount;
     const venuesTopEl = document.getElementById('venuesTop');


### PR DESCRIPTION
## Summary
- display venue images in top venues lists and modal
- style venue name text separately and align images
- compute venue rankings with accompanying venue objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68869069545c8326a5bda0b3207b50c4