### PR TITLE
Add rating-based Elo initialization

### DIFF
--- a/lib/elo.js
+++ b/lib/elo.js
@@ -33,7 +33,7 @@ function initializeEloFromRatings(ratedGames) {
     console.log(`  ➤ Use formula:`, useFormula);
 
     const baseElo = useFormula
-      ? Math.round(1000 + ((rating - 1) / 9) * 1000)
+      ? Math.round(1000 + ((rating - 1) * 100 / 9))
       : 1500;
 
     console.log(`  ➤ Assigned ELO:`, baseElo);
@@ -146,11 +146,11 @@ module.exports = {
 function ratingToElo(rating) {
   const r = parseFloat(rating);
   if (isNaN(r)) return 1500;
-  return 1000 + ((r - 1) / 9) * 1000;
+  return Math.round(1000 + ((r - 1) * 100 / 9));
 }
 
 function eloToRating(elo) {
-  return 1 + 9 * ((parseFloat(elo) - 1000) / 1000);
+  return 1 + 9 * ((parseFloat(elo) - 1000) / 100);
 }
 
 function getNextComparisonCandidate(user, newGame, minElo, maxElo) {

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -27,6 +27,7 @@
     const winnerInput2 = $('#winnerInput2');
     const eloGames = window.eloGamesData || [];
     const finalizedGames = eloGames.filter(g => g.finalized);
+    const eloCount = eloGames.length;
     let randomGame1 = null;
     let randomGame2 = null;
     let comparisonStep = 0;
@@ -384,6 +385,15 @@
       winnerInput2.val('');
       compareGameInput1.val('');
       compareGameInput2.val('');
+      if(ratingGroup){
+        if(eloCount < 5){
+          ratingGroup.show();
+          ratingRange && ratingRange.setAttribute('required','');
+        } else {
+          ratingGroup.hide();
+          ratingRange && ratingRange.removeAttribute('required');
+        }
+      }
       if(finalizedGames.length){
         nextBtn.show();
         eloStep.hide();

--- a/public/js/editGameModal.js
+++ b/public/js/editGameModal.js
@@ -27,7 +27,7 @@
       if(!data) return;
       entryIdInput.value = id;
       if(ratingRange){
-        const r = data.elo ? ((data.elo - 1000) / 1000) * 9 + 1 : 5;
+        const r = data.elo ? ((data.elo - 1000) * 9 / 100) + 1 : 5;
         ratingRange.value = r;
         updateRating();
       }
@@ -46,7 +46,7 @@
         if(json && json.entry){
           const wrapper = document.querySelector(`.rating-wrapper[data-entry-id="${id}"]`);
           if(wrapper){
-            const r = json.entry.elo ? ((json.entry.elo - 1000) / 1000) * 9 + 1 : 5;
+            const r = json.entry.elo ? ((json.entry.elo - 1000) * 9 / 100) + 1 : 5;
             wrapper.querySelector('.rating-number').textContent = `${r.toFixed(1)}/10`;
             const commentEl = wrapper.querySelector('.rating-comment');
             if(commentEl){ commentEl.textContent = json.entry.comment || ''; }

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -261,7 +261,7 @@
                                 </a>
                             </div>
                             <% const eloEntry = (eloGames || []).find(e => String(e.game && (e.game._id || e.game)) === String(game._id));
-                               if(eloEntry && typeof eloEntry.elo === 'number'){ const elo = eloEntry.elo; const raw = ((elo - 1000)/1000)*9 + 1; const rating = Math.max(1.0, Math.min(10.0, Math.round(raw*10)/10)); %>
+                               if(eloEntry && typeof eloEntry.elo === 'number'){ const elo = eloEntry.elo; const rating = Math.round(((elo - 1000) * 9 / 100) + 1); %>
                             <div class="rating-wrapper ms-md-4">
                                 <span class="rating-number"><%= rating %>/10</span>
                                 <% if(entry.comment){ %><span class="rating-comment"><%= entry.comment %></span><% } %>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -158,8 +158,7 @@
 
   if (eloEntry && typeof eloEntry.elo === 'number') {
     const elo = eloEntry.elo;
-    const rawScore = ((elo - 1000) / 1000) * 9 + 1;
-    const normalizedRating = Math.max(1.0, Math.min(10.0, Math.round(rawScore * 10) / 10));
+    const normalizedRating = Math.round(((elo - 1000) * 9 / 100) + 1);
 %>
                         <div class="rating-wrapper gradient-overlay" data-entry-id="<%= entry._id %>">
                             <img class="bw-img" src="<%= game.venue && game.venue.imgUrl ? game.venue.imgUrl : '/images/placeholder.jpg' %>" alt="<%= game.Venue || game.venue %>">

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -535,7 +535,7 @@
             const gameDate = g.startDate || g.StartDate || null;
             const awayLogo = g.awayTeam && g.awayTeam.logos && g.awayTeam.logos[0] ? g.awayTeam.logos[0] : '/images/placeholder.jpg';
             const homeLogo = g.homeTeam && g.homeTeam.logos && g.homeTeam.logos[0] ? g.homeTeam.logos[0] : '/images/placeholder.jpg';
-            const rating = e.elo ? ((e.elo - 1000) / 1000) * 9 + 1 : 0;
+            const rating = e.elo ? Math.round(((e.elo - 1000) * 9 / 100) + 1) : 0;
             return { _id: g._id, gameDate, awayTeamLogoUrl: awayLogo, homeTeamLogoUrl: homeLogo, rating };
         })
         .sort((a,b) => b.rating - a.rating);


### PR DESCRIPTION
## Summary
- convert 1-10 ratings to Elo using new formula
- save initial 5 game entries with rating-based Elo
- hide rating slider when user has 5+ Elo entries
- update reverse conversion logic across client and views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a88a48e388326ba3a4988ab0908df