### PR TITLE
Fix game dropdown limit and add loading spinner

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -379,7 +379,6 @@ exports.searchPastGames = async (req, res, next) => {
     }
     const games = await PastGame.find(match)
       .sort({ StartDate: 1 })
-      .limit(10)
       .lean();
     const teamIds = [...new Set(games.flatMap(g => [g.HomeId, g.AwayId]))];
     const teams = await Team.find({ teamId: { $in: teamIds } })

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -6,6 +6,7 @@
     const seasonSelect = $('#seasonSelect');
     const teamSelect = $('#teamSelect');
     const gameSelect = $('#gameSelect');
+    const gameSpinner = $('#gameSpinner');
     const commentInput = $('#commentInput');
     const commentCounter = $('#commentCounter');
     const submitBtn = $('#submitGameBtn');
@@ -81,6 +82,9 @@
         url:'/pastGames/search',
         dataType:'json',
         delay:250,
+        beforeSend:function(){
+          if(gameSpinner){ gameSpinner.show(); }
+        },
         data:function(params){
           return {
             leagueId: leagueSelect.val(),
@@ -105,6 +109,9 @@
               text:`${g.awayTeamName} vs ${g.homeTeamName}`
             };
           }) };
+        },
+        complete:function(){
+          if(gameSpinner){ gameSpinner.hide(); }
         }
       }
     });

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -111,7 +111,12 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Game</label>
-                        <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
+                        <div class="d-flex align-items-center">
+                            <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
+                            <div id="gameSpinner" class="spinner-border text-light ms-2" style="display:none;width:1.5rem;height:1.5rem;" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                        </div>
                     </div>
                     <div class="mb-3 position-relative">
                         <label class="form-label d-flex justify-content-between">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -364,7 +364,12 @@
                         </div>
                         <div class="mb-3">
                             <label class="form-label">Game</label>
-                            <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
+                            <div class="d-flex align-items-center">
+                                <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
+                                <div id="gameSpinner" class="spinner-border text-light ms-2" style="display:none;width:1.5rem;height:1.5rem;" role="status">
+                                    <span class="visually-hidden">Loading...</span>
+                                </div>
+                            </div>
                         </div>
                         <div class="mb-3 position-relative">
                             <label class="form-label d-flex justify-content-between">


### PR DESCRIPTION
## Summary
- remove hard limit from past game search API
- display a spinner while fetching games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c3a34bdc832695b6e0fc3901e3c2