### PR TITLE
Make ELO matchup cards clickable

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -962,12 +962,17 @@
 
 /* ELO matchup cards */
 .elo-game-card{
-  border:1px solid #fff;
+  border:1px solid rgba(255,255,255,0.8);
   border-radius:.5rem;
   padding:.5rem;
   background:rgba(255,255,255,0.15);
   backdrop-filter:blur(8px);
   color:#fff;
+  cursor:pointer;
+  transition:border-color .2s;
+}
+.elo-game-card:hover{
+  border-color:#fff;
 }
 .elo-game-grid{
   display:grid;

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -69,7 +69,6 @@
     function showComparison(){
       if(compareIdx >= eloGames.length){
         rankingDone = true;
-        $('#comparisonButtons').hide();
         $('#comparisonPrompt').text('Placement recorded');
         updateSubmitState();
         return;
@@ -119,7 +118,6 @@
     if(betterBtn){
       betterBtn.on('click', function(){
         rankingDone = true;
-        $('#comparisonButtons').hide();
         $('#comparisonPrompt').text('Placement recorded');
         updateSubmitState();
       });
@@ -128,6 +126,18 @@
       worseBtn.on('click', function(){
         compareIdx++;
         showComparison();
+      });
+    }
+
+    if(newCard){
+      newCard.on('click', function(){
+        if(betterBtn) betterBtn.trigger('click');
+      });
+    }
+
+    if(existingCard){
+      existingCard.on('click', function(){
+        if(worseBtn) worseBtn.trigger('click');
       });
     }
 
@@ -295,7 +305,6 @@
         eloStep.hide();
         infoStep.show();
         backBtn.addClass('d-none');
-        $('#comparisonButtons').show();
         $('#comparisonPrompt').text('');
       } else {
         if(ratingGroup) ratingGroup.show();

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -148,7 +148,7 @@
                                 <div id="existingGameCard" class="elo-game-card flex-fill ms-2"></div>
                             </div>
                             <p id="comparisonPrompt" class="mb-2 fw-bold text-center"></p>
-                            <div id="comparisonButtons" class="d-flex justify-content-around">
+                            <div id="comparisonButtons" class="d-flex justify-content-around" style="display:none;">
                                 <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
                                 <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
                             </div>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -400,7 +400,7 @@
                                     <div id="existingGameCard" class="elo-game-card flex-fill ms-2"></div>
                                 </div>
                                 <p id="comparisonPrompt" class="mb-2 fw-bold text-center"></p>
-                                <div id="comparisonButtons" class="d-flex justify-content-around">
+                                <div id="comparisonButtons" class="d-flex justify-content-around" style="display:none;">
                                     <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
                                     <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
                                 </div>


### PR DESCRIPTION
## Summary
- hide comparison buttons and allow clicking on cards instead
- wire card clicks to existing comparison logic
- tweak ELO card CSS for pointer cursor and hover border

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887f664b87083269f3b12afeca35618