### PR TITLE
Compute average rating from user Elo

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -429,21 +429,47 @@ exports.showPastGame = async (req, res, next) => {
         homeBgColor = game.homeTeam.color;
       }
     }
-
-    const ratingMap = {};
-    (game.ratings || []).forEach(r => { ratingMap[String(r.userId)] = r.rating; });
     const userIds = (game.comments || []).map(c => c.userId);
-    const users = await require('../models/users').find({ _id: { $in: userIds } }).select('username');
+    const User = require('../models/users');
+    const users = await User.find({ _id: { $in: userIds } })
+      .select('username gameElo');
     const userMap = {};
-    users.forEach(u => { userMap[String(u._id)] = u.username; });
-    const reviews = (game.comments || []).map(c => ({
-      userId: c.userId,
-      username: userMap[String(c.userId)] || 'User',
-      comment: c.comment,
-      rating: ratingMap[String(c.userId)] || null
-    }));
+    users.forEach(u => {
+      userMap[String(u._id)] = {
+        username: u.username,
+        gameElo: u.gameElo || []
+      };
+    });
+    const reviews = (game.comments || []).map(c => {
+      const info = userMap[String(c.userId)] || { username: 'User', gameElo: [] };
+      const eloEntry = (info.gameElo || []).find(e =>
+        String(e.game) === String(game._id) && typeof e.elo === 'number'
+      );
+      let rating = null;
+      if (eloEntry && eloEntry.elo != null) {
+        rating = (((eloEntry.elo - 1000) / 1000) * 9 + 1).toFixed(1);
+      }
+      return {
+        userId: c.userId,
+        username: info.username,
+        comment: c.comment,
+        rating
+      };
+    });
 
-    res.render('pastGame', { game, homeBgColor, awayBgColor, reviews, venue });
+    const eloAgg = await User.aggregate([
+      { $unwind: '$gameElo' },
+      { $match: { 'gameElo.game': game._id, 'gameElo.elo': { $ne: null } } },
+      { $group: { _id: null, avgElo: { $avg: '$gameElo.elo' } } }
+    ]);
+    let avgRating = 'N/A';
+    if (eloAgg.length && eloAgg[0].avgElo != null) {
+      const avgElo = eloAgg[0].avgElo;
+      const rating = ((avgElo - 1000) / 1000) * 9 + 1;
+      avgRating = rating.toFixed(1);
+    }
+
+    res.render('pastGame', { game, homeBgColor, awayBgColor, reviews, venue, avgRating });
   } catch(err){
     next(err);
   }

--- a/views/pastGame.ejs
+++ b/views/pastGame.ejs
@@ -10,7 +10,6 @@
 <body class="d-flex flex-column min-vh-100 gradient-bg past-game-page">
   <%- include('partials/header') %>
   <div class="container my-4 flex-grow-1">
-    <% const average = (game.ratings && game.ratings.length ? (game.ratings.reduce((s,r)=>s+(r.rating||r),0)/game.ratings.length).toFixed(1) : 'N/A'); %>
     <% const reviewCount = reviews ? reviews.length : 0; %>
     <% const dateObj = new Date(game.startDate || game.StartDate); %>
     <% const gameDateString = dateObj.toLocaleDateString('en-US', { year:'numeric', month:'short', day:'numeric' }); %>
@@ -33,7 +32,7 @@
             <div class="avg-label fw-bold">AVG Rating:</div>
             <div class="text-end">
               <div class="avg-number-wrapper">
-              <div class="avg-number fw-bold"><%= average %></div>
+              <div class="avg-number fw-bold"><%= avgRating %></div>
               <a href="#" id="toggleReviews" class="avg-reviews-link fw-bold text-decoration-none">(<%= reviewCount %> review<%= reviewCount===1?'':'s' %>)</a>
               </div>
             </div>
@@ -51,7 +50,9 @@
                     </div>
                     <%= r.comment %>
                   </div>
-                  <div class="col-3 col-md-2 fw-bold text-end rating-value"><%= r.rating %></div>
+                  <div class="col-3 col-md-2 fw-bold text-end rating-value">
+                    <%= r.rating ? r.rating + '/10' : '--' %>
+                  </div>
                 </div>
               <% }) } else { %>
                 <p class="text-white">No reviews yet.</p>


### PR DESCRIPTION
## Summary
- compute average rating for a past game using users' `gameElo`
- show user comment rating based on the same Elo conversion
- display converted rating in past game template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ad2d41be4832687b53a3a5f3b9140