### PR TITLE
Implement multi-step +Game modal

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -392,7 +392,10 @@ exports.searchPastGames = async (req, res, next) => {
       awayTeamName: g.AwayTeam,
       homeLogo: teamMap[g.HomeId] && teamMap[g.HomeId].logos && teamMap[g.HomeId].logos[0],
       awayLogo: teamMap[g.AwayId] && teamMap[g.AwayId].logos && teamMap[g.AwayId].logos[0],
-      score: `${g.HomePoints ?? ''}-${g.AwayPoints ?? ''}`
+      score: `${g.HomePoints ?? ''}-${g.AwayPoints ?? ''}`,
+      homePoints: g.HomePoints,
+      awayPoints: g.AwayPoints,
+      gameDate: g.StartDate
     }));
     res.json(results);
   } catch(err){

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -959,3 +959,27 @@
   opacity: 0.8;
 }
 .username-status{position:absolute;top:50%;right:1rem;transform:translateY(-50%);font-size:1.25rem;}
+
+/* ELO matchup cards */
+.elo-game-card{
+  border:1px solid #fff;
+  border-radius:.5rem;
+  padding:.5rem;
+  background:rgba(255,255,255,0.15);
+  backdrop-filter:blur(8px);
+  color:#fff;
+}
+.elo-game-grid{
+  display:grid;
+  grid-template-columns:repeat(3,1fr);
+  grid-template-rows:repeat(3,auto);
+  align-items:center;
+  text-align:center;
+}
+.elo-game-grid img{
+  width:40px;
+  height:40px;
+  object-fit:cover;
+  border-radius:50%;
+  margin:0 auto;
+}

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -93,10 +93,12 @@
         <div class="modal-content p-3">
             <form action="/profile/games" method="post" enctype="multipart/form-data">
                 <div class="modal-header border-0">
-                    <h5 class="modal-title">Add Game</h5>
+                    <button type="button" id="backBtn" class="btn btn-link text-white p-0 me-2 d-none"><i class="bi bi-arrow-left"></i></button>
+                    <h5 class="modal-title flex-grow-1">Add Game</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
+                    <div id="gameInfoStep">
                     <div class="mb-3">
                         <label class="form-label">League</label>
                         <select id="leagueSelect" class="form-select glass-control"></select>
@@ -127,13 +129,6 @@
                             <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
                         </div>
                     </div>
-                    <div id="comparisonContainer" class="mb-3" style="display:none;">
-                        <p id="comparisonPrompt" class="mb-2 fw-bold"></p>
-                        <div id="comparisonButtons" class="d-flex justify-content-around">
-                            <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
-                            <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
-                        </div>
-                    </div>
                     <div class="mb-3">
                         <label class="form-label">Photo</label>
                         <input type="file" name="photo" class="form-control glass-control">
@@ -144,6 +139,20 @@
                             <small id="commentCounter">0/100</small>
                         </label>
                         <textarea id="commentInput" class="form-control glass-control" name="comment" rows="3" maxlength="100"></textarea>
+                    </div>
+                    </div> <!-- gameInfoStep -->
+                    <div id="eloStep" style="display:none;">
+                        <div id="eloMatchup" class="mb-3">
+                            <div class="d-flex justify-content-between mb-3">
+                                <div id="newGameCard" class="elo-game-card flex-fill me-2"></div>
+                                <div id="existingGameCard" class="elo-game-card flex-fill ms-2"></div>
+                            </div>
+                            <p id="comparisonPrompt" class="mb-2 fw-bold text-center"></p>
+                            <div id="comparisonButtons" class="d-flex justify-content-around">
+                                <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
+                                <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer border-0">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -354,10 +354,12 @@
             <div class="modal-content p-3">
                 <form action="/profile/games" method="post" enctype="multipart/form-data">
                     <div class="modal-header border-0">
-                        <h5 class="modal-title">Add Game</h5>
+                        <button type="button" id="backBtn" class="btn btn-link text-white p-0 me-2 d-none"><i class="bi bi-arrow-left"></i></button>
+                        <h5 class="modal-title flex-grow-1">Add Game</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
+                        <div id="gameInfoStep">
                         <div class="mb-3">
                             <label class="form-label">Season</label>
                             <select id="seasonSelect" class="form-select glass-control"></select>
@@ -380,13 +382,6 @@
                                 <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
                             </div>
                         </div>
-                        <div id="comparisonContainer" class="mb-3" style="display:none;">
-                            <p id="comparisonPrompt" class="mb-2 fw-bold"></p>
-                            <div id="comparisonButtons" class="d-flex justify-content-around">
-                                <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
-                                <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
-                            </div>
-                        </div>
                         <div class="mb-3">
                             <label class="form-label">Photo</label>
                             <input type="file" name="photo" class="form-control glass-control">
@@ -397,6 +392,20 @@
                         </div>
                         <input type="hidden" name="teamsList" id="teamsListInput">
                         <input type="hidden" name="venuesList" id="venuesListInput">
+                        </div>
+                        <div id="eloStep" style="display:none;">
+                            <div id="eloMatchup" class="mb-3">
+                                <div class="d-flex justify-content-between mb-3">
+                                    <div id="newGameCard" class="elo-game-card flex-fill me-2"></div>
+                                    <div id="existingGameCard" class="elo-game-card flex-fill ms-2"></div>
+                                </div>
+                                <p id="comparisonPrompt" class="mb-2 fw-bold text-center"></p>
+                                <div id="comparisonButtons" class="d-flex justify-content-around">
+                                    <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
+                                    <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="modal-footer border-0">
                         <button type="button" id="nextBtn" class="btn btn-primary">Next</button>
@@ -417,6 +426,7 @@
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
         window.gameEntryCount = <%- (user.gameEntries || []).length %>;
         window.gameEntryNames = <%- JSON.stringify((gameEntries || []).map(function(e){ var g=e.game||{}; return (g.awayTeamName || '') + ' vs ' + (g.homeTeamName || ''); })) %>;
+        window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>

--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -41,6 +41,7 @@
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
         window.gameEntryCount = <%- (user.gameEntries || []).length %>;
+        window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -215,6 +215,7 @@
             return `${g.awayTeamName || ''} vs ${g.homeTeamName || ''}`;
         })) %>;
         window.gameEntriesData = <%- JSON.stringify(gameEntries || []) %>;
+        window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script src="/js/editGameModal.js"></script>

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -657,6 +657,7 @@ document.addEventListener('DOMContentLoaded', renderStats);
             const g = e.game || {};
             return `${g.awayTeamName || ''} vs ${g.homeTeamName || ''}`;
         })) %>;
+        window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -88,6 +88,7 @@
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.game))) %>;
         window.gameEntryCount = <%- (user.gameEntries || []).length %>;
+        window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- expand +Game modal to have multi-step flow for ELO matchups
- add enriched ELO game data to profile pages
- expose past game date and scores in search API
- style ELO matchup cards
- update frontend logic for ranking comparisons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887f01817048326814cafd0d998a976