### PR TITLE
Fix and save game ELO ratings

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -43,10 +43,13 @@ const userSchema = new mongoose.Schema({
         updatedAt: Date
     },
     messageThreads: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Message' }],
-    gameElo: [{
-        game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
-        elo: { type: Number, default: 1500 }
-      }], default: []
+    gameElo: {
+        type: [{
+            game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
+            elo: { type: Number, default: 1500 }
+        }],
+        default: []
+    }
 });
 
 // Automatically hash a password before saving


### PR DESCRIPTION
## Summary
- fix schema for `gameElo`
- compute ELO ratings from first 5 manual scores
- store results on user when games are added, updated or removed
- log ratings, ELOs and array being saved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887da59187c8326b8dc487c9aead377