### PR TITLE
Add username availability check

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -153,6 +153,16 @@ exports.loginUser = async (req, res, next) => {
     }
 };
 
+exports.checkUsername = async (req, res, next) => {
+    try {
+        const username = req.params.username;
+        const exists = await User.exists({ username: new RegExp("^" + username + "$", "i") });
+        res.json({ available: !exists });
+    } catch (err) {
+        next(err);
+    }
+};
+
 
 
 exports.getProfile = async (req, res, next) => {

--- a/main.js
+++ b/main.js
@@ -105,6 +105,7 @@ app.get('/signup', profileController.getSignUp);
 app.get('/login', profileController.getLogin);
 app.post('/signup', profileController.saveUser);
 app.post('/login', profileController.loginUser);
+app.get("/check-username/:username", profileController.checkUsername);
 app.get('/logout', (req, res) => {
     res.clearCookie('token');
     res.redirect('/login');

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -953,3 +953,4 @@
   mix-blend-mode: multiply;
   opacity: 0.8;
 }
+.username-status{position:absolute;top:50%;right:1rem;transform:translateY(-50%);font-size:1.25rem;}

--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -88,7 +88,10 @@
             <% if (typeof error !== 'undefined') { %>
                 <div class="alert alert-danger"><%= error %></div>
             <% } %>
-            <input type="text" name="username" placeholder="Username" class="form-control gradient-input mb-3" maxlength="20" pattern="^[a-zA-Z0-9_]+$" required>
+            <div class="position-relative mb-3">
+            <input type="text" id="username" name="username" placeholder="Username" class="form-control gradient-input pe-5" maxlength="20" pattern="^[a-zA-Z0-9_]+$" required>
+            <span id="usernameStatus" class="username-status"></span>
+        </div>
             <input type="email" name="email" placeholder="Email" class="form-control gradient-input mb-3" required>
             <input type="password" name="password" placeholder="Password" class="form-control gradient-input mb-3" required>
             <input type="text" name="phoneNumber" placeholder="Phone Number" pattern="[0-9]{10}" class="form-control gradient-input mb-3" required>
@@ -131,6 +134,32 @@
         const fileLabel = document.getElementById('profileImageLabel');
         fileInput.addEventListener('change', function(){
             fileLabel.textContent = this.files[0] ? this.files[0].name : 'Profile Image';
+        });
+        const usernameInput = document.getElementById("username");
+        const usernameStatus = document.getElementById("usernameStatus");
+        let usernameTimer;
+        usernameInput.addEventListener("input", function(){
+            clearTimeout(usernameTimer);
+            const val = this.value.trim();
+            if(!val){
+                usernameStatus.textContent = "";
+                return;
+            }
+            usernameTimer = setTimeout(async () => {
+                try{
+                    const res = await fetch(`/check-username/${encodeURIComponent(val)}`);
+                    const data = await res.json();
+                    if(data.available){
+                        usernameStatus.textContent = "✅";
+                        usernameStatus.style.color = "green";
+                    }else{
+                        usernameStatus.textContent = "❌";
+                        usernameStatus.style.color = "red";
+                    }
+                }catch(e){
+                    usernameStatus.textContent = "";
+                }
+            }, 300);
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- backend endpoint `/check-username/:username` to verify username availability
- UI updates for signup to show real-time feedback
- frontend JS sends debounced fetch requests
- CSS rule for username status icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886fa69a7008326ac8a57e6d2bb8855