### PR TITLE
Implement async game comparison flow

### DIFF
--- a/controllers/comparisonsController.js
+++ b/controllers/comparisonsController.js
@@ -1,0 +1,43 @@
+const Comparison = require('../models/Comparison');
+const PastGame = require('../models/PastGame');
+const User = require('../models/users');
+const { findEloPlacement } = require('../lib/elo');
+
+exports.nextComparison = async (req, res, next) => {
+  try {
+    const comp = await Comparison.findOne({ userId: req.user.id, resolved: false }).sort({ createdAt: 1 });
+    if (!comp) return res.json(null);
+    const newGame = await PastGame.findById(comp.newGameId).lean();
+    const existingGame = await PastGame.findById(comp.existingGameId).lean();
+    res.json({
+      comparisonId: comp._id,
+      indexLeft: comp.indexLeft,
+      indexRight: comp.indexRight,
+      indexMid: comp.indexMid,
+      newGame,
+      existingGame
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.submitComparison = async (req, res, next) => {
+  try {
+    const { comparisonId, winner } = req.body;
+    const comp = await Comparison.findById(comparisonId);
+    if (!comp || String(comp.userId) !== String(req.user.id)) {
+      return res.status(404).json({ error: 'Comparison not found' });
+    }
+    comp.winner = winner;
+    comp.resolved = true;
+    await comp.save();
+
+    const user = await User.findById(req.user.id);
+    await findEloPlacement(comp.newGameId, user);
+
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/lib/elo.js
+++ b/lib/elo.js
@@ -1,4 +1,4 @@
-const readline = require('readline');
+const Comparison = require('../models/Comparison');
 
 const K = 32;
 
@@ -28,10 +28,7 @@ function initializeEloFromRatings(ratedGames) {
   return games.map(g => ({ gameId: g.gameId, elo: Math.round(g.elo) }));
 }
 
-function ask(question) {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
-}
+
 
 function extractGameId(obj) {
   if (!obj) return null;
@@ -44,75 +41,49 @@ function extractGameId(obj) {
   return null;
 }
 
-async function findEloPlacement(newGame, existingEloGames, user) {
-  const newGameId = extractGameId(newGame);
-  if (!newGameId) {
-    console.warn('[findEloPlacement] Unable to determine ID for new game.');
-    return;
+async function applyComparisons(user, newGameId) {
+  const comparisons = await Comparison.find({ userId: user._id, newGameId, resolved: true }).sort({ createdAt: 1 }).lean();
+  const eloGames = (user.gameElo || []).map(e => ({ ...e }));
+  const newGame = { elo: 1500 };
+  let left = 0;
+  let right = eloGames.length - 1;
+  for (const c of comparisons) {
+    const opponent = eloGames[c.indexMid];
+    if (!opponent) continue;
+    const scoreNew = c.winner === 'new' ? 1 : 0;
+    updateRatings(newGame, opponent, scoreNew);
+    if (c.winner === 'new') right = c.indexMid - 1; else left = c.indexMid + 1;
   }
+  return { eloGames, newGame, left, right };
+}
 
-  const alreadyExists = existingEloGames.some(e => extractGameId(e) === newGameId);
+async function findEloPlacement(newGameId, user) {
+  const { eloGames, newGame, left, right } = await applyComparisons(user, newGameId);
+
+  const alreadyExists = eloGames.some(e => extractGameId(e.game || e) === String(newGameId));
   if (alreadyExists) {
     console.warn('[findEloPlacement] Game already in ELO list — skipping.', newGameId);
     return;
   }
 
-  newGame.elo = 1500;
-
-  let left = 0;
-  let right = existingEloGames.length - 1;
-  let iterations = 0;
-  const maxIterations = existingEloGames.length + 5;
-
-  while (left <= right && iterations < maxIterations) {
+  if (left <= right) {
     const mid = Math.floor((left + right) / 2);
-    const opponent = existingEloGames[mid];
-    const opponentId = extractGameId(opponent);
-    console.log(`[findEloPlacement] iteration ${iterations} - left:${left}, right:${right}, mid:${mid} (${opponentId})`);
-
-    const ans = await ask(`Which do you prefer? (n) ${newGameId} or (o) ${opponentId}? `);
-    const prefersNew = ans.trim().toLowerCase().startsWith('n');
-    const scoreNew = prefersNew ? 1 : 0;
-
-    updateRatings(newGame, opponent, scoreNew);
-
-    if (prefersNew) {
-      // new game ranks higher, search upper half
-      right = mid - 1;
-    } else {
-      // new game ranks lower, search lower half
-      left = mid + 1;
-    }
-    iterations++;
-  }
-
-  if (iterations >= maxIterations) {
-    console.warn('[findEloPlacement] Binary search exceeded safe iteration limit.');
-  }
-
-  let finalElo = Math.round(newGame.elo || 1500);
-  if (iterations === 0) {
-    console.warn('[findEloPlacement] No comparisons performed, using default ELO');
-    finalElo = 1500;
-  }
-  console.log(`[findEloPlacement] Final ELO for new game ${newGameId}: ${finalElo}`);
-
-  if (user && user.gameElo) {
-    if (!user.gameElo) user.gameElo = [];
-    user.gameElo.push({ game: newGameId, elo: finalElo });
-    console.log('[findEloPlacement] Saving new ELO to user:', {
+    const opponentId = extractGameId(eloGames[mid]);
+    await Comparison.create({
       userId: user._id,
-      gameId: newGameId,
-      elo: finalElo,
-      preSaveLength: user.gameElo.length
+      newGameId,
+      existingGameId: opponentId,
+      indexLeft: left,
+      indexRight: right,
+      indexMid: mid
     });
-    if (typeof user.save === 'function') {
-      await user.save();
-      console.log(`✅ Saved gameElo for game ${newGameId}: ${finalElo}`);
-    }
+    return;
   }
 
-  return finalElo;
+  user.gameElo = eloGames;
+  user.gameElo.push({ game: newGameId, elo: Math.round(newGame.elo) });
+  await user.save();
+  return Math.round(newGame.elo);
 }
 
 module.exports = { initializeEloFromRatings, findEloPlacement };

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const express = require("express"),
     profileController = require("./controllers/profileController"),
     projectsController = require("./controllers/projectsController"),
     gamesController = require("./controllers/gamesController"),
+    comparisonsController = require('./controllers/comparisonsController'),
     venuesController = require('./controllers/venuesController'),
     messagesController = require('./controllers/messagesController'),
     Message = require('./models/Message'),
@@ -169,6 +170,10 @@ app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);
 app.post('/games/:id/list', requireAuth, gamesController.toggleGameList);
 app.post('/teams/:id/list', requireAuth, gamesController.toggleTeamList);
 app.post('/venues/:id/list', requireAuth, gamesController.toggleVenueList);
+
+app.get('/nextComparison', requireAuth, comparisonsController.nextComparison);
+app.post('/submitComparison', requireAuth, comparisonsController.submitComparison);
+app.get('/compare', requireAuth, (req, res) => res.render('compare'));
 
 app.get('/venues', venuesController.listVenues);
 

--- a/models/Comparison.js
+++ b/models/Comparison.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const comparisonSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  newGameId: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame', required: true },
+  existingGameId: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame', required: true },
+  indexLeft: Number,
+  indexRight: Number,
+  indexMid: Number,
+  resolved: { type: Boolean, default: false },
+  winner: { type: String, enum: ['new', 'existing'] }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Comparison', comparisonSchema);

--- a/views/compare.ejs
+++ b/views/compare.ejs
@@ -1,0 +1,43 @@
+<%- include('partials/header') %>
+<div class="container mt-5" id="comparison-container">
+  <div id="games" class="d-flex justify-content-around"></div>
+  <div class="text-center mt-3" id="actions" style="display:none;">
+    <button id="leftBtn" class="btn btn-primary me-2">Left is better</button>
+    <button id="rightBtn" class="btn btn-primary">Right is better</button>
+  </div>
+</div>
+<script>
+async function loadComparison(){
+  const res = await fetch('/nextComparison');
+  const data = await res.json();
+  const gamesDiv = document.getElementById('games');
+  const actions = document.getElementById('actions');
+  gamesDiv.innerHTML = '';
+  if(!data){
+    gamesDiv.innerHTML = '<p>No comparisons pending</p>';
+    actions.style.display='none';
+    return;
+  }
+  window.currentComparisonId = data.comparisonId;
+  const left = data.newGame;
+  const right = data.existingGame;
+  gamesDiv.innerHTML = `
+    <div class="text-center">
+      <h5>New Game</h5>
+      <p>${left.HomeTeam} vs ${left.AwayTeam}</p>
+    </div>
+    <div class="text-center">
+      <h5>Existing Game</h5>
+      <p>${right.HomeTeam} vs ${right.AwayTeam}</p>
+    </div>
+  `;
+  actions.style.display='block';
+}
+async function sendResult(winner){
+  await fetch('/submitComparison',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({comparisonId:window.currentComparisonId,winner})});
+  loadComparison();
+}
+ document.getElementById('leftBtn').onclick=()=>sendResult('new');
+ document.getElementById('rightBtn').onclick=()=>sendResult('existing');
+ loadComparison();
+</script>


### PR DESCRIPTION
## Summary
- add Mongoose model for ongoing comparisons
- rework Elo logic to create & resume comparisons asynchronously
- add controller and routes to fetch/submit comparisons
- provide simple comparison page in the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890c6de04c832681ae87ec1712370e