### PR TITLE
Add Conference model with CSV loader

### DIFF
--- a/loadConferences.js
+++ b/loadConferences.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const csv = require('csv-parser');
+const mongoose = require('mongoose');
+const db = require('./db');
+const Conference = require('./models/Conference');
+
+// Log connection events
+
+db.on('error', err => console.error('MongoDB connection error:', err));
+db.once('open', () => console.log('Connected to MongoDB'));
+
+function loadConferences(filePath, overwrite = false) {
+  return new Promise((resolve, reject) => {
+    const conferences = [];
+    fs.createReadStream(filePath)
+      .pipe(csv())
+      .on('data', row => {
+        const confName = row.confName;
+        const confId = row.confId ? Number(row.confId) : undefined;
+        if (confName && confId) {
+          conferences.push({ confName, confId });
+        } else {
+          console.warn(`Malformed row skipped: ${JSON.stringify(row)}`);
+        }
+      })
+      .on('end', async () => {
+        try {
+          for (const conf of conferences) {
+            if (overwrite) {
+              await Conference.findOneAndUpdate(
+                { confId: conf.confId },
+                conf,
+                { upsert: true, new: true }
+              );
+              console.log(`Upserted conference ${conf.confName}`);
+            } else {
+              const exists = await Conference.exists({ confId: conf.confId });
+              if (exists) {
+                console.log(`Skipped existing conference ${conf.confName}`);
+                continue;
+              }
+              await new Conference(conf).save();
+              console.log(`Inserted conference ${conf.confName}`);
+            }
+          }
+          console.log(`Processed ${conferences.length} conferences`);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      })
+      .on('error', reject);
+  });
+}
+
+const file = process.argv[2] || 'public/files/Conferences.csv';
+const overwrite = process.argv.includes('--overwrite');
+
+loadConferences(file, overwrite)
+  .then(() => console.log('Conference load completed'))
+  .catch(err => {
+    console.error('Failed to load conferences:', err);
+  })
+  .finally(() => {
+    mongoose.disconnect();
+  });

--- a/models/Conference.js
+++ b/models/Conference.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const conferenceSchema = new mongoose.Schema({
+  confName: { type: String, required: true, unique: true },
+  confId: { type: Number, required: true, unique: true }
+});
+
+module.exports = mongoose.model('Conference', conferenceSchema);

--- a/public/files/Conferences.csv
+++ b/public/files/Conferences.csv
@@ -1,0 +1,4 @@
+confName,confId
+ACC,1
+"Big Ten",2
+SEC,3


### PR DESCRIPTION
## Summary
- create `Conference` mongoose model
- add `loadConferences.js` script to import conference data from CSV
- provide example `public/files/Conferences.csv`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887a6aae9a88326806c9ac4f32a1981