### PR TITLE
Add conference completion stats

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -308,26 +308,45 @@
 
         /* Conferences specific styles */
         #conferenceBlock .stat-content {
-  display: grid;
-  grid-template-columns: 24% 1% 75%;
-}
-#conferenceBlock::after {
-  left: 25%; /* Adjust this to match the new spacer's position */
-}
+            display: grid;
+            grid-template-columns: 24% 1% 60% 15%;
+            align-items: center;
+        }
+
+        #conferenceBlock::after {
+            left: 25%; /* Match the end of the first column */
+        }
+
         #conferenceBlock .stat-left {
             grid-column: 1;
         }
+
         #conferenceBlock .stat-spacer {
             grid-column: 2;
         }
-        #conferenceBlock .stat-right {
+
+        #conferenceBlock .stat-middle {
             grid-column: 3;
-            
             display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            justify-content: flex-start;
+            flex-wrap: wrap;
             gap: 0.25rem;
+            align-items: center;
+        }
+
+        #conferenceBlock .stat-right {
+            grid-column: 4;
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            text-align: right;
+        }
+
+        .team-dot {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background-color: #bbb;
         }
 
         .conference-name-text {
@@ -393,18 +412,18 @@
         <br>
         <br>
         <div class="stat-block" id="conferenceBlock">
-            <div class="stat-content">
-                <div class="stat-left">
-                    <div id="conferencesCount" class="stat-number"><%= conferenceNames.length %></div>
-                    <h3 class="stat-label">Conferences</h3>
+            <% conferenceStats.forEach(function(conf){ %>
+                <div class="stat-content">
+                    <div class="stat-left"><%= conf.name %></div>
+                    <div class="stat-spacer"></div>
+                    <div class="stat-middle">
+                        <% for (var i = 0; i < conf.totalTeams; i++) { %>
+                            <span class="team-dot"></span>
+                        <% } %>
+                    </div>
+                    <div class="stat-right"><%= conf.percentage %>%</div>
                 </div>
-                <div class="stat-spacer"></div>
-                <div id="conferencesTop" class="stat-right">
-                    <% conferenceNames.forEach(function(name){ %>
-                        <div class="conference-name"><span class="conference-name-text"><%= name %></span></div>
-                    <% }) %>
-                </div>
-            </div>
+            <% }) %>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- compute conference completion stats using `conferenceTeamMap.json`
- display each conference with team count dots and unlocked percentage on profile stats page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb3be79c08326a50c26fd14d6212a