### PR TITLE
Add badge filtering with gradient heading

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -305,13 +305,18 @@ exports.profileBadges = async (req, res, next) => {
         // Fetch all badges and compute user's progress for each
         const badgesRaw = await Badge.find().lean();
 
-        const teamIdsFromBadges = badgesRaw
+ const teamIdsFromBadges = badgesRaw
   .map(b => b.teamConstraints || [])
   .flat()
   .filter(Boolean)
   .map(id => id.toString());
 
-  const teamsData = await Team.find({ _id: { $in: teamIdsFromBadges } }, '_id alternateColor').lean();
+ const teamsData = await Team.find(
+  { _id: { $in: teamIdsFromBadges } },
+  '_id school alternateColor'
+ ).lean();
+
+ const conferences = await Conference.find({}, 'confId confName').lean();
 
 
         // Convert image buffers to base64 data URLs
@@ -376,7 +381,8 @@ exports.profileBadges = async (req, res, next) => {
             eloGames,
             badges,
             userProgress,
-            teamsData // 👈 Add this line
+            teamsData,
+            conferences
         });
     } catch (err) {
         next(err);

--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -100,12 +100,112 @@
     opacity: 0.75;
 }
 
+        .badge-page-title {
+            font-size: 2.5rem;
+            font-weight: 700;
+            background: linear-gradient(to right, #7e22ce, #14b8a6);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .filters-row .select2-container {
+            width: 50% !important;
+        }
+
+        .filters-row .select2-container--default .select2-selection--single,
+        .filters-row .select2-container--default .select2-dropdown,
+        .glass-select2.select2-dropdown {
+            position: relative;
+            background: linear-gradient(to right, #14b8a6, #7e22ce) !important;
+            border: 1px solid rgba(255, 255, 255, 0.2) !important;
+            border-radius: 0.5rem !important;
+            overflow: hidden;
+            backdrop-filter: blur(8px);
+        }
+
+        .filters-row .select2-container--default .select2-selection--single::before,
+        .filters-row .select2-container--default .select2-dropdown::before,
+        .glass-select2.select2-dropdown::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: rgba(255, 255, 255, 0.15);
+            backdrop-filter: blur(8px);
+            border-radius: inherit;
+            pointer-events: none;
+        }
+
+        .filters-row .select2-container--default .select2-selection--single {
+            height: 3.15rem !important;
+            display: flex;
+            align-items: center;
+        }
+
+        .filters-row .select2-container--default .select2-selection__rendered {
+            position: relative;
+            z-index: 1;
+            color: #fff !important;
+            font-weight: bold;
+        }
+
+        .filters-row .select2-container--default .select2-selection__placeholder {
+            color: #fff !important;
+        }
+
+        .filters-row .select2-container--default .select2-selection__clear,
+        .filters-row .select2-container--default .select2-selection__clear:hover,
+        .filters-row .select2-container--default .select2-selection__clear:focus {
+            position: relative;
+            z-index: 1;
+            display: inline-block;
+            background: linear-gradient(to right, #14b8a6, #7e22ce);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            cursor: pointer;
+        }
+
+        .filters-row .select2-container--default .select2-dropdown,
+        .glass-select2.select2-dropdown {
+            color: #fff;
+        }
+
+        .filters-row .select2-container--default .select2-results__option,
+        .glass-select2.select2-dropdown .select2-results__option {
+            color: #fff;
+        }
+
+        .filters-row .select2-container--default .select2-results__option--highlighted,
+        .glass-select2.select2-dropdown .select2-results__option--highlighted {
+            background: rgba(255, 255, 255, 0.3) !important;
+            color: #fff !important;
+        }
+
     </style>
 </head>
 <body class="d-flex flex-column min-vh-100">
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'badges' }) %>
     <div class="container my-4 flex-grow-1">
