### PR TITLE
Add debug logging for ELO placement

### DIFF
--- a/lib/elo.js
+++ b/lib/elo.js
@@ -120,8 +120,11 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
   if (prevMid !== undefined && winner) {
     const opponent = existingEloGames[prevMid];
     if (opponent) {
-      updateRatings(newGame, opponent, winner === 'new' ? 1 : 0);
       const oppId = extractGameId(opponent);
+      const preNew = newGame.elo;
+      const preOpp = opponent.elo;
+      updateRatings(newGame, opponent, winner === 'new' ? 1 : 0);
+      console.log(`[ELO] ${newGameId} vs ${oppId} winner:${winner} ${preNew}->${newGame.elo} ${preOpp}->${opponent.elo}`);
       if (!newGame.comparisonHistory) newGame.comparisonHistory = [];
       newGame.comparisonHistory.push({ againstGame: oppId, preferred: winner === 'new', timestamp: new Date() });
 
@@ -140,6 +143,7 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
     userEntry.comparisonHistory = newGame.comparisonHistory || [];
     userEntry.finalized = true;
     userEntry.updatedAt = new Date();
+    console.log(`[ELO] ${newGameId} finalized at ${newGame.elo}`);
     await user.save();
     return userEntry; // ✅ Return full elo object
   }
@@ -150,6 +154,7 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
     newGame.finalized = true;
     userEntry.finalized = true;
     userEntry.updatedAt = new Date();
+    console.log(`[ELO] ${newGameId} finalized at ${newGame.elo}`);
     await user.save();
     return userEntry; // ✅
   }
@@ -163,6 +168,7 @@ async function findEloPlacement(newGame, existingEloGames, user, state = {}) {
     indexMid: mid,
     resolved: false
   });
+  console.log(`[ELO] Next: ${newGameId} vs ${extractGameId(opponent)} (in progress)`);
   await user.save();
   return null;
 }


### PR DESCRIPTION
## Summary
- log comparison results in `findEloPlacement`
- indicate when a game is finalized or another comparison is queued

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688922666c3083269dba5c6070a0f3be