### PR TITLE
Fix Elo placement for games beyond first 5

### DIFF
--- a/lib/elo.js
+++ b/lib/elo.js
@@ -240,11 +240,15 @@ function getNextComparisonCandidate(user, newGame, minElo, maxElo) {
   let best = null;
   let bestDiff = Infinity;
   const newId = extractGameId(newGame.game || newGame);
+  const compared = new Set(
+    (newGame.comparisonHistory || []).map(h => String(extractGameId(h.againstGame)))
+  );
 
   (user.gameElo || []).forEach(g => {
     const gid = extractGameId(g.game);
     if (gid === newId || !g.finalized) return;
     if (g.elo < minElo || g.elo > maxElo) return;
+    if (compared.has(String(gid))) return;
     const diff = Math.abs(g.elo - midpoint);
     if (diff < bestDiff) {
       best = g;


### PR DESCRIPTION
## Summary
- rewrite `submitComparison` controller to narrow Elo bounds and finalize placement
- skip repeated comparisons in `getNextComparisonCandidate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a569986548326afcf4cd31f2b0a4a