### PR TITLE
Add async Elo comparison workflow

### DIFF
--- a/controllers/comparisonController.js
+++ b/controllers/comparisonController.js
@@ -1,0 +1,53 @@
+const Comparison = require('../models/Comparison');
+const Game = require('../models/PastGame');
+const User = require('../models/users');
+const { findEloPlacement, extractGameId } = require('../lib/elo');
+
+module.exports.getNext = async function(req, res, next){
+  try {
+    const cmp = await Comparison.findOne({ userId: req.user.id, resolved: false }).sort({ _id: 1 });
+    if(!cmp) return res.json(null);
+    const newGame = await Game.findById(cmp.newGameId);
+    const existingGame = await Game.findById(cmp.existingGameId);
+    res.json({
+      _id: cmp._id,
+      indexLeft: cmp.indexLeft,
+      indexRight: cmp.indexRight,
+      indexMid: cmp.indexMid,
+      newGame,
+      existingGame
+    });
+  } catch(err){
+    next(err);
+  }
+};
+
+module.exports.submit = async function(req, res, next){
+  try {
+    const { comparisonId, winner } = req.body;
+    const cmp = await Comparison.findById(comparisonId);
+    if(!cmp) return res.status(404).json({ error: 'Comparison not found' });
+    if(String(cmp.userId) !== String(req.user.id)) return res.status(403).json({ error:'Forbidden' });
+
+    cmp.winner = winner;
+    cmp.resolved = true;
+    await cmp.save();
+
+    const user = await User.findById(req.user.id);
+    const newEntry = user.gameElo.find(e => String(extractGameId(e.game)) === String(cmp.newGameId));
+    if(!newEntry) {
+      user.gameElo.push({ game: cmp.newGameId, elo: 1500, finalized:false, comparisonHistory:[] });
+    }
+
+    await findEloPlacement(newEntry || {gameId: cmp.newGameId, elo: 1500}, user.gameElo, user, {
+      indexLeft: cmp.indexLeft,
+      indexRight: cmp.indexRight,
+      indexMid: cmp.indexMid,
+      winner
+    });
+
+    res.json({ success: true });
+  } catch(err){
+    next(err);
+  }
+};

--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -757,14 +757,13 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
             user.gameElo = [...(user.gameElo || []), newElo];
             console.log('[ELO INIT] Scaled entry added:', newElo);
           } else {
-            const enrichedEloGames = await enrichEloGames(user.gameElo || []);
             const newGame = { gameId: gameId, elo: 1500 };
             console.log('[ELO] Calling findEloPlacement() for game:', gameId);
 
             const existing = user.gameElo.find(g => String(g.game) === String(gameId));
             if (existing?.finalized) return;
 
-            await findEloPlacement(newGame, enrichedEloGames, user);
+            await findEloPlacement(newGame, user.gameElo || [], user);
             console.log('[ELO] findEloPlacement complete');
         }
 

--- a/lib/elo.js
+++ b/lib/elo.js
@@ -1,4 +1,5 @@
 const readline = require('readline');
+const Comparison = require('../models/Comparison');
 
 const K = 32;
 
@@ -87,119 +88,85 @@ function extractGameId(obj) {
 }
 
 
