### PR TITLE
Refactor Elo placement

### DIFF
--- a/controllers/comparisonController.js
+++ b/controllers/comparisonController.js
@@ -1,7 +1,13 @@
 const Comparison = require('../models/Comparison');
+const GameComparison = require('../models/gameComparison');
 const Game = require('../models/PastGame');
 const User = require('../models/users');
-const { findEloPlacement, extractGameId } = require('../lib/elo');
+const {
+  findEloPlacement,
+  extractGameId,
+  getNextComparisonCandidate,
+  ratingToElo
+} = require('../lib/elo');
 
 module.exports.getNext = async function(req, res, next){
   try {
@@ -86,6 +92,101 @@ module.exports.submit = async function(req, res, next) {
     }
 
     res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// New Elo placement logic for games beyond the first 5
+module.exports.submitComparison = async function(req, res, next) {
+  try {
+    const { userId, newGameId, existingGameId, winner } = req.body;
+
+    if (String(req.user.id) !== String(userId)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    // Avoid duplicate comparison records
+    const existing = await GameComparison.findOne({
+      userId,
+      $or: [
+        { gameA: newGameId, gameB: existingGameId },
+        { gameA: existingGameId, gameB: newGameId }
+      ]
+    });
+
+    if (existing) {
+      if (!existing.winner) {
+        existing.winner = winner;
+        await existing.save();
+      }
+    } else {
+      await GameComparison.create({
+        userId,
+        gameA: newGameId,
+        gameB: existingGameId,
+        winner
+      });
+    }
+
+    const user = await User.findById(userId);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    let newEntry = user.gameElo.find(e => String(extractGameId(e.game)) === String(newGameId));
+    if (!newEntry) {
+      newEntry = { game: newGameId, elo: 1500, finalized: false, comparisonHistory: [] };
+      user.gameElo.push(newEntry);
+    }
+
+    // Determine current bounds based on all recorded comparisons for this game
+    let minElo = ratingToElo(1);
+    let maxElo = ratingToElo(10);
+
+    const comps = await GameComparison.find({
+      userId,
+      $or: [{ gameA: newGameId }, { gameB: newGameId }]
+    });
+
+    for (const cmp of comps) {
+      if (!cmp.winner) continue;
+      const opponentId = String(cmp.gameA) === String(newGameId) ? cmp.gameB : cmp.gameA;
+      const opp = user.gameElo.find(e => String(extractGameId(e.game)) === String(opponentId));
+      if (!opp) continue;
+      if (String(cmp.winner) === String(newGameId)) {
+        if (opp.elo + 1 > minElo) minElo = opp.elo + 1;
+      } else if (String(cmp.winner) === String(opponentId)) {
+        if (opp.elo - 1 < maxElo) maxElo = opp.elo - 1;
+      }
+    }
+
+    if (minElo > maxElo) {
+      const finalElo = Math.floor((minElo + maxElo) / 2);
+      newEntry.elo = finalElo;
+      newEntry.finalized = true;
+      newEntry.updatedAt = new Date();
+      await user.save();
+      return res.json({ finalized: true, elo: finalElo });
+    }
+
+    const candidate = getNextComparisonCandidate(user, newEntry, minElo, maxElo);
+    if (!candidate) {
+      const finalElo = Math.floor((minElo + maxElo) / 2);
+      newEntry.elo = finalElo;
+      newEntry.finalized = true;
+      newEntry.updatedAt = new Date();
+      await user.save();
+      return res.json({ finalized: true, elo: finalElo });
+    }
+
+    await user.save();
+    return res.json({
+      nextComparison: {
+        newGameId,
+        existingGameId: extractGameId(candidate.game),
+        minElo,
+        maxElo
+      }
+    });
   } catch (err) {
     next(err);
   }

--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -756,28 +756,13 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
             user.gameElo = [...(user.gameElo || []), newElo];
             console.log('[ELO INIT] Scaled entry added:', newElo);
           } else {
-            console.log('[ELO] Calling findEloPlacement() for game:', gameId);
+            console.log('[ELO] Starting placement for game:', gameId);
 
             let eloEntry = user.gameElo.find(g => String(g.game) === String(gameId));
-            if (eloEntry?.finalized) return;
-
             if (!eloEntry) {
               user.gameElo.push({ game: new mongoose.Types.ObjectId(gameId), elo: 1500, finalized: false, comparisonHistory: [] });
-              eloEntry = user.gameElo[user.gameElo.length - 1];
             }
-
-            const updatedEntry = await findEloPlacement(eloEntry, user.gameElo || [], user);
-if (updatedEntry) {
-  const idx = user.gameElo.findIndex(e => String(e.game) === String(gameId));
-  if (idx !== -1) {
-    user.gameElo[idx].elo = updatedEntry.elo;
-    user.gameElo[idx].finalized = updatedEntry.finalized || false;
-    user.gameElo[idx].comparisonHistory = updatedEntry.comparisonHistory || [];
-    user.gameElo[idx].updatedAt = new Date();
-    console.log('[ELO] Updated eloEntry to', updatedEntry.elo);
-  }
-}
-        }
+          }
 
         const pastGameDoc = await PastGame.findById(gameId);
 

--- a/lib/elo.js
+++ b/lib/elo.js
@@ -225,4 +225,42 @@ console.log('  otherGames.length:', otherGames?.length);
   };
 }
 
-module.exports = { initializeEloFromRatings, findEloPlacement, updateRatings, extractGameId };
+function ratingToElo(rating) {
+  const r = parseFloat(rating);
+  if (isNaN(r)) return 1500;
+  return 1000 + ((r - 1) / 9) * 1000;
+}
+
+function eloToRating(elo) {
+  return 1 + 9 * ((parseFloat(elo) - 1000) / 1000);
+}
+
+function getNextComparisonCandidate(user, newGame, minElo, maxElo) {
+  const midpoint = (minElo + maxElo) / 2;
+  let best = null;
+  let bestDiff = Infinity;
+  const newId = extractGameId(newGame.game || newGame);
+
+  (user.gameElo || []).forEach(g => {
+    const gid = extractGameId(g.game);
+    if (gid === newId || !g.finalized) return;
+    if (g.elo < minElo || g.elo > maxElo) return;
+    const diff = Math.abs(g.elo - midpoint);
+    if (diff < bestDiff) {
+      best = g;
+      bestDiff = diff;
+    }
+  });
+
+  return best;
+}
+
+module.exports = {
+  initializeEloFromRatings,
+  findEloPlacement,
+  updateRatings,
+  extractGameId,
+  ratingToElo,
+  eloToRating,
+  getNextComparisonCandidate
+};


### PR DESCRIPTION
## Summary
- overhaul Elo placement logic
- implement helper utilities for Elo ranges
- store comparison outcomes in `GameComparison`
- integrate new placement flow when adding games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a52fa61688326be1fb897504e500d