### PR TITLE
refactor badge styles into reusable classes

### DIFF
--- a/lib/badgeUtils.js
+++ b/lib/badgeUtils.js
@@ -1,0 +1,8 @@
+function getBadgeStyleClass(badgeID) {
+  if (badgeID >= 231 && badgeID <= 364) return 'special-badge-container';
+  if (badgeID >= 365 && badgeID <= 594) return 'gold-badge-container';
+  if (badgeID >= 595 && badgeID <= 730) return 'bronze-badge-container';
+  return '';
+}
+
+module.exports = { getBadgeStyleClass };

--- a/main.js
+++ b/main.js
@@ -20,8 +20,8 @@ const express = require("express"),
     mongoose = require('mongoose'),
     cookieParser = require('cookie-parser'),
     path = require('path'),
-
-    jwt = require('./lib/simpleJWT');
+    jwt = require('./lib/simpleJWT'),
+    { getBadgeStyleClass } = require('./lib/badgeUtils');
 
 
 
@@ -45,6 +45,7 @@ app.use(express.urlencoded({
 );
 
 app.use(express.json());
+app.locals.getBadgeStyleClass = getBadgeStyleClass;
 
 // Middleware to authenticate token
 app.use(async (req, res, next) => {

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1015,3 +1015,167 @@
 }
 
 .loading-overlay{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:1055;}
+
+/* Badge styles */
+.badge-icon-container {
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #999;
+  margin: 0 auto 0.5rem auto;
+  position: relative;
+  overflow: hidden;
+}
+
+.badge-icon-container img {
+  max-width: 80%;
+  max-height: 80%;
+  object-fit: contain;
+  filter: blur(0);
+  transition: filter 0.3s ease;
+}
+
+.badge-icon-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 5;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.3);
+  color: white;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.special-badge-container {
+  position: relative;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(to bottom, #6b6b6b, #dcdcdc);
+  isolation: isolate;
+}
+
+.special-badge-metal-bg {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, #a1a1a1, #e0e0e0);
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  transform: rotate(-75deg);
+  pointer-events: none;
+}
+
+.special-badge-metal-bg span {
+  font-size: 1.25rem;
+  font-weight: 900;
+  color: inherit;
+  white-space: nowrap;
+  opacity: 0.15;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.special-badge-logo {
+  width: 80%;
+  height: 80%;
+  object-fit: contain;
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.special-badge-logo.blurred {
+  filter: blur(2px);
+}
+
+.gold-badge-container {
+  position: relative;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(to bottom, #b28c2c, #f9e67a);
+  isolation: isolate;
+}
+
+.gold-badge-metal-bg {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, #c9a02c, #fff2a6);
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  transform: rotate(-75deg);
+  pointer-events: none;
+}
+
+.gold-badge-metal-bg span {
+  font-size: 1.25rem;
+  font-weight: 900;
+  color: inherit;
+  white-space: nowrap;
+  opacity: 0.15;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.bronze-badge-container {
+  position: relative;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(to bottom, #8d5524, #d4a373);
+  isolation: isolate;
+}
+
+.bronze-badge-metal-bg {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, #a86b36, #f0caa0);
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  transform: rotate(-75deg);
+  pointer-events: none;
+}
+
+.bronze-badge-metal-bg span {
+  font-size: 1.25rem;
+  font-weight: 900;
+  color: inherit;
+  white-space: nowrap;
+  opacity: 0.15;
+  line-height: 1.2;
+  text-transform: uppercase;
+}

--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -75,97 +75,6 @@
         .badge-link {
             text-align: right;
         }
-        .badge-icon-container {
-            width: 7rem;
-            height: 7rem;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border: 1px solid #999;
-            margin: 0 auto 0.5rem auto;
-            position: relative;
-            overflow: hidden;
-        }
-        .badge-icon-container img {
-            max-width: 80%;
-            max-height: 80%;
-            object-fit: contain;
-            filter: blur(0);
-            transition: filter 0.3s ease;
-        }
-        .badge-icon-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 4; /* this is fine */
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: rgba(0, 0, 0, 0.3);
-    color: white;
-    font-size: 2rem;
-    font-weight: bold;
-}
-
-        /* Special 2025 badge effect for badgeIDs 231-364 */
-        .special-badge-container {
-    position: relative;
-    width: 7rem;
-    height: 7rem;
-    border-radius: 50%;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(to bottom, #6b6b6b, #dcdcdc); /* dark silver to light silver */
-    isolation: isolate;
-}
-
-.special-badge-metal-bg {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to bottom, #a1a1a1, #e0e0e0); /* Silver base */
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  transform: rotate(-75deg);
-  pointer-events: none;
-}
-
-.special-badge-metal-bg span {
-  font-size: 1.25rem;
-  font-weight: 900;
-  color: inherit; /* inherit from .special-badge-metal-bg */
-  white-space: nowrap;
-  opacity: 0.15;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
-.special-badge-logo {
-  width: 80%;
-  height: 80%;
-  object-fit: contain;
-  position: absolute;
-  z-index: 2;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.badge-icon-overlay {
-  z-index: 5; /* bump it up above everything */
-}
-.special-badge-logo.blurred {
-  filter: blur(2px);
-}
-
         .diamond-text {
             font-weight: bold;
             color: #89d5e0;
@@ -293,80 +202,6 @@
         }
 
 
-        .gold-badge-container {
-  position: relative;
-  width: 7rem;
-  height: 7rem;
-  border-radius: 50%;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(to bottom, #b28c2c, #f9e67a); /* dark gold to light gold */
-  isolation: isolate;
-}
-
-.gold-badge-metal-bg {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to bottom, #c9a02c, #fff2a6); /* gold metallic feel */
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  transform: rotate(-75deg);
-  pointer-events: none;
-}
-
-.gold-badge-metal-bg span {
-  font-size: 1.25rem;
-  font-weight: 900;
-  color: inherit;
-  white-space: nowrap;
-  opacity: 0.15;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
-.bronze-badge-container {
-  position: relative;
-  width: 7rem;
-  height: 7rem;
-  border-radius: 50%;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(to bottom, #8d5524, #d4a373); /* bronze tones */
-  isolation: isolate;
-}
-
-.bronze-badge-metal-bg {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to bottom, #a86b36, #f0caa0); /* bronze metallic effect */
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  transform: rotate(-75deg);
-  pointer-events: none;
-}
-
-.bronze-badge-metal-bg span {
-  font-size: 1.25rem;
-  font-weight: 900;
-  color: inherit;
-  white-space: nowrap;
-  opacity: 0.15;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
     </style>
     
     
@@ -416,13 +251,9 @@
         %>
         <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= index >= 9 ? 'display: none;' : '' %>">
             <div class="card h-100 p-3 badge-card">
-                <div class="badge-icon-container 
-  <%= (badge.badgeID >= 231 && badge.badgeID <= 364) ? 'special-badge-container' : '' %>
-  <%= (badge.badgeID >= 365 && badge.badgeID <= 594) ? 'gold-badge-container' : '' %>
-  <%= (badge.badgeID >= 595 && badge.badgeID <= 730) ? 'bronze-badge-container' : '' %>"
-  style="<%= ((badge.badgeID >= 231 && badge.badgeID <= 730)) ? '' : 'background-color: ' + (team?.alternateColor || '#ccc') %>">
-
-  <% if (badge.badgeID >= 231 && badge.badgeID <= 364) { %>
+                <% const badgeClass = getBadgeStyleClass(badge.badgeID); %>
+                <div class="badge-icon-container <%= badgeClass %>" style="<%= badgeClass ? '' : 'background-color: ' + (team?.alternateColor || '#ccc') %>">
+  <% if (badgeClass === 'special-badge-container') { %>
     <div class="special-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team?.alternateColor || '#aaa' %>">
       <% for (let i = 0; i < 6; i++) { %>
         <span>2025 2025 2025 2025 2025</span>
@@ -432,7 +263,7 @@
     <% if (inProgress) { %>
       <div class="badge-icon-overlay"><%= percent %>%</div>
     <% } %>
-  <% } else if (badge.badgeID >= 365 && badge.badgeID <= 594) { %>
+  <% } else if (badgeClass === 'gold-badge-container') { %>
     <div class="gold-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team?.alternateColor || '#aaa' %>">
       <% for (let i = 0; i < 6; i++) { %>
         <span>2025 2025 2025 2025 2025</span>
@@ -442,7 +273,7 @@
     <% if (inProgress) { %>
       <div class="badge-icon-overlay"><%= percent %>%</div>
     <% } %>
-  <% } else if (badge.badgeID >= 595 && badge.badgeID <= 730) { %>
+  <% } else if (badgeClass === 'bronze-badge-container') { %>
     <div class="bronze-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team?.alternateColor || '#aaa' %>">
       <% for (let i = 0; i < 6; i++) { %>
         <span>2025 2025 2025 2025 2025</span>
@@ -458,6 +289,7 @@
       <div class="badge-icon-overlay"><%= percent %>%</div>
     <% } %>
   <% } %>
+  </div>
 </div>
 
                 <div class="diamond-text">💎 <%= badge.pointValue %></div>

--- a/views/team.ejs
+++ b/views/team.ejs
@@ -7,24 +7,6 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/custom.css">
   <style>
-    .badge-icon-container {
-      width: 7rem;
-      height: 7rem;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border: 1px solid #999;
-      margin: 0 auto 0.5rem auto;
-      position: relative;
-      overflow: hidden;
-    }
-    .badge-icon-container img {
-      max-width: 80%;
-      max-height: 80%;
-      object-fit: contain;
-    }
-
     .team-diagonal-square {
   width: 25rem;
   height: 25rem;
@@ -106,10 +88,33 @@
   <h5 class="text-white fw-bold mb-2"><%= team.school %> related Badges</h5>
   <div class="badge-wrapper p-3">
     <div class="row row-cols-2 row-cols-md-3 g-3">
-      <% relevantBadges.forEach(function(badge){ %>
+      <% relevantBadges.forEach(function(badge){ const badgeClass = getBadgeStyleClass(badge.badgeID); %>
         <div class="col">
-          <div class="badge-icon-container">
-            <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>">
+          <div class="badge-icon-container <%= badgeClass %>" style="<%= badgeClass ? '' : 'background-color: ' + (team.alternateColor || '#ccc') %>">
+            <% if (badgeClass === 'special-badge-container') { %>
+              <div class="special-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team.alternateColor || '#aaa' %>">
+                <% for (let i = 0; i < 6; i++) { %>
+                  <span>2025 2025 2025 2025 2025</span>
+                <% } %>
+              </div>
+              <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo">
+            <% } else if (badgeClass === 'gold-badge-container') { %>
+              <div class="gold-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team.alternateColor || '#aaa' %>">
+                <% for (let i = 0; i < 6; i++) { %>
+                  <span>2025 2025 2025 2025 2025</span>
+                <% } %>
+              </div>
+              <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo">
+            <% } else if (badgeClass === 'bronze-badge-container') { %>
+              <div class="bronze-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team.alternateColor || '#aaa' %>">
+                <% for (let i = 0; i < 6; i++) { %>
+                  <span>2025 2025 2025 2025 2025</span>
+                <% } %>
+              </div>
+              <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo">
+            <% } else { %>
+              <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>">
+            <% } %>
           </div>
         </div>
       <% }) %>


### PR DESCRIPTION
## Summary
- centralize badge appearance styles in global custom.css
- add helper to map badge IDs to badge style classes
- update badge displays to use shared classes for consistent styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689657d0d3f0832688c67fad959316c4