### PR TITLE
Enable automatic game check-in via geolocation

### DIFF
--- a/main.js
+++ b/main.js
@@ -259,6 +259,8 @@ app.get('/team/:id', async (req, res) => {
     });
 });
 app.get('/badge/:id', badgeController.showBadge);
+app.post('/api/nearbyGameCheckin', gamesController.nearbyGameCheckin);
+app.post('/api/checkin', gamesController.apiCheckIn);
 app.post('/games/:id/checkin', gamesController.checkIn);
 app.post('/games/:id/wishlist', requireAuth, gamesController.toggleWishlist);
 app.post('/games/:id/list', requireAuth, gamesController.toggleGameList);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -461,6 +461,16 @@
   backdrop-filter: blur(10px);
 }
 
+/* Nearby check-in modal styling */
+.checkin-modal .modal-content{
+  background: linear-gradient(to right, #7e22ce, #14b8a6);
+  background-clip: padding-box;
+  border-radius:1rem;
+  border:1px solid rgba(255,255,255,0.2);
+  color:#fff;
+  backdrop-filter: blur(10px);
+}
+
 /* Timestamp styling */
 .message-timestamp{
   font-size:0.7em;

--- a/public/js/nearbyCheckin.js
+++ b/public/js/nearbyCheckin.js
@@ -1,0 +1,55 @@
+(function(){
+  window.addEventListener('load', function(){
+    if(!window.loggedInUser) return;
+    if(sessionStorage.getItem('nearbyCheckDone')) return;
+    sessionStorage.setItem('nearbyCheckDone','1');
+    if(!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(async function(pos){
+      try{
+        const res = await fetch('/api/nearbyGameCheckin',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          credentials:'include',
+          body: JSON.stringify({ lat: pos.coords.latitude, lng: pos.coords.longitude })
+        });
+        if(!res.ok) return;
+        const data = await res.json();
+        if(data && data.game){
+          showCheckinModal(data.game);
+        } else {
+          console.log('No game nearby');
+        }
+      }catch(err){console.error(err);}
+    }, function(err){ console.error(err); });
+  });
+
+  function showCheckinModal(game){
+    if(!window.bootstrap) return;
+    const awayLogo = game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/60';
+    const homeLogo = game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/60';
+    const awayName = game.awayTeamName || (game.awayTeam && game.awayTeam.school) || '';
+    const homeName = game.homeTeamName || (game.homeTeam && game.homeTeam.school) || '';
+    const dateStr = new Date(game.startDate).toLocaleString();
+    const html = `\n    <div class="modal fade checkin-modal" id="checkinModal" tabindex="-1" aria-hidden="true">\n      <div class="modal-dialog modal-dialog-centered">\n        <div class="modal-content p-4 text-center">\n          <div class="modal-body">\n            <div class="d-flex align-items-center justify-content-between mb-3">\n              <div class="logo-wrapper">\n                <div class="team-logo-container mb-1"><img src="${awayLogo}" alt="${awayName}"></div>\n                <span class="team-name">${awayName}</span>\n              </div>\n              <div class="fs-3">@</div>\n              <div class="logo-wrapper">\n                <div class="team-logo-container mb-1"><img src="${homeLogo}" alt="${homeName}"></div>\n                <span class="team-name">${homeName}</span>\n              </div>\n            </div>\n            <div class="game-date mb-3">${dateStr}</div>\n            <button class="btn gradient-glass-btn w-100" id="confirmCheckin">Check In</button>\n          </div>\n        </div>\n      </div>\n    </div>\n    <div class="modal fade checkin-modal" id="checkinThanks" tabindex="-1" aria-hidden="true">\n      <div class="modal-dialog modal-dialog-centered">\n        <div class="modal-content p-3 text-center">\n          <div class="modal-body">Thank you for checking in!</div>\n        </div>\n      </div>\n    </div>`;
+    document.body.insertAdjacentHTML('beforeend', html);
+    const modalEl = document.getElementById('checkinModal');
+    const thanksEl = document.getElementById('checkinThanks');
+    const modal = new bootstrap.Modal(modalEl);
+    const thanks = new bootstrap.Modal(thanksEl);
+    modalEl.addEventListener('hidden.bs.modal', () => modalEl.remove());
+    thanksEl.addEventListener('hidden.bs.modal', () => thanksEl.remove());
+    modalEl.querySelector('#confirmCheckin').addEventListener('click', async function(){
+      try{
+        await fetch('/api/checkin',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({ gameId: game._id })
+        });
+      }catch(err){console.error(err);} 
+      modal.hide();
+      thanks.show();
+      setTimeout(()=>thanks.hide(), 2500);
+    });
+    modal.show();
+  }
+})();

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -37,3 +37,4 @@
 </div>
 <script src="/js/inboxModal.js"></script>
 <script>window.loggedInUser = <%- JSON.stringify(loggedInUser || null) %>;</script>
+<script src="/js/nearbyCheckin.js"></script>


### PR DESCRIPTION
## Summary
- add backend endpoints to look up nearby games and record check-ins
- implement client-side geolocation check that surfaces a check-in modal
- style check-in modal with existing gradient glass theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f62f8f6948326a1fd64146beeaceb