### PR TITLE
Remove placeholder Elo

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -720,7 +720,6 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
             if (!eloEntry) {
                 user.gameElo.push({
                   game: newGameObjectId,
-                  elo: 1500,
                   finalized: false,
                   comparisonHistory: [],
                   minElo: 1000,

--- a/lib/eloHelpers.js
+++ b/lib/eloHelpers.js
@@ -2,21 +2,21 @@
 function getEloBounds() {
     return { minElo: 1000, maxElo: 2000 };
   }
-  
+
   function sortGameEloByElo(gameElo) {
     return gameElo.filter(e => e.finalized).sort((a, b) => a.elo - b.elo);
   }
-  
+
   function getComparisonCandidate(gameElo, minElo, maxElo) {
     const finalized = sortGameEloByElo(gameElo);
     const midpoint = Math.floor((minElo + maxElo) / 2);
-  
+
     return finalized.reduce((closest, game) => {
       const dist = Math.abs(game.elo - midpoint);
       return !closest || dist < Math.abs(closest.elo - midpoint) ? game : closest;
     }, null);
   }
-  
+
   function updateEloBounds(result, comparisonGame, currentMin, currentMax) {
     const comparisonElo = comparisonGame.elo;
     if (result === 'new') {
@@ -25,11 +25,11 @@ function getEloBounds() {
       return { minElo: currentMin, maxElo: comparisonElo - 1 };
     }
   }
-  
+
   function calculateFinalElo(minElo, maxElo) {
     return Math.floor((minElo + maxElo) / 2);
   }
-  
+
   module.exports = {
     getEloBounds,
     sortGameEloByElo,
@@ -37,4 +37,4 @@ function getEloBounds() {
     updateEloBounds,
     calculateFinalElo
   };
-  
+

--- a/models/users.js
+++ b/models/users.js
@@ -46,13 +46,15 @@ const userSchema = new mongoose.Schema({
     gameElo: {
         type: [{
           game: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame' },
-          elo: { type: Number, default: 1500 },
+          elo: Number,
           comparisonHistory: [{
             againstGame: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame' },
             preferred: Boolean,
             timestamp: Date
           }],
           finalized: { type: Boolean, default: false },
+          minElo: { type: Number, default: 1000 },
+          maxElo: { type: Number, default: 2000 },
           updatedAt: { type: Date }
         }],
         default: []


### PR DESCRIPTION
## Summary
- track Elo ranges on the user model instead of storing a 1500 default
- drop default Elo assignment when creating gameElo entries
- clean up stray text in `eloHelpers`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7a54bea48326bdd5435e35ba10f7