### PR TITLE
Implement two-stage Elo comparison

### DIFF
--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -140,8 +140,10 @@
                         </label>
                         <textarea id="commentInput" class="form-control glass-control" name="comment" rows="3" maxlength="100"></textarea>
                     </div>
-                    <input type="hidden" name="compareGameId" id="compareGameId">
-                    <input type="hidden" name="winner" id="winnerInput">
+                    <input type="hidden" name="compareGameId1" id="compareGameId1">
+                    <input type="hidden" name="winner1" id="winnerInput1">
+                    <input type="hidden" name="compareGameId2" id="compareGameId2">
+                    <input type="hidden" name="winner2" id="winnerInput2">
                     </div> <!-- gameInfoStep -->
                     <div id="eloStep" style="display:none;">
                         <div id="eloMatchup" class="mb-3">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -391,8 +391,10 @@
                             <label class="form-label">Comment</label>
                             <textarea class="form-control glass-control" name="comment" rows="3"></textarea>
                         </div>
-                        <input type="hidden" name="compareGameId" id="compareGameId">
-                        <input type="hidden" name="winner" id="winnerInput">
+                        <input type="hidden" name="compareGameId1" id="compareGameId1">
+                        <input type="hidden" name="winner1" id="winnerInput1">
+                        <input type="hidden" name="compareGameId2" id="compareGameId2">
+                        <input type="hidden" name="winner2" id="winnerInput2">
                         <input type="hidden" name="teamsList" id="teamsListInput">
                         <input type="hidden" name="venuesList" id="venuesListInput">
                         </div>


### PR DESCRIPTION
## Summary
- extend `addGame` controller to accept two comparison results
- finalize the Elo for a new game after two comparisons
- update Add Game modal to collect two comparisons
- update modal JS logic for back-to-back comparisons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a841ebd448326825e813a1c9e1716