### PR TITLE
Fix ELO placement not persisting

### DIFF
--- a/lib/elo.js
+++ b/lib/elo.js
@@ -33,7 +33,7 @@ function ask(question) {
   return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
 }
 
-async function findEloPlacement(newGame, existingEloGames) {
+async function findEloPlacement(newGame, existingEloGames, user) {
   let left = 0;
   let right = existingEloGames.length - 1;
   while (left <= right) {
@@ -49,7 +49,16 @@ async function findEloPlacement(newGame, existingEloGames) {
       left = mid + 1;
     }
   }
-  return Math.round(newGame.elo);
+  const finalElo = Math.round(newGame.elo);
+  if (user && user.gameElo) {
+    const gameId = newGame.gameId || newGame._id;
+    user.gameElo.push({ game: gameId, elo: finalElo });
+    console.log(`Added ELO entry for game ${gameId}: ${finalElo}`);
+    if (typeof user.save === 'function') {
+      await user.save();
+    }
+  }
+  return finalElo;
 }
 
 module.exports = { initializeEloFromRatings, findEloPlacement };


### PR DESCRIPTION
## Summary
- extend `findEloPlacement` helper to update the user's `gameElo` array
- log which game and ELO value were added

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887ff4e07648326bf9eed47e3a2b697