### PR TITLE
Compute average rating from user Elo

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -429,11 +429,11 @@ exports.showPastGame = async (req, res, next) => {
         homeBgColor = game.homeTeam.color;
       }
     }
-
     const ratingMap = {};
     (game.ratings || []).forEach(r => { ratingMap[String(r.userId)] = r.rating; });
     const userIds = (game.comments || []).map(c => c.userId);
-    const users = await require('../models/users').find({ _id: { $in: userIds } }).select('username');
+    const User = require('../models/users');
+    const users = await User.find({ _id: { $in: userIds } }).select('username');
     const userMap = {};
     users.forEach(u => { userMap[String(u._id)] = u.username; });
     const reviews = (game.comments || []).map(c => ({
@@ -443,7 +443,19 @@ exports.showPastGame = async (req, res, next) => {
       rating: ratingMap[String(c.userId)] || null
     }));
 
-    res.render('pastGame', { game, homeBgColor, awayBgColor, reviews, venue });
+    const eloAgg = await User.aggregate([
+      { $unwind: '$gameElo' },
+      { $match: { 'gameElo.game': game._id, 'gameElo.elo': { $ne: null } } },
+      { $group: { _id: null, avgElo: { $avg: '$gameElo.elo' } } }
+    ]);
+    let avgRating = 'N/A';
+    if (eloAgg.length && eloAgg[0].avgElo != null) {
+      const avgElo = eloAgg[0].avgElo;
+      const rating = ((avgElo - 1000) / 1000) * 9 + 1;
+      avgRating = rating.toFixed(1);
+    }
+
+    res.render('pastGame', { game, homeBgColor, awayBgColor, reviews, venue, avgRating });
   } catch(err){
     next(err);
   }

--- a/views/pastGame.ejs
+++ b/views/pastGame.ejs
@@ -10,7 +10,6 @@
 <body class="d-flex flex-column min-vh-100 gradient-bg past-game-page">
   <%- include('partials/header') %>
   <div class="container my-4 flex-grow-1">
-    <% const average = (game.ratings && game.ratings.length ? (game.ratings.reduce((s,r)=>s+(r.rating||r),0)/game.ratings.length).toFixed(1) : 'N/A'); %>
     <% const reviewCount = reviews ? reviews.length : 0; %>
     <% const dateObj = new Date(game.startDate || game.StartDate); %>
     <% const gameDateString = dateObj.toLocaleDateString('en-US', { year:'numeric', month:'short', day:'numeric' }); %>
@@ -33,7 +32,7 @@
             <div class="avg-label fw-bold">AVG Rating:</div>
             <div class="text-end">
               <div class="avg-number-wrapper">
-              <div class="avg-number fw-bold"><%= average %></div>
+              <div class="avg-number fw-bold"><%= avgRating %></div>
               <a href="#" id="toggleReviews" class="avg-reviews-link fw-bold text-decoration-none">(<%= reviewCount %> review<%= reviewCount===1?'':'s' %>)</a>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- compute average rating for a past game using users' `gameElo`
- show the calculated rating in the past game template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ad2d41be4832687b53a3a5f3b9140