### PR TITLE
Implement game entry deletion

### DIFF
--- a/main.js
+++ b/main.js
@@ -121,6 +121,7 @@ app.post('/profile/photo', requireAuth, profileController.uploadProfilePhoto);
 app.post('/profile/location', requireAuth, profileController.setLocation);
 app.post('/profile/games', requireAuth, profileController.addGame);
 app.put('/gameEntry/:id', requireAuth, profileController.updateGameEntry);
+app.delete('/gameEntry/:id', requireAuth, profileController.deleteGameEntry);
 app.get('/welcome', requireAuth, (req, res) => {
     res.redirect('/');
 });

--- a/public/js/editGameModal.js
+++ b/public/js/editGameModal.js
@@ -61,5 +61,22 @@
         window.openEditEntryModal(id);
       });
     });
+
+    document.querySelectorAll('.delete-entry-icon').forEach(icon => {
+      icon.addEventListener('click', async () => {
+        const id = icon.getAttribute('data-entry-id');
+        if(!confirm('Delete this entry?')) return;
+        try {
+          const res = await fetch(`/gameEntry/${id}`, { method: 'DELETE' });
+          if(!res.ok) throw new Error('Failed');
+          const col = icon.closest('.col');
+          if(col) col.remove();
+          const idx = (window.gameEntriesData || []).findIndex(e => e._id === id);
+          if(idx > -1){ window.gameEntriesData.splice(idx,1); }
+        } catch(err){
+          alert('Delete failed');
+        }
+      });
+    });
   });
 })();

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -119,6 +119,7 @@
                     <span><%= (dateObj.getMonth() + 1).toString().padStart(2, '0') %>/<%= dateObj.getDate().toString().padStart(2, '0') %>/<%= dateObj.getFullYear() %></span>
                     <% if(isCurrentUser){ %>
                         <i class="bi bi-pencil-square ms-2 text-black edit-entry-icon" role="button" data-entry-id="<%= entry._id %>"></i>
+                        <i class="bi bi-trash ms-2 text-black delete-entry-icon" role="button" data-entry-id="<%= entry._id %>"></i>
                     <% } %>
                 </div>
                 <div class="d-flex align-items-center">


### PR DESCRIPTION
## Summary
- add delete icon next to edit icon for game entries
- implement client-side handler to call new API and update DOM
- support deleting game entry, team references, and venue references
- expose new DELETE /gameEntry/:id route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886d563df848326b1cbc7758bccefc6