### PR TITLE
Add ranking flow to +Game modal

### DIFF
--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -118,13 +118,20 @@
                             </div>
                         </div>
                     </div>
-                    <div class="mb-3 position-relative">
+                    <div class="mb-3 position-relative" id="ratingGroup">
                         <label class="form-label d-flex justify-content-between">
                             <span>Rating:</span>
                             <span id="ratingValue" class="fw-bold text-white">5</span>
                         </label>
                         <div class="glass-range-wrapper">
                             <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
+                        </div>
+                    </div>
+                    <div id="comparisonContainer" class="mb-3" style="display:none;">
+                        <p id="comparisonPrompt" class="mb-2 fw-bold"></p>
+                        <div id="comparisonButtons" class="d-flex justify-content-around">
+                            <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
+                            <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
                         </div>
                     </div>
                     <div class="mb-3">
@@ -140,6 +147,7 @@
                     </div>
                 </div>
                 <div class="modal-footer border-0">
+                    <button type="button" id="nextBtn" class="btn btn-primary">Next</button>
                     <button type="submit" id="submitGameBtn" class="btn btn-primary" disabled>Submit</button>
                 </div>
             </form>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -371,13 +371,20 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="mb-3 position-relative">
+                        <div class="mb-3 position-relative" id="ratingGroup">
                             <label class="form-label d-flex justify-content-between">
                                 <span>Rating:</span>
                                 <span id="ratingValue" class="fw-bold text-white">5</span>
                             </label>
                             <div class="glass-range-wrapper">
                                 <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
+                            </div>
+                        </div>
+                        <div id="comparisonContainer" class="mb-3" style="display:none;">
+                            <p id="comparisonPrompt" class="mb-2 fw-bold"></p>
+                            <div id="comparisonButtons" class="d-flex justify-content-around">
+                                <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
+                                <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
                             </div>
                         </div>
                         <div class="mb-3">
@@ -392,7 +399,8 @@
                         <input type="hidden" name="venuesList" id="venuesListInput">
                     </div>
                     <div class="modal-footer border-0">
-                        <button type="submit" class="btn btn-primary">Submit</button>
+                        <button type="button" id="nextBtn" class="btn btn-primary">Next</button>
+                        <button type="submit" id="submitGameBtn" class="btn btn-primary">Submit</button>
                     </div>
                 </form>
             </div>
@@ -407,6 +415,8 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
+        window.gameEntryCount = <%- (user.gameEntries || []).length %>;
+        window.gameEntryNames = <%- JSON.stringify((gameEntries || []).map(function(e){ var g=e.game||{}; return (g.awayTeamName || '') + ' vs ' + (g.homeTeamName || ''); })) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>

--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -40,6 +40,7 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
+        window.gameEntryCount = <%- (user.gameEntries || []).length %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -209,6 +209,11 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
+        window.gameEntryCount = <%- (user.gameEntries || []).length %>;
+        window.gameEntryNames = <%- JSON.stringify((gameEntries || []).map(e => {
+            const g = e.game || {};
+            return `${g.awayTeamName || ''} vs ${g.homeTeamName || ''}`;
+        })) %>;
         window.gameEntriesData = <%- JSON.stringify(gameEntries || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -652,6 +652,11 @@ document.addEventListener('DOMContentLoaded', renderStats);
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
+        window.gameEntryCount = <%- (user.gameEntries || []).length %>;
+        window.gameEntryNames = <%- JSON.stringify((gameEntries || []).map(e => {
+            const g = e.game || {};
+            return `${g.awayTeamName || ''} vs ${g.homeTeamName || ''}`;
+        })) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -87,6 +87,7 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
+        window.gameEntryCount = <%- (user.gameEntries || []).length %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- add conditional rating/ranking UI to profile add game modal
- expose game counts and names to frontend templates
- adjust profile header modal markup for new ranking buttons
- update Add Game modal JS with "this or that" flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887d6714b688326a6df4af73d5320d4