### PR TITLE
Add mutual message button

### DIFF
--- a/main.js
+++ b/main.js
@@ -144,6 +144,7 @@ app.get('/messages/modal', requireAuth, messagesController.renderModal);
 app.get('/inbox/modal', requireAuth, messagesController.renderInboxModal);
 app.get('/messages/:id', requireAuth, messagesController.viewThread);
 app.post('/messages/start/:id', requireAuth, messagesController.startThread);
+app.post('/messages/thread/:userId', requireAuth, messagesController.getOrCreateThread);
 app.post('/messages/:id/send', requireAuth, messagesController.sendMessage);
 
 app.get('/tutorial', requireAuth, homeController.showTutorial);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -115,6 +115,11 @@
     padding: 0.25rem 0.75rem;
 }
 
+.message-btn {
+    font-size: 0.8rem;
+    padding: 0.25rem 0.75rem;
+}
+
 .add-game-btn {
     padding: 0.5rem 2rem;
     font-size: 1.1rem;

--- a/public/js/inboxModal.js
+++ b/public/js/inboxModal.js
@@ -88,5 +88,23 @@
       }catch(err){console.error(err);}
     }
   });
+
+  document.addEventListener('click', async function(e){
+    const btn = e.target.closest('.message-btn');
+    if(btn){
+      e.preventDefault();
+      const userId = btn.dataset.user;
+      try{
+        const res = await fetch(`/messages/thread/${userId}`, {method:'POST', headers:{'Accept':'application/json'}});
+        if(!res.ok){
+          const data = await res.json().catch(()=>({}));
+          alert(data.error || 'You can only message users who follow you back.');
+          return;
+        }
+        const data = await res.json();
+        loadModal(data.threadId);
+      }catch(err){ console.error(err); }
+    }
+  });
   });
 })();

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -19,6 +19,8 @@
                         <h2 class="fw-bold mb-0 me-3">@<%= user.username %></h2>
                         <% if(isCurrentUser){ %>
                             <a href="/profile/edit" class="btn glassy-btn btn-sm edit-profile-btn ms-2">Edit Profile</a>
+                        <% } else if(canMessage){ %>
+                            <button class="btn glassy-btn btn-sm message-btn ms-2" data-user="<%= user._id %>">Message</button>
                         <% } %>
                     </div>
                     <% if(isCurrentUser){ %>


### PR DESCRIPTION
## Summary
- add message button to profileHeader partial
- support fetching/creating threads through `/messages/thread/:userId`
- hook up message button to inbox modal via JS
- style the new message button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887bef8cf7c8326be548708dda36f06