### PR TITLE
Fix ELO persistence logic

### DIFF
--- a/controllers/comparisonController.js
+++ b/controllers/comparisonController.js
@@ -38,8 +38,8 @@ module.exports.submit = async function(req, res, next){
 
     let newEntry = user.gameElo.find(e => String(extractGameId(e.game)) === String(cmp.newGameId));
     if (!newEntry) {
-      newEntry = { game: cmp.newGameId, elo: 1500, finalized: false, comparisonHistory: [] };
-      user.gameElo.push(newEntry);
+      user.gameElo.push({ game: cmp.newGameId, elo: 1500, finalized: false, comparisonHistory: [] });
+      newEntry = user.gameElo[user.gameElo.length - 1];
     }
 
     const updatedEntry = await findEloPlacement(newEntry, user.gameElo, user, {

--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -757,13 +757,17 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
             user.gameElo = [...(user.gameElo || []), newElo];
             console.log('[ELO INIT] Scaled entry added:', newElo);
           } else {
-            const newGame = { gameId: gameId, elo: 1500 };
             console.log('[ELO] Calling findEloPlacement() for game:', gameId);
 
-            const existing = user.gameElo.find(g => String(g.game) === String(gameId));
-            if (existing?.finalized) return;
+            let eloEntry = user.gameElo.find(g => String(g.game) === String(gameId));
+            if (eloEntry?.finalized) return;
 
-            await findEloPlacement(newGame, user.gameElo || [], user);
+            if (!eloEntry) {
+              user.gameElo.push({ game: new mongoose.Types.ObjectId(gameId), elo: 1500, finalized: false, comparisonHistory: [] });
+              eloEntry = user.gameElo[user.gameElo.length - 1];
+            }
+
+            await findEloPlacement(eloEntry, user.gameElo || [], user);
             console.log('[ELO] findEloPlacement complete');
         }
 

--- a/lib/elo.js
+++ b/lib/elo.js
@@ -103,11 +103,12 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
   if (!userEntry) {
     userEntry = { game: newGameId, elo: newGame.elo, comparisonHistory: [], finalized: false, updatedAt: new Date() };
     user.gameElo.push(userEntry);
-  } else {
-    userEntry.elo = newGame.elo;
-    userEntry.finalized = false;
-    userEntry.updatedAt = new Date();
   }
+
+  // operate directly on the stored subdocument
+  newGame = userEntry;
+  userEntry.finalized = false;
+  userEntry.updatedAt = new Date();
 
   let left = state.indexLeft ?? 0;
   let right = state.indexRight ?? (existingEloGames.length - 1);
@@ -136,7 +137,6 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
 
   if (left > right) {
     newGame.finalized = true;
-    userEntry.elo = newGame.elo;
     userEntry.comparisonHistory = newGame.comparisonHistory || [];
     userEntry.finalized = true;
     userEntry.updatedAt = new Date();
@@ -163,8 +163,6 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
     indexMid: mid,
     resolved: false
   });
-
-  userEntry.elo = newGame.elo;
   await user.save();
   return null;
 }


### PR DESCRIPTION
## Summary
- ensure the actual gameElo subdocument is used when processing comparisons
- update findEloPlacement to operate on the stored subdocument without resetting ELO values
- persist new ELO values when adding new games through the profile controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68891c491f2483269bc8da821aeb3ebb