### PR TITLE
Add team detail page and link logos

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ const express = require("express"),
     comparisonController = require('./controllers/comparisonController'),
     Message = require('./models/Message'),
     User = require('./models/users'),
+    Team = require('./models/Team'),
     layouts = require('express-ejs-layouts'),
     mongoose = require('mongoose'),
     cookieParser = require('cookie-parser'),
@@ -199,6 +200,11 @@ app.get('/pastGames/teams', gamesController.listPastGameTeams);
 app.get('/pastGames/search', gamesController.searchPastGames);
 app.get('/pastGames/:id', gamesController.showPastGame);
 app.get('/games/:id', gamesController.showGame);
+app.get('/team/:id', async (req, res) => {
+    const team = await Team.findById(req.params.id);
+    if (!team) return res.status(404).send('Team not found');
+    res.render('team', { team });
+});
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);
 app.post('/games/:id/list', requireAuth, gamesController.toggleGameList);

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -16,14 +16,18 @@
         <div class="team-diagonal-square mx-auto" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>">
           <!-- Away Team: Top-left triangle -->
           <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);">
-            <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>"
-                 alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">
+            <a href="/team/<%= game.awayTeam && game.awayTeam._id %>">
+              <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>"
+                   alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">
+            </a>
           </div>
 
           <!-- Home Team: Bottom-right triangle -->
           <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);">
-            <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>"
-                 alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
+            <a href="/team/<%= game.homeTeam && game.homeTeam._id %>">
+              <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>"
+                   alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
+            </a>
           </div>
         </div>
         <% if(followerWishers && followerWishers.length){ const extra = followerWishers.length - 5; %>

--- a/views/pastGame.ejs
+++ b/views/pastGame.ejs
@@ -18,12 +18,16 @@
         <div class="position-relative logo-wrapper">
           <div class="team-diagonal-square mx-auto" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>;">
             <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);">
-              <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>"
-                   alt="<%= game.AwayTeam || game.awayTeamName %>" class="team-logo-detail away-logo">
+              <a href="/team/<%= game.awayTeam && game.awayTeam._id %>">
+                <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>"
+                     alt="<%= game.AwayTeam || game.awayTeamName %>" class="team-logo-detail away-logo">
+              </a>
             </div>
             <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);">
-              <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>"
-                   alt="<%= game.HomeTeam || game.homeTeamName %>" class="team-logo-detail home-logo">
+              <a href="/team/<%= game.homeTeam && game.homeTeam._id %>">
+                <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>"
+                     alt="<%= game.HomeTeam || game.homeTeamName %>" class="team-logo-detail home-logo">
+              </a>
             </div>
           </div>
         </div>
@@ -79,7 +83,9 @@
           <div class="flex-grow-1">
             <div class="game-score-grid mb-3">
               <div class="team-column text-center">
-                <img class="score-logo" src="<%= awayLogo %>" alt="<%= game.AwayTeam || game.awayTeamName %>">
+                <a href="/team/<%= game.awayTeam && game.awayTeam._id %>">
+                  <img class="score-logo" src="<%= awayLogo %>" alt="<%= game.AwayTeam || game.awayTeamName %>">
+                </a>
                 <div class="team-name-large fw-bold"><%= game.AwayTeam || game.awayTeamName %></div>
                 <div class="score-number fw-bold"><%= game.AwayPoints ?? game.awayPoints %></div>
               </div>
@@ -91,7 +97,9 @@
               </div>
               
               <div class="team-column text-center">
-                <img class="score-logo" src="<%= homeLogo %>" alt="<%= game.HomeTeam || game.homeTeamName %>">
+                <a href="/team/<%= game.homeTeam && game.homeTeam._id %>">
+                  <img class="score-logo" src="<%= homeLogo %>" alt="<%= game.HomeTeam || game.homeTeamName %>">
+                </a>
                 <div class="team-name-large fw-bold"><%= game.HomeTeam || game.homeTeamName %></div>
                 <div class="score-number fw-bold"><%= game.HomePoints ?? game.homePoints %></div>
               </div>

--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -680,7 +680,9 @@ const stateEntries = <%- JSON.stringify(stateEntries || []) %>;
                 const name = team.school || team.name;
                 return `
                     <div class="top-list-item">${prefix}${displayTeamRank}.</div>
-                    <img src="${logo}" alt="${name}" class="game-logo-sm">
+                    <a href="/team/${team._id}">
+                        <img src="${logo}" alt="${name}" class="game-logo-sm">
+                    </a>
                     <div class="venue-name"><span class="venue-name-text">${name}</span></div>
                     <div class="venue-count">${item.count}</div>
                 `;
@@ -792,8 +794,10 @@ const stateEntries = <%- JSON.stringify(stateEntries || []) %>;
         const logo = team.logos && team.logos[0] ? team.logos[0] : '/images/placeholder.jpg';
         return `<div class="team-stat-col">
     <div class="team-count">${item.count}</div>
-    <img src="${logo}" alt="${team.school}" class="team-logo" title="${team.school}">
-    
+    <a href="/team/${team._id}">
+        <img src="${logo}" alt="${team.school}" class="team-logo" title="${team.school}">
+    </a>
+
 </div>`;
     }).join('');
 

--- a/views/team.ejs
+++ b/views/team.ejs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= team.school %></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/custom.css">
+  <style>
+    .team-logo-lg {
+      width: 200px;
+      height: 200px;
+      object-fit: contain;
+    }
+  </style>
+</head>
+<body class="d-flex flex-column min-vh-100 gradient-bg">
+  <%- include('partials/header') %>
+  <div class="container my-4 flex-grow-1 d-flex justify-content-center align-items-center">
+    <img src="<%= team.logos && team.logos[0] ? team.logos[0] : '/images/placeholder.jpg' %>" alt="<%= team.school %>" class="team-logo-lg">
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Team model to routing and create /team/:id handler
- display large team logo on new team.ejs
- link existing team logos in pastGame, game, and profile stats pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963742a0b88326a8228c10710e10a1