### PR TITLE
Implement third comparison stage

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -663,7 +663,7 @@ const { initializeEloFromRatings } = require('../lib/elo'); // or wherever it's 
 
 exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
     try {
-        const { gameId, rating, comment, compareGameId1, winner1, compareGameId2, winner2 } = req.body;
+        const { gameId, rating, comment, compareGameId1, winner1, compareGameId2, winner2, compareGameId3, winner3 } = req.body;
 
         const sanitizedComment = sanitizeComment(comment || '');
 
@@ -740,6 +740,21 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
                     minElo = comp2.elo;
                 } else {
                     maxElo = comp2.elo;
+                }
+            }
+
+            const comp3 = finalizedGames.find(g => String(g.game) === String(compareGameId3));
+            if (comp3 && (winner3 === 'new' || winner3 === 'existing')) {
+                await GameComparison.create({
+                    userId: user._id,
+                    gameA: newGameObjectId,
+                    gameB: comp3.game,
+                    winner: winner3 === 'new' ? newGameObjectId : comp3.game
+                });
+                if (winner3 === 'new') {
+                    minElo = comp3.elo;
+                } else {
+                    maxElo = comp3.elo;
                 }
             }
 

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -25,10 +25,13 @@
     const winnerInput1 = $('#winnerInput1');
     const compareGameInput2 = $('#compareGameId2');
     const winnerInput2 = $('#winnerInput2');
+    const compareGameInput3 = $('#compareGameId3');
+    const winnerInput3 = $('#winnerInput3');
     const eloGames = window.eloGamesData || [];
     const finalizedGames = eloGames.filter(g => g.finalized);
     let randomGame1 = null;
     let randomGame2 = null;
+    let randomGame3 = null;
     let comparisonStep = 0;
     let minRange = 1000;
     let maxRange = 2000;
@@ -75,15 +78,24 @@
       );
     }
 
-    function pickRandomGame(min,max,exclude){
+    function pickRandomGame(min, max, exclude) {
       exclude = exclude || [];
-      const eligible = finalizedGames.filter(g=>{
+      const eligible = finalizedGames.filter(g => {
         const id = String(g.game && g.game._id ? g.game._id : g.game);
         return g.elo >= min && g.elo <= max && !exclude.includes(id);
       });
-      if(!eligible.length) return null;
-      const idx = Math.floor(Math.random()*eligible.length);
-      return eligible[idx];
+      if (!eligible.length) return null;
+      const midpoint = Math.floor((min + max) / 2);
+      let closest = eligible[0];
+      let bestDist = Math.abs(closest.elo - midpoint);
+      for (let i = 1; i < eligible.length; i++) {
+        const dist = Math.abs(eligible[i].elo - midpoint);
+        if (dist < bestDist) {
+          closest = eligible[i];
+          bestDist = dist;
+        }
+      }
+      return closest;
     }
 
     function showComparison1(){
@@ -135,6 +147,32 @@
       comparisonStep = 2;
     }
 
+    function showComparison3(){
+      const exclude = [
+        String(randomGame1 && (randomGame1.game && randomGame1.game._id ? randomGame1.game._id : randomGame1.game)),
+        String(randomGame2 && (randomGame2.game && randomGame2.game._id ? randomGame2.game._id : randomGame2.game))
+      ];
+      randomGame3 = pickRandomGame(minRange, maxRange, exclude);
+      if(!randomGame3){
+        finalize();
+        return;
+      }
+      const comp = randomGame3.game || {};
+      compareGameInput3.val(comp._id ? comp._id : randomGame3.game);
+      const compData = {
+        awayLogo: comp.awayTeam && comp.awayTeam.logos && comp.awayTeam.logos[0],
+        homeLogo: comp.homeTeam && comp.homeTeam.logos && comp.homeTeam.logos[0],
+        awayPoints: comp.AwayPoints ?? comp.awayPoints,
+        homePoints: comp.HomePoints ?? comp.homePoints,
+        gameDate: comp.StartDate || comp.startDate
+      };
+      $('#comparisonPrompt').text('Which game is better?');
+      renderCard(newCard, selectedGameData);
+      renderCard(existingCard, compData);
+      $('#comparisonButtons').show();
+      comparisonStep = 3;
+    }
+
     if(nextBtn){
       nextBtn.on('click', function(){
         nextBtn.hide();
@@ -174,10 +212,13 @@
         comparisonStep = 0;
         randomGame1 = null;
         randomGame2 = null;
+        randomGame3 = null;
         winnerInput1.val('');
         winnerInput2.val('');
+        winnerInput3.val('');
         compareGameInput1.val('');
         compareGameInput2.val('');
+        compareGameInput3.val('');
         rankingDone = gameEntryCount < 5 ? true : finalizedGames.length === 0;
         $('#comparisonButtons').hide();
         $('#comparisonPrompt').text('');
@@ -200,6 +241,10 @@
       } else if(comparisonStep === 2){
         winnerInput2.val('new');
         minRange = randomGame2.elo;
+        showComparison3();
+      } else if(comparisonStep === 3){
+        winnerInput3.val('new');
+        minRange = randomGame3.elo;
         finalize();
       }
     });
@@ -212,6 +257,10 @@
       } else if(comparisonStep === 2){
         winnerInput2.val('existing');
         maxRange = randomGame2.elo;
+        showComparison3();
+      } else if(comparisonStep === 3){
+        winnerInput3.val('existing');
+        maxRange = randomGame3.elo;
         finalize();
       }
     });
@@ -387,11 +436,14 @@
       rankingDone = gameEntryCount < 5 ? true : finalizedGames.length === 0;
       randomGame1 = null;
       randomGame2 = null;
+      randomGame3 = null;
       comparisonStep = 0;
       winnerInput1.val('');
       winnerInput2.val('');
+      winnerInput3.val('');
       compareGameInput1.val('');
       compareGameInput2.val('');
+      compareGameInput3.val('');
       if(ratingGroup){
         if(gameEntryCount < 5){
           ratingGroup.show();

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -144,6 +144,8 @@
                     <input type="hidden" name="winner1" id="winnerInput1">
                     <input type="hidden" name="compareGameId2" id="compareGameId2">
                     <input type="hidden" name="winner2" id="winnerInput2">
+                    <input type="hidden" name="compareGameId3" id="compareGameId3">
+                    <input type="hidden" name="winner3" id="winnerInput3">
                     </div> <!-- gameInfoStep -->
                     <div id="eloStep" style="display:none;">
                         <div id="eloMatchup" class="mb-3">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -395,6 +395,8 @@
                         <input type="hidden" name="winner1" id="winnerInput1">
                         <input type="hidden" name="compareGameId2" id="compareGameId2">
                         <input type="hidden" name="winner2" id="winnerInput2">
+                        <input type="hidden" name="compareGameId3" id="compareGameId3">
+                        <input type="hidden" name="winner3" id="winnerInput3">
                         <input type="hidden" name="teamsList" id="teamsListInput">
                         <input type="hidden" name="venuesList" id="venuesListInput">
                         </div>


### PR DESCRIPTION
## Summary
- extend add game form to support a third comparison
- update `addGameModal.js` with optional stage 3
- record third comparison server-side when computing Elo ranking
- select comparison candidates near the Elo midpoint
- finalize when no third candidate exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a9481becc832685a4bfc32bca0272