### PR TITLE
Add team profile page with stats and future games

### DIFF
--- a/views/team.ejs
+++ b/views/team.ejs
@@ -7,18 +7,105 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/custom.css">
   <style>
-    .team-logo-lg {
-      width: 200px;
-      height: 200px;
+    .badge-icon-container {
+      width: 7rem;
+      height: 7rem;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid #999;
+      margin: 0 auto 0.5rem auto;
+      position: relative;
+      overflow: hidden;
+    }
+    .badge-icon-container img {
+      max-width: 80%;
+      max-height: 80%;
       object-fit: contain;
     }
   </style>
 </head>
 <body class="d-flex flex-column min-vh-100 gradient-bg">
   <%- include('partials/header') %>
-  <div class="container my-4 flex-grow-1 d-flex justify-content-center align-items-center">
-    <img src="<%= team.logos && team.logos[0] ? team.logos[0] : '/images/placeholder.jpg' %>" alt="<%= team.school %>" class="team-logo-lg">
+  <div class="container my-4 flex-grow-1">
+    <div class="row g-4">
+      <!-- Left column -->
+      <div class="col-md-4 text-white text-center">
+        <div class="position-relative logo-wrapper">
+          <div class="team-diagonal-square mx-auto">
+            <div class="triangle home-bg" style="background:<%= team.alternateColor || '#ccc' %>; clip-path: polygon(0 0,100% 0,100% 100%,0 100%);">
+              <img src="<%= team.logos && team.logos[0] ? team.logos[0] : '/images/placeholder.jpg' %>" alt="<%= team.school %>" class="team-logo-detail">
+            </div>
+          </div>
+        </div>
+        <div class="mt-3">
+          <div class="avg-rating-container d-flex justify-content-center align-items-center">
+            <div class="avg-label fw-bold me-2">AVG Rating:</div>
+            <div class="avg-number fw-bold"><%= averageElo %></div>
+          </div>
+        </div>
+        <div class="mt-4">
+          <div class="row row-cols-2 row-cols-md-3 g-3">
+            <% relevantBadges.forEach(function(badge){ %>
+              <div class="col">
+                <div class="badge-icon-container">
+                  <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>">
+                </div>
+              </div>
+            <% }) %>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right column -->
+      <div class="col-md-8 text-white">
+        <div class="bg-dark p-3 rounded mb-4 text-center">
+          <div class="fs-4 fw-bold"><%= usersCheckedIn %></div>
+          <div>Users Checked In</div>
+        </div>
+        <div class="row row-cols-1 g-4">
+          <% upcomingGames.forEach(function(game){
+               const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
+               const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
+          %>
+          <div class="col">
+            <a href="/games/<%= game._id %>" class="text-decoration-none">
+              <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
+                <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                  <div class="logo-wrapper me-3">
+                    <div class="team-logo-container">
+                      <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.awayTeamName %>">
+                    </div>
+                    <span class="team-name"><%= game.awayTeamName %></span>
+                  </div>
+                  <div class="logo-wrapper ms-3">
+                    <div class="team-logo-container">
+                      <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60' %>" alt="<%= game.homeTeamName %>">
+                    </div>
+                    <span class="team-name"><%= game.homeTeamName %></span>
+                  </div>
+                  <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
+                </div>
+              </div>
+            </a>
+          </div>
+          <% }) %>
+          <% if (upcomingGames.length === 0) { %>
+            <p class="text-center">No upcoming games.</p>
+          <% } %>
+        </div>
+      </div>
+    </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    document.querySelectorAll('.game-date[data-start]').forEach(el => {
+      const date = new Date(el.dataset.start);
+      el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+    });
+  </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- expand `/team/:id` route to gather team games, user check-ins, average elo ratings and relevant badges
- create rich `team.ejs` page showing team logo, rating, badge icons and upcoming game cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964ab4eba88326b052519361c71e0a