### PR TITLE
Remove rating field from user game entries

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -21,7 +21,7 @@ const userSchema = new mongoose.Schema({
     venuesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Venue' }], default: [] },
     gameEntries: [{
         game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
-        rating: Number,
+        elo: Number,
         comment: String,
         image: String
     }],

--- a/public/js/editGameModal.js
+++ b/public/js/editGameModal.js
@@ -26,7 +26,11 @@
       const data = (window.gameEntriesData || []).find(e => e._id === id);
       if(!data) return;
       entryIdInput.value = id;
-      if(ratingRange){ ratingRange.value = data.rating || 5; updateRating(); }
+      if(ratingRange){
+        const r = data.elo ? ((data.elo - 1000) / 1000) * 9 + 1 : 5;
+        ratingRange.value = r;
+        updateRating();
+      }
       if(commentInput){ commentInput.value = data.comment || ''; commentCounter.textContent = `${(data.comment||'').length}/100`; }
       modal.show();
     };
@@ -42,7 +46,8 @@
         if(json && json.entry){
           const wrapper = document.querySelector(`.rating-wrapper[data-entry-id="${id}"]`);
           if(wrapper){
-            wrapper.querySelector('.rating-number').textContent = `${json.entry.rating}/10`;
+            const r = json.entry.elo ? ((json.entry.elo - 1000) / 1000) * 9 + 1 : 5;
+            wrapper.querySelector('.rating-number').textContent = `${r.toFixed(1)}/10`;
             const commentEl = wrapper.querySelector('.rating-comment');
             if(commentEl){ commentEl.textContent = json.entry.comment || ''; }
           }

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -260,9 +260,10 @@
                                     </div>
                                 </a>
                             </div>
-                            <% if(entry.rating){ %>
+                            <% const eloEntry = (eloGames || []).find(e => String(e.game && (e.game._id || e.game)) === String(game._id));
+                               if(eloEntry && typeof eloEntry.elo === 'number'){ const elo = eloEntry.elo; const raw = ((elo - 1000)/1000)*9 + 1; const rating = Math.max(1.0, Math.min(10.0, Math.round(raw*10)/10)); %>
                             <div class="rating-wrapper ms-md-4">
-                                <span class="rating-number"><%= entry.rating %>/10</span>
+                                <span class="rating-number"><%= rating %>/10</span>
                                 <% if(entry.comment){ %><span class="rating-comment"><%= entry.comment %></span><% } %>
                             </div>
                             <% } %>

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -535,7 +535,7 @@
             const gameDate = g.startDate || g.StartDate || null;
             const awayLogo = g.awayTeam && g.awayTeam.logos && g.awayTeam.logos[0] ? g.awayTeam.logos[0] : '/images/placeholder.jpg';
             const homeLogo = g.homeTeam && g.homeTeam.logos && g.homeTeam.logos[0] ? g.homeTeam.logos[0] : '/images/placeholder.jpg';
-            const rating = typeof e.rating === 'number' ? e.rating : 0;
+            const rating = e.elo ? ((e.elo - 1000) / 1000) * 9 + 1 : 0;
             return { _id: g._id, gameDate, awayTeamLogoUrl: awayLogo, homeTeamLogoUrl: homeLogo, rating };
         })
         .sort((a,b) => b.rating - a.rating);


### PR DESCRIPTION
## Summary
- drop rating from `gameEntries` schema and store Elo instead
- convert rating input to Elo when adding or editing a game entry
- update elo handling on delete and update flows
- refresh UI to calculate rating display from Elo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a741d598c832685795bea3163f81a