### PR TITLE
Replace manual rating with ELO

### DIFF
--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -147,10 +147,14 @@
                             </div>
                         </a>
                     </div>
-                    <% if(entry.rating){ %>
+                    <% const eloEntry = (eloGames || []).find(e => String(e.game && e.game._id) === String(game._id));
+                       if(eloEntry){
+                           const elo = eloEntry.elo || 1500;
+                           const rawScore = ((elo - 1000) / 800) * 9 + 1;
+                           const normalizedRating = Math.max(1.0, Math.min(10.0, Math.round(rawScore * 10) / 10)); %>
                         <div class="rating-wrapper gradient-overlay" data-entry-id="<%= entry._id %>">
                             <img class="bw-img" src="<%= game.venue && game.venue.imgUrl ? game.venue.imgUrl : '/images/placeholder.jpg' %>" alt="<%= game.Venue || game.venue %>">
-                            <span class="rating-number"><%= entry.rating %>/10</span>
+                            <span class="rating-number"><%= normalizedRating %>/10</span>
                             <% if(entry.comment){ %><span class="rating-comment"><%= entry.comment %></span><% } %>
                         </div>
                     <% } %>


### PR DESCRIPTION
## Summary
- show game ELO as 1-10 rating on profile games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887fcea60ec8326b1698a43b45562db