### PR TITLE
Add badge detail page and shared badge icon component

### DIFF
--- a/main.js
+++ b/main.js
@@ -257,6 +257,21 @@ app.get('/team/:id', async (req, res) => {
         relevantBadges
     });
 });
+app.get('/badge/:id', async (req, res) => {
+    try {
+        const badge = await Badge.findById(req.params.id).lean();
+        if (!badge) return res.status(404).send('Badge not found');
+
+        let team = null;
+        if (badge.teamConstraints && badge.teamConstraints.length > 0) {
+            team = await Team.findById(badge.teamConstraints[0]).lean();
+        }
+
+        res.render('badge', { badge, team });
+    } catch (err) {
+        res.status(500).send('Server error');
+    }
+});
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);
 app.post('/games/:id/list', requireAuth, gamesController.toggleGameList);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1030,6 +1030,15 @@
   overflow: hidden;
 }
 
+.badge-icon {
+  transition: transform 0.2s ease;
+  cursor: pointer;
+}
+
+.badge-icon:hover {
+  transform: scale(1.05);
+}
+
 .badge-icon-container img {
   max-width: 80%;
   max-height: 80%;

--- a/views/badge.ejs
+++ b/views/badge.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= badge.badgeName %></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/custom.css">
+</head>
+<body class="d-flex flex-column min-vh-100 gradient-bg">
+  <%- include('partials/header') %>
+  <div class="container my-5 flex-grow-1 text-center">
+    <%- include('partials/badgeIcon', { badge, team }) %>
+    <h2 class="mt-3"><%= badge.badgeName %></h2>
+    <p><%= badge.description %></p>
+  </div>
+</body>
+</html>

--- a/views/partials/badgeIcon.ejs
+++ b/views/partials/badgeIcon.ejs
@@ -1,0 +1,36 @@
+<%
+  const badgeClass = getBadgeStyleClass(badge.badgeID);
+  const altColor = team?.alternateColor || '#ccc';
+  const showOverlay = typeof percent !== 'undefined' && percent < 100;
+%>
+<a href="/badge/<%= badge._id %>" class="badge-link d-inline-block">
+  <div class="badge-icon badge-icon-container <%= badgeClass %>" style="<%= badgeClass ? '' : 'background-color: ' + altColor %>">
+    <% if (badgeClass === 'special-badge-container') { %>
+      <div class="special-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= altColor %>">
+        <% for (let i = 0; i < 6; i++) { %>
+          <span>2025 2025 2025 2025 2025</span>
+        <% } %>
+      </div>
+      <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo <%= showOverlay ? 'blurred' : '' %>">
+    <% } else if (badgeClass === 'gold-badge-container') { %>
+      <div class="gold-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= altColor %>">
+        <% for (let i = 0; i < 6; i++) { %>
+          <span>2025 2025 2025 2025 2025</span>
+        <% } %>
+      </div>
+      <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo <%= showOverlay ? 'blurred' : '' %>">
+    <% } else if (badgeClass === 'bronze-badge-container') { %>
+      <div class="bronze-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= altColor %>">
+        <% for (let i = 0; i < 6; i++) { %>
+          <span>2025 2025 2025 2025 2025</span>
+        <% } %>
+      </div>
+      <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo <%= showOverlay ? 'blurred' : '' %>">
+    <% } else { %>
+      <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" style="<%= showOverlay ? 'filter: blur(2px);' : '' %>">
+    <% } %>
+    <% if (showOverlay) { %>
+      <div class="badge-icon-overlay"><%= percent %>%</div>
+    <% } %>
+  </div>
+</a>

--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -247,50 +247,10 @@
             const team = teamsData.find(t => String(t._id) === String(teams));
             const progress = userProgress[badge.badgeID] || 0;
             const percent = Math.round((progress / badge.reqGames) * 100);
-            const inProgress = percent < 100;
         %>
         <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= index >= 9 ? 'display: none;' : '' %>">
             <div class="card h-100 badge-card p-3 d-flex flex-column">
-  <% const badgeClass = getBadgeStyleClass(badge.badgeID); %>
-  <div class="badge-icon-container <%= badgeClass %>" style="<%= badgeClass ? '' : 'background-color: ' + (team?.alternateColor || '#ccc') %>">
-  <% if (badgeClass === 'special-badge-container') { %>
-    <div class="special-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team?.alternateColor || '#aaa' %>">
-      <% for (let i = 0; i < 6; i++) { %>
-        <span>2025 2025 2025 2025 2025</span>
-      <% } %>
-    </div>
-    <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo <%= inProgress ? 'blurred' : '' %>">
-    <% if (inProgress) { %>
-      <div class="badge-icon-overlay"><%= percent %>%</div>
-    <% } %>
-  <% } else if (badgeClass === 'gold-badge-container') { %>
-    <div class="gold-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team?.alternateColor || '#aaa' %>">
-      <% for (let i = 0; i < 6; i++) { %>
-        <span>2025 2025 2025 2025 2025</span>
-      <% } %>
-    </div>
-    <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo <%= inProgress ? 'blurred' : '' %>">
-    <% if (inProgress) { %>
-      <div class="badge-icon-overlay"><%= percent %>%</div>
-    <% } %>
-  <% } else if (badgeClass === 'bronze-badge-container') { %>
-    <div class="bronze-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team?.alternateColor || '#aaa' %>">
-      <% for (let i = 0; i < 6; i++) { %>
-        <span>2025 2025 2025 2025 2025</span>
-      <% } %>
-    </div>
-    <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo <%= inProgress ? 'blurred' : '' %>">
-    <% if (inProgress) { %>
-      <div class="badge-icon-overlay"><%= percent %>%</div>
-    <% } %>
-  <% } else { %>
-    <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" style="<%= inProgress ? 'filter: blur(2px);' : '' %>">
-    <% if (inProgress) { %>
-      <div class="badge-icon-overlay"><%= percent %>%</div>
-    <% } %>
-  <% } %>
-  </div>
-
+  <%- include('partials/badgeIcon', { badge, team, percent }) %>
 
                  <div class="diamond-text mt-2">💎 <%= badge.pointValue %></div>
 

--- a/views/team.ejs
+++ b/views/team.ejs
@@ -91,34 +91,9 @@
       <p class="text-white mb-0 text-center">No current badges for <%= team.school %></p>
     <% } else { %>
       <div class="row row-cols-2 row-cols-md-3 g-3">
-        <% relevantBadges.forEach(function(badge){ const badgeClass = getBadgeStyleClass(badge.badgeID); %>
+        <% relevantBadges.forEach(function(badge){ %>
           <div class="col">
-            <div class="badge-icon-container <%= badgeClass %>" style="<%= badgeClass ? '' : 'background-color: ' + (team.alternateColor || '#ccc') %>">
-              <% if (badgeClass === 'special-badge-container') { %>
-                <div class="special-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team.alternateColor || '#aaa' %>">
-                  <% for (let i = 0; i < 6; i++) { %>
-                    <span>2025 2025 2025 2025 2025</span>
-                  <% } %>
-                </div>
-                <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo">
-              <% } else if (badgeClass === 'gold-badge-container') { %>
-                <div class="gold-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team.alternateColor || '#aaa' %>">
-                  <% for (let i = 0; i < 6; i++) { %>
-                    <span>2025 2025 2025 2025 2025</span>
-                  <% } %>
-                </div>
-                <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo">
-              <% } else if (badgeClass === 'bronze-badge-container') { %>
-                <div class="bronze-badge-metal-bg" style="color: var(--team-alt-color, #aaa); --team-alt-color: <%= team.alternateColor || '#aaa' %>">
-                  <% for (let i = 0; i < 6; i++) { %>
-                    <span>2025 2025 2025 2025 2025</span>
-                  <% } %>
-                </div>
-                <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>" class="special-badge-logo">
-              <% } else { %>
-                <img src="<%= badge.iconUrl %>" alt="<%= badge.badgeName %>">
-              <% } %>
-            </div>
+            <%- include('partials/badgeIcon', { badge, team }) %>
           </div>
         <% }) %>
       </div>


### PR DESCRIPTION
## Summary
- Add `/badge/:id` route to fetch badges and render a new badge.ejs page
- Create reusable `badgeIcon` partial and apply across badge displays
- Introduce hover/scale effect and links to badge detail page for icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689669718e608326bd82e6c8f63c84d4