### PR TITLE
feat: add badge check-in modals

### DIFF
--- a/lib/badgeUtils.js
+++ b/lib/badgeUtils.js
@@ -5,4 +5,46 @@ function getBadgeStyleClass(badgeID) {
   return '';
 }
 
-module.exports = { getBadgeStyleClass };
+function computeBadgeProgress(badge, games) {
+  const eligible = games.filter(g => {
+    const homeTeam = g.homeTeam || {};
+    const awayTeam = g.awayTeam || {};
+    const leagueMatch = !badge.leagueConstraints?.length ||
+      badge.leagueConstraints.some(l => [homeTeam.leagueId, awayTeam.leagueId].map(String).includes(String(l)));
+    const teamMatch = !badge.teamConstraints?.length ||
+      badge.teamConstraints.some(t => {
+        if (badge.homeTeamOnly) return String(homeTeam._id) === String(t);
+        return [homeTeam._id, awayTeam._id].map(String).includes(String(t));
+      });
+    const confMatch = !badge.conferenceConstraints?.length ||
+      badge.conferenceConstraints.some(c => [homeTeam.conferenceId, awayTeam.conferenceId].map(String).includes(String(c)));
+    const startOk = !badge.startDate || g.startDate >= badge.startDate;
+    const endOk = !badge.endDate || g.startDate <= badge.endDate;
+    return leagueMatch && teamMatch && confMatch && startOk && endOk;
+  });
+
+  if (badge.oneTeamEach) {
+    const teamSet = new Set();
+    eligible.forEach(g => {
+      const homeTeam = g.homeTeam || {};
+      const awayTeam = g.awayTeam || {};
+      if (badge.teamConstraints && badge.teamConstraints.length) {
+        badge.teamConstraints.forEach(t => {
+          if (badge.homeTeamOnly) {
+            if (String(homeTeam._id) === String(t)) teamSet.add(String(t));
+          } else if ([String(homeTeam._id), String(awayTeam._id)].includes(String(t))) {
+            teamSet.add(String(t));
+          }
+        });
+      } else {
+        teamSet.add(String(homeTeam._id));
+        if (!badge.homeTeamOnly) teamSet.add(String(awayTeam._id));
+      }
+    });
+    return teamSet.size;
+  }
+
+  return eligible.length;
+}
+
+module.exports = { getBadgeStyleClass, computeBadgeProgress };

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1073,6 +1073,25 @@
   font-weight: bold;
 }
 
+.badge-card {
+  border: 2px solid transparent;
+  background-image: linear-gradient(white, white), linear-gradient(to right, #14b8a6, #7e22ce);
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  border-radius: 0.5rem;
+}
+
+.badge-label {
+  color: #fff;
+  font-weight: bold;
+  text-align: center;
+}
+
+.badge-complete-icon {
+  width: 20rem;
+  height: 20rem;
+  object-fit: contain;
+}
 .special-badge-container {
   position: relative;
   width: 7rem;

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -51,9 +51,45 @@
         <h3 class="mb-3"><%= game.awayTeamName %> @ <%= game.homeTeamName %></h3>
         <p class="mb-1">(<%= game.awayRecord || '0-0' %>) vs (<%= game.homeRecord || '0-0' %>)</p>
         <p class="mb-3"><%= game.venue %> - <%= venue && venue.city ? venue.city : '' %></p>
-        <form method="post" action="/games/<%= game._id %>/checkin" class="d-inline w-100">
-          <button type="submit" class="btn checkin-btn w-100">Check-In</button>
-        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Check-In Modal -->
+  <div class="modal fade checkin-modal" id="checkinModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content p-4 text-center">
+        <div class="team-diagonal-square mx-auto mb-3" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>">
+          <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);">
+            <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">
+          </div>
+          <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);">
+            <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
+          </div>
+        </div>
+        <button id="confirmCheckIn" class="btn btn-success fw-bold">Check In</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Badge Completed Modal -->
+  <div class="modal fade checkin-modal" id="badgeCompleteModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content p-4 text-center">
+        <img id="badgeCompleteImage" class="badge-complete-icon mb-3" alt="Completed Badge">
+        <h3 id="badgeCompleteTitle" class="fw-bold"></h3>
+        <button id="badgeNextBtn" class="btn gradient-glass-btn mt-3">Next</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Thank You Modal -->
+  <div class="modal fade checkin-modal" id="thankYouModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content p-4 text-center">
+        <h2 class="fw-bold">Thanks for checking in!</h2>
+        <div id="progressedBadgesContainer" class="d-flex flex-wrap gap-3 justify-content-center mt-3"></div>
+        <button type="button" class="btn gradient-glass-btn mt-3" data-bs-dismiss="modal">Close</button>
       </div>
     </div>
   </div>
@@ -63,6 +99,62 @@
     const startDate = new Date('<%= game.startDate.toISOString() %>');
     document.getElementById('gameStart').textContent =
       new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(startDate);
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const checkinModal = new bootstrap.Modal(document.getElementById('checkinModal'));
+      const badgeModal = new bootstrap.Modal(document.getElementById('badgeCompleteModal'));
+      const thankYouModal = new bootstrap.Modal(document.getElementById('thankYouModal'));
+      checkinModal.show();
+
+      document.getElementById('confirmCheckIn').addEventListener('click', async () => {
+        const res = await fetch('/api/checkin', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ gameId: '<%= game._id %>' })
+        });
+        const data = await res.json();
+        checkinModal.hide();
+        const completed = data.completedBadges || [];
+        const progressed = data.progressedBadges || [];
+
+        const showThankYou = () => {
+          const container = document.getElementById('progressedBadgesContainer');
+          container.innerHTML = '';
+          progressed.forEach(b => {
+            const card = document.createElement('div');
+            card.className = 'badge-card d-flex flex-column align-items-center p-2';
+            card.innerHTML = `<div class="badge-icon-container"><img src="${b.iconUrl}" alt="${b.badgeName}" class="badge-icon"></div><div class="badge-label mt-2">${b.badgeName}</div>`;
+            container.appendChild(card);
+          });
+          thankYouModal.show();
+        };
+
+        if (completed.length) {
+          let index = 0;
+          const img = document.getElementById('badgeCompleteImage');
+          const title = document.getElementById('badgeCompleteTitle');
+          const nextBtn = document.getElementById('badgeNextBtn');
+          const showBadge = () => {
+            const b = completed[index];
+            img.src = b.iconUrl;
+            title.textContent = b.badgeName;
+            badgeModal.show();
+          };
+          nextBtn.onclick = () => {
+            index++;
+            if (index < completed.length) {
+              showBadge();
+            } else {
+              badgeModal.hide();
+              showThankYou();
+            }
+          };
+          showBadge();
+        } else {
+          showThankYou();
+        }
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compute badge progress and return completed or progressed badges during API check-in
- show check-in, badge-complete, and thank-you modals on game page
- style badge icons and completion modal to match site motif

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f7da7d85883269bae116901e4042e