+        <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-3 mb-4">
+            <h2 class="badge-page-title text-center text-lg-start mb-0"><%= user.username %>'s Badges</h2>
+            <div class="filters-row d-flex flex-column flex-sm-row gap-2 ms-lg-auto">
+                <select id="conferenceFilter" class="form-select">
+                    <option></option>
+                    <% conferences.forEach(function(conf){ %>
+                        <option value="<%= conf.confId %>"><%= conf.confName %></option>
+                    <% }); %>
+                </select>
+                <select id="teamFilter" class="form-select">
+                    <option></option>
+                    <% teamsData.forEach(function(team){ %>
+                        <option value="<%= team._id %>"><%= team.school %></option>
+                    <% }); %>
+                </select>
+                <button id="clearFilters" class="btn btn-outline-light btn-sm">Clear Filters</button>
+            </div>
+        </div>
         <% if (badges && badges.length) { %>
         <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4" id="badgeGrid">
             <% badges.forEach(function(badge, index) {
@@ -115,7 +215,7 @@
                 const percent = Math.round((progress / badge.reqGames) * 100);
                 const inProgress = percent < 100;
             %>
-            <div class="col badge-col" style="<%= index >= 9 ? 'display: none;' : '' %>">
+            <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= index >= 9 ? 'display: none;' : '' %>">
                 <div class="card h-100 p-3 badge-card">
                     <div class="badge-icon-container" style="background-color: <%= team?.alternateColor || '#ccc' %>">
                         <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" style="<%= inProgress ? 'filter: blur(2px);' : '' %>">
@@ -154,17 +254,84 @@
     <script src="/js/addGameModal.js"></script>
     <script>
         let shown = 9;
-    const batch = 12; // Show 4 rows (3 per row)
-    const btn = document.getElementById('loadMoreBtn');
-    btn.addEventListener('click', () => {
-        const hidden = document.querySelectorAll('.badge-col[style*="display: none"]');
-        for (let i = 0; i < batch && i < hidden.length; i++) {
-            hidden[i].style.display = 'block';
+        const batch = 12; // Show 4 rows (3 per row)
+        const btn = document.getElementById('loadMoreBtn');
+
+        function resetGrid() {
+            const cols = document.querySelectorAll('.badge-col');
+            cols.forEach((col, index) => {
+                col.style.display = index < shown ? 'block' : 'none';
+            });
+            if (btn) {
+                if (cols.length > shown) {
+                    btn.style.display = 'block';
+                } else {
+                    btn.style.display = 'none';
+                }
+            }
         }
-        if (document.querySelectorAll('.badge-col[style*="display: none"]').length === 0) {
-            btn.style.display = 'none';
+
+        if (btn) {
+            btn.addEventListener('click', () => {
+                const hidden = document.querySelectorAll('.badge-col[style*="display: none"]');
+                for (let i = 0; i < batch && i < hidden.length; i++) {
+                    hidden[i].style.display = 'block';
+                }
+                if (document.querySelectorAll('.badge-col[style*="display: none"]').length === 0) {
+                    btn.style.display = 'none';
+                }
+            });
         }
-    });
+
+        const conferenceFilter = $('#conferenceFilter');
+        const teamFilter = $('#teamFilter');
+
+        conferenceFilter.select2({
+            placeholder: 'Conference',
+            allowClear: true,
+            width: 'resolve',
+            containerCssClass: 'glass-select2',
+            dropdownCssClass: 'glass-select2'
+        });
+
+        teamFilter.select2({
+            placeholder: 'Team',
+            allowClear: true,
+            width: 'resolve',
+            containerCssClass: 'glass-select2',
+            dropdownCssClass: 'glass-select2'
+        });
+
+        const badgeCols = document.querySelectorAll('.badge-col');
+
+        function applyFilters() {
+            const confVal = conferenceFilter.val();
+            const teamVal = teamFilter.val();
+            const active = confVal || teamVal;
+            badgeCols.forEach(col => {
+                const confs = (col.dataset.conferences || '').split(',').filter(Boolean);
+                const teams = (col.dataset.teams || '').split(',').filter(Boolean);
+                const confMatch = !confVal || confs.includes(confVal);
+                const teamMatch = !teamVal || teams.includes(teamVal);
+                col.style.display = confMatch && teamMatch ? '' : 'none';
+            });
+            if (active) {
+                if (btn) btn.style.display = 'none';
+            } else {
+                resetGrid();
+            }
+        }
+
+        conferenceFilter.on('change', applyFilters);
+        teamFilter.on('change', applyFilters);
+
+        $('#clearFilters').on('click', function () {
+            conferenceFilter.val(null).trigger('change');
+            teamFilter.val(null).trigger('change');
+            applyFilters();
+        });
+
+        resetGrid();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add gradient "Badges" title with responsive filter controls
- populate filters with conferences and teams and apply frosted glass Select2 styling
- enable client-side badge filtering by conference and team
- refine filter dropdowns with gradient backgrounds, reduced width and taller controls, plus gradient clear icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c09051b083268126353a0309cdb5