### PR TITLE
Add conference stats to profile

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -349,6 +349,19 @@
                     <div id="statesTop" class="stat-right"></div>
                 </div>
             </div>
+            <div class="stat-block">
+                <div class="stat-content">
+                    <div class="stat-left">
+                        <div id="conferencesCount" class="stat-number"><%= conferencesCount %></div>
+                        <h3 class="stat-label">Conferences</h3>
+                    </div>
+                    <div id="conferencesTop" class="stat-right">
+                        <% (conferenceNames || []).forEach(function(name){ %>
+                            <div class="venue-name"><span class="venue-name-text"><%= name %></span></div>
+                        <% }) %>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- show how many conferences a user has seen games from
- display the conference names on the profile stats page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bcc62720083268a79c7310d58f5ed