### PR TITLE
Ensure ELO results persist

### DIFF
--- a/lib/elo.js
+++ b/lib/elo.js
@@ -53,13 +53,20 @@ async function findEloPlacement(newGame, existingEloGames, user) {
   }
   
   const finalElo = Math.round(newGame.elo || 1500);
-console.log(`Final ELO for new game: ${finalElo}`);
+  console.log(`Final ELO for new game: ${finalElo}`);
   if (user && user.gameElo) {
     const gameId = newGame.gameId || newGame._id;
+    if (!user.gameElo) user.gameElo = [];
     user.gameElo.push({ game: gameId, elo: finalElo });
-    console.log(`Added ELO entry for game ${gameId}: ${finalElo}`);
+    console.log("Saving new elo to user:", {
+      userId: user._id,
+      gameId: gameId,
+      elo: finalElo,
+      preSaveLength: user.gameElo.length
+    });
     if (typeof user.save === 'function') {
       await user.save();
+      console.log(`✅ Saved gameElo for game ${gameId}: ${finalElo}`);
     }
   }
   return finalElo;


### PR DESCRIPTION
## Summary
- log when saving ELO placement
- verify `user.save()` is awaited when pushing to `gameElo`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888075b58608326ae69c015866be6a6