-async function findEloPlacement(newGame, existingEloGames, user) {
+async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
   const newGameId = extractGameId(newGame);
   if (!newGameId) {
     console.warn('[findEloPlacement] Unable to determine ID for new game.');
     return;
   }
 
-  const alreadyExists = user.gameElo?.some(e => String(extractGameId(e)) === String(newGameId));
+  if (!newGame.elo) newGame.elo = 1500;
 
-  if (alreadyExists) {
-    console.warn('[findEloPlacement] Game already in ELO list — skipping.', newGameId);
-    return;
+  // ensure entry exists on user
+  if (!user.gameElo) user.gameElo = [];
+  let userEntry = user.gameElo.find(e => String(extractGameId(e.game)) === String(newGameId));
+  if (!userEntry) {
+    userEntry = { game: newGameId, elo: newGame.elo, comparisonHistory: [], finalized: false, updatedAt: new Date() };
+    user.gameElo.push(userEntry);
+  } else {
+    userEntry.elo = newGame.elo;
+    userEntry.finalized = false;
+    userEntry.updatedAt = new Date();
   }
 
-  newGame.elo = 1500;
+  let left = state.indexLeft ?? 0;
+  let right = state.indexRight ?? (existingEloGames.length - 1);
+  const prevMid = state.indexMid;
+  const winner = state.winner;
 
-  let left = 0;
-  let right = existingEloGames.length - 1;
-  let iterations = 0;
-  const maxIterations = existingEloGames.length + 5;
   existingEloGames = existingEloGames.filter(g => extractGameId(g) !== newGameId);
 
-  let prevMid = -1; // Prevent repeating same mid
+  if (prevMid !== undefined && winner) {
+    const opponent = existingEloGames[prevMid];
+    if (opponent) {
+      updateRatings(newGame, opponent, winner === 'new' ? 1 : 0);
+      const oppId = extractGameId(opponent);
+      if (!newGame.comparisonHistory) newGame.comparisonHistory = [];
+      newGame.comparisonHistory.push({ againstGame: oppId, preferred: winner === 'new', timestamp: new Date() });
 
-while (left <= right && iterations < maxIterations) {
-  const mid = Math.floor((left + right) / 2);
+      const oppEntry = user.gameElo.find(e => String(extractGameId(e.game)) === String(oppId));
+      if (oppEntry) {
+        oppEntry.elo = opponent.elo;
+        oppEntry.updatedAt = new Date();
+      }
 
-  // Prevent infinite loop by breaking if we're stuck
-  if (mid === prevMid) {
-    console.warn(`[findEloPlacement] Stuck at same midpoint ${mid}, breaking to avoid infinite loop.`);
-    break;
+      if (winner === 'new') right = prevMid - 1; else left = prevMid + 1;
+    }
   }
 
-  const opponent = existingEloGames[mid];
-  const opponentId = extractGameId(opponent);
-
-  console.log(`[findEloPlacement] iteration ${iterations} - left:${left}, right:${right}, mid:${mid} (${opponentId})`);
-
-  const ans = await ask(`Which do you prefer? (n) ${newGameId} or (o) ${opponentId}? `);
-  console.log('→ Received answer from prompt:', ans);
-  const prefersNew = ans.trim().toLowerCase().startsWith('n');
-  const scoreNew = prefersNew ? 1 : 0;
-
-  updateRatings(newGame, opponent, scoreNew);
-
-  if (!newGame.comparisonHistory) newGame.comparisonHistory = [];
-  newGame.comparisonHistory.push({
-    againstGame: opponentId,
-    preferred: prefersNew,
-    timestamp: new Date()
-  });
-
-  prevMid = mid;
-
-  if (prefersNew) {
-    right = mid - 1;
-  } else {
-    left = mid + 1;
-  }
-
-  iterations++;
-}
-  
-  
-
-  if (iterations >= maxIterations) {
-    console.warn('[findEloPlacement] Binary search exceeded safe iteration limit.');
-  }
-
-  let finalElo = Math.round(newGame.elo || 1500);
-  if (iterations === 0) {
-    console.warn('[findEloPlacement] No comparisons performed, using default ELO');
-    finalElo = 1500;
-  }
-  console.log(`[findEloPlacement] Final ELO for new game ${newGameId}: ${finalElo}`);
-
-  newGame.elo = Math.round(newGame.elo || 1500);
-newGame.finalized = true;
-newGame.updatedAt = new Date();
-
-if (iterations === 0) {
-  console.warn('[findEloPlacement] No comparisons performed, using default ELO');
-  newGame.elo = 1500;
-}
-
-console.log(`[findEloPlacement] Final ELO for new game ${newGameId}: ${newGame.elo}`);
-
-// Push enriched game object instead of just ID/ELO pair
-if (user) {
-  if (!user.gameElo) user.gameElo = [];
-  user.gameElo.push({
-    game: newGameId,
-    elo: newGame.elo,
-    comparisonHistory: newGame.comparisonHistory || [],
-    finalized: true,
-    updatedAt: new Date()
-  });
-
-  console.log('[findEloPlacement] Saving new ELO to user:', {
-    userId: user._id,
-    gameId: newGameId,
-    elo: newGame.elo,
-    preSaveLength: user.gameElo.length
-  });
-
-  if (typeof user.save === 'function') {
+  if (left > right) {
+    newGame.finalized = true;
+    userEntry.elo = newGame.elo;
+    userEntry.comparisonHistory = newGame.comparisonHistory || [];
+    userEntry.finalized = true;
+    userEntry.updatedAt = new Date();
     await user.save();
-    console.log(`✅ Saved gameElo for game ${newGameId}: ${newGame.elo}`);
+    return newGame.elo;
   }
+
+  const mid = Math.floor((left + right) / 2);
+  const opponent = existingEloGames[mid];
+  if (!opponent) {
+    newGame.finalized = true;
+    userEntry.finalized = true;
+    userEntry.updatedAt = new Date();
+    await user.save();
+    return newGame.elo;
+  }
+
+  await Comparison.create({
+    userId: user._id,
+    newGameId: newGameId,
+    existingGameId: extractGameId(opponent),
+    indexLeft: left,
+    indexRight: right,
+    indexMid: mid,
+    resolved: false
+  });
+
+  userEntry.elo = newGame.elo;
+  await user.save();
+  return null;
 }
 
-
-  return finalElo;
-}
-
-module.exports = { initializeEloFromRatings, findEloPlacement };
+module.exports = { initializeEloFromRatings, findEloPlacement, updateRatings, extractGameId };

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const express = require("express"),
     gamesController = require("./controllers/gamesController"),
     venuesController = require('./controllers/venuesController'),
     messagesController = require('./controllers/messagesController'),
+    comparisonController = require('./controllers/comparisonController'),
     Message = require('./models/Message'),
     User = require('./models/users'),
     layouts = require('express-ejs-layouts'),
@@ -171,6 +172,10 @@ app.post('/teams/:id/list', requireAuth, gamesController.toggleTeamList);
 app.post('/venues/:id/list', requireAuth, gamesController.toggleVenueList);
 
 app.get('/venues', venuesController.listVenues);
+
+app.get('/compare', requireAuth, (req,res)=>{ res.render('compare'); });
+app.get('/nextComparison', requireAuth, comparisonController.getNext);
+app.post('/submitComparison', requireAuth, comparisonController.submit);
 
 
 app.use(homeController.logRequestPaths);

--- a/models/Comparison.js
+++ b/models/Comparison.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const comparisonSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  newGameId: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame', required: true },
+  existingGameId: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame', required: true },
+  indexLeft: Number,
+  indexRight: Number,
+  indexMid: Number,
+  resolved: { type: Boolean, default: false },
+  winner: { type: String, enum: ['new','existing'], default: undefined }
+});
+
+module.exports = mongoose.model('Comparison', comparisonSchema);

--- a/views/compare.ejs
+++ b/views/compare.ejs
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Game Comparison</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div id="comparison" class="text-center"></div>
+  <script>
+    async function load(){
+      const res = await fetch('/nextComparison');
+      const data = await res.json();
+      const container = document.getElementById('comparison');
+      if(!data){
+        container.innerHTML = '<p>No comparisons pending</p>';
+        return;
+      }
+      container.innerHTML = `
+        <div class="row">
+          <div class="col-6">
+            <h3>${data.newGame.homeTeamName || ''} vs ${data.newGame.awayTeamName || ''}</h3>
+            <img src="${data.newGame.thumbnail || ''}" class="img-fluid"/>
+            <button class="btn btn-primary mt-2" onclick="vote('${data._id}','new')">Left is better</button>
+          </div>
+          <div class="col-6">
+            <h3>${data.existingGame.homeTeamName || ''} vs ${data.existingGame.awayTeamName || ''}</h3>
+            <img src="${data.existingGame.thumbnail || ''}" class="img-fluid"/>
+            <button class="btn btn-primary mt-2" onclick="vote('${data._id}','existing')">Right is better</button>
+          </div>
+        </div>
+      `;
+    }
+    async function vote(id,winner){
+      await fetch('/submitComparison',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({comparisonId:id,winner})});
+      load();
+    }
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store comparison decisions in new `Comparison` model
- overhaul `findEloPlacement` for async step-based comparisons
- add controller and routes to fetch and submit comparisons
- create `/compare` page for resolving comparisons on the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890fd664108326a3979644676bcf72