### PR TITLE
Simplify Elo placement with single random comparison

### DIFF
--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -140,6 +140,8 @@
                         </label>
                         <textarea id="commentInput" class="form-control glass-control" name="comment" rows="3" maxlength="100"></textarea>
                     </div>
+                    <input type="hidden" name="compareGameId" id="compareGameId">
+                    <input type="hidden" name="winner" id="winnerInput">
                     </div> <!-- gameInfoStep -->
                     <div id="eloStep" style="display:none;">
                         <div id="eloMatchup" class="mb-3">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -391,6 +391,8 @@
                             <label class="form-label">Comment</label>
                             <textarea class="form-control glass-control" name="comment" rows="3"></textarea>
                         </div>
+                        <input type="hidden" name="compareGameId" id="compareGameId">
+                        <input type="hidden" name="winner" id="winnerInput">
                         <input type="hidden" name="teamsList" id="teamsListInput">
                         <input type="hidden" name="venuesList" id="venuesListInput">
                         </div>
@@ -400,6 +402,10 @@
                                 <div class="d-flex justify-content-between mb-3">
                                     <div id="newGameCard" class="elo-game-card flex-fill me-2"></div>
                                     <div id="existingGameCard" class="elo-game-card flex-fill ms-2"></div>
+                                </div>
+                                <div id="comparisonButtons" class="d-flex justify-content-around" style="display:none;">
+                                    <button type="button" id="betterBtn" class="btn btn-primary btn-sm">New Game</button>
+                                    <button type="button" id="worseBtn" class="btn btn-secondary btn-sm">Existing Game</button>
                                 </div>
                                 
                                 


### PR DESCRIPTION
## Summary
- implement single random game comparison when adding a new game
- store comparison result in GameComparison model and finalize elo immediately
- update add game modal to show one random matchup and capture winner
- include hidden fields for comparison ids in forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7d89559883268b806fd14853216e