### PR TITLE
Fix ID handling in ELO placement

### DIFF
--- a/lib/elo.js
+++ b/lib/elo.js
@@ -33,42 +33,79 @@ function ask(question) {
   return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
 }
 
+function extractGameId(obj) {
+  if (!obj) return null;
+  if (typeof obj === 'string' || typeof obj === 'number') return String(obj);
+  if (typeof obj === 'object') {
+    if (obj._id) return String(obj._id);
+    if (obj.game) return extractGameId(obj.game);
+    if (obj.gameId) return String(obj.gameId);
+  }
+  return null;
+}
+
 async function findEloPlacement(newGame, existingEloGames, user) {
+  const newGameId = extractGameId(newGame);
+  if (!newGameId) {
+    console.warn('[findEloPlacement] Unable to determine ID for new game.');
+    return;
+  }
+
+  const alreadyExists = existingEloGames.some(e => extractGameId(e) === newGameId);
+  if (alreadyExists) {
+    console.warn('[findEloPlacement] Game already in ELO list — skipping.', newGameId);
+    return;
+  }
 
   newGame.elo = 1500;
+
   let left = 0;
   let right = existingEloGames.length - 1;
-  while (left <= right) {
+  let iterations = 0;
+  const maxIterations = existingEloGames.length + 5;
+
+  while (left <= right && iterations < maxIterations) {
     const mid = Math.floor((left + right) / 2);
     const opponent = existingEloGames[mid];
-    const ans = await ask(`Which do you prefer? (n) ${newGame.gameId} or (o) ${opponent.gameId}? `);
+    const opponentId = extractGameId(opponent);
+    console.log(`[findEloPlacement] Compare new ${newGameId} with ${opponentId} at index ${mid}`);
+
+    const ans = await ask(`Which do you prefer? (n) ${newGameId} or (o) ${opponentId}? `);
     const prefersNew = ans.trim().toLowerCase().startsWith('n');
     const scoreNew = prefersNew ? 1 : 0;
+
     updateRatings(newGame, opponent, scoreNew);
+
     if (prefersNew) {
       right = mid - 1;
     } else {
       left = mid + 1;
     }
+    iterations++;
   }
-  
+
+  if (iterations >= maxIterations) {
+    console.warn('[findEloPlacement] Binary search exceeded safe iteration limit.');
+  }
+
   const finalElo = Math.round(newGame.elo || 1500);
-  console.log(`Final ELO for new game: ${finalElo}`);
+  console.log(`[findEloPlacement] Final ELO for new game ${newGameId}: ${finalElo}`);
+
   if (user && user.gameElo) {
-    const gameId = newGame.gameId || newGame._id;
     if (!user.gameElo) user.gameElo = [];
-    user.gameElo.push({ game: gameId, elo: finalElo });
-    console.log("Saving new elo to user:", {
+    user.gameElo.push({ game: newGameId, elo: finalElo });
+    console.log('[findEloPlacement] Saving new ELO to user:', {
       userId: user._id,
-      gameId: gameId,
+      gameId: newGameId,
       elo: finalElo,
       preSaveLength: user.gameElo.length
     });
     if (typeof user.save === 'function') {
       await user.save();
-      console.log(`✅ Saved gameElo for game ${gameId}: ${finalElo}`);
+      console.log(`✅ Saved gameElo for game ${newGameId}: ${finalElo}`);
     }
   }
+
   return finalElo;
 }
 


### PR DESCRIPTION
## Summary
- add `extractGameId` helper to normalize ids
- use the helper in `findEloPlacement` and add duplicate safeguard
- limit iterations in the binary search and log comparisons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68881bf5ef2c8326ada65a9d4420437f