### PR TITLE
Add badge progress grid

### DIFF
--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -32,7 +32,39 @@
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'badges' }) %>
     <div class="container my-4 flex-grow-1">
-        <p class="empty-tab-message text-center">No content yet</p>
+        <% if (badges && badges.length) { %>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4">
+            <% badges.forEach(function(badge){
+                const progress = userProgress[badge.badgeID] || 0;
+                const clamped = Math.min(progress, badge.reqGames);
+                const complete = clamped >= badge.reqGames;
+                const percent = Math.round((clamped / badge.reqGames) * 100);
+                const leagues = (badge.leagueConstraints || []).join(',');
+                const teams = (badge.teamConstraints || []).join(',');
+                const query = [];
+                if (leagues) query.push('leagueId=' + encodeURIComponent(leagues));
+                if (teams) query.push('teamId=' + encodeURIComponent(teams));
+                const link = '/games' + (query.length ? '?' + query.join('&') : '');
+            %>
+            <div class="col">
+                <div class="card h-100">
+                    <img src="<%= badge.iconUrl %>" class="card-img-top" alt="<%= badge.badgeName %>">
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title"><%= badge.badgeName %></h5>
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <span class="<%= complete ? 'text-success fw-bold' : '' %>">(<%= clamped %>/<%= badge.reqGames %>)</span>
+                            <span><%= percent %>% 💎<%= badge.pointValue %></span>
+                        </div>
+                        <p class="card-text flex-grow-1"><%= badge.description %></p>
+                        <a href="<%= link %>" class="mt-auto text-decoration-none">See Upcoming Games →</a>
+                    </div>
+                </div>
+            </div>
+            <% }); %>
+        </div>
+        <% } else { %>
+        <p class="empty-tab-message text-center">No badges yet</p>
+        <% } %>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- show user badge progress in a responsive three-column grid with images and gem values
- load badges and user progress in controller

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893968441548326bda445d2a86d5ca0