### PR TITLE
UI tweaks for +Game modal

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -981,9 +981,13 @@
   align-items:center;
   text-align:center;
 }
+.elo-game-grid div:nth-child(7),
+.elo-game-grid div:nth-child(9){
+  font-weight:700;
+}
 .elo-game-grid img{
-  width:40px;
-  height:40px;
+  width:46px;
+  height:46px;
   object-fit:cover;
   border-radius:50%;
   margin:0 auto;

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -63,7 +63,10 @@
     submitBtn.prop('disabled', true);
 
     function updateRating(){
-      if(ratingRange && ratingValue){ ratingValue.textContent = ratingRange.value; }
+      if(ratingRange && ratingValue){
+        const val = parseFloat(ratingRange.value);
+        ratingValue.textContent = isNaN(val) ? '' : val.toFixed(1);
+      }
     }
     if(ratingRange){
       updateRating();

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -126,7 +126,7 @@
                             <span id="ratingValue" class="fw-bold text-white">5</span>
                         </label>
                         <div class="glass-range-wrapper">
-                            <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
+                            <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.1" value="5" required>
                         </div>
                     </div>
                     <div class="mb-3">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -380,7 +380,7 @@
                                 <span id="ratingValue" class="fw-bold text-white">5</span>
                             </label>
                             <div class="glass-range-wrapper">
-                                <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.5" value="5" required>
+                                <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.1" value="5" required>
                             </div>
                         </div>
                         <div class="mb-3">


### PR DESCRIPTION
## Summary
- show decimal rating values in Add Game modal
- adjust rating input step to 0.1
- enlarge Elo matchup logos and bold their scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ac17144b88326a5c6bbefcb5421e2