### PR TITLE
Centralize check-in flow with badge progress modal

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -381,7 +381,16 @@ exports.apiCheckIn = async (req, res, next) => {
       const progressBefore = computeBadgeProgress(badge, beforeGames);
       const progressAfter = computeBadgeProgress(badge, afterGames);
       if (progressAfter > progressBefore) {
-        const badgeInfo = { _id: badge._id, badgeName: badge.badgeName, iconUrl: badge.iconUrl };
+        const percent = Math.round((progressAfter / badge.reqGames) * 100);
+        const badgeInfo = {
+          _id: badge._id,
+          badgeName: badge.badgeName,
+          iconUrl: badge.iconUrl,
+          description: badge.description,
+          reqGames: badge.reqGames,
+          progress: progressAfter,
+          percent
+        };
         if (progressAfter >= badge.reqGames && progressBefore < badge.reqGames) {
           completedBadges.push(badgeInfo);
         } else {

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1217,3 +1217,23 @@
   line-height: 1.2;
   text-transform: uppercase;
 }
+
+/* Check-in badge celebration */
+.badge-celebrate {
+  animation: badgeGlow 1.5s ease-in-out infinite;
+}
+
+@keyframes badgeGlow {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 255, 255, 0.4);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.8);
+    transform: scale(1.05);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 255, 255, 0.4);
+    transform: scale(1);
+  }
+}

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -55,106 +55,11 @@
     </div>
   </div>
 
-  <!-- Check-In Modal -->
-  <div class="modal fade checkin-modal" id="checkinModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content p-4 text-center">
-        <div class="team-diagonal-square mx-auto mb-3" style="--homeColor:<%= homeBgColor %>; --awayColor:<%= awayBgColor %>">
-          <div class="triangle away-bg" style="background: var(--awayColor); clip-path: polygon(0 0, 100% 0, 0 100%);">
-            <img src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.awayTeamName %>" class="team-logo-detail away-logo">
-          </div>
-          <div class="triangle home-bg" style="background: var(--homeColor); clip-path: polygon(100% 0, 100% 100%, 0 100%);">
-            <img src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : 'https://via.placeholder.com/150' %>" alt="<%= game.homeTeamName %>" class="team-logo-detail home-logo">
-          </div>
-        </div>
-        <button id="confirmCheckIn" class="btn btn-success fw-bold">Check In</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Badge Completed Modal -->
-  <div class="modal fade checkin-modal" id="badgeCompleteModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content p-4 text-center">
-        <img id="badgeCompleteImage" class="badge-complete-icon mb-3" alt="Completed Badge">
-        <h3 id="badgeCompleteTitle" class="fw-bold"></h3>
-        <button id="badgeNextBtn" class="btn gradient-glass-btn mt-3">Next</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Thank You Modal -->
-  <div class="modal fade checkin-modal" id="thankYouModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content p-4 text-center">
-        <h2 class="fw-bold">Thanks for checking in!</h2>
-        <div id="progressedBadgesContainer" class="d-flex flex-wrap gap-3 justify-content-center mt-3"></div>
-        <button type="button" class="btn gradient-glass-btn mt-3" data-bs-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     const startDate = new Date('<%= game.startDate.toISOString() %>');
     document.getElementById('gameStart').textContent =
       new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(startDate);
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const checkinModal = new bootstrap.Modal(document.getElementById('checkinModal'));
-      const badgeModal = new bootstrap.Modal(document.getElementById('badgeCompleteModal'));
-      const thankYouModal = new bootstrap.Modal(document.getElementById('thankYouModal'));
-      checkinModal.show();
-
-      document.getElementById('confirmCheckIn').addEventListener('click', async () => {
-        const res = await fetch('/api/checkin', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ gameId: '<%= game._id %>' })
-        });
-        const data = await res.json();
-        checkinModal.hide();
-        const completed = data.completedBadges || [];
-        const progressed = data.progressedBadges || [];
-
-        const showThankYou = () => {
-          const container = document.getElementById('progressedBadgesContainer');
-          container.innerHTML = '';
-          progressed.forEach(b => {
-            const card = document.createElement('div');
-            card.className = 'badge-card d-flex flex-column align-items-center p-2';
-            card.innerHTML = `<div class="badge-icon-container"><img src="${b.iconUrl}" alt="${b.badgeName}" class="badge-icon"></div><div class="badge-label mt-2">${b.badgeName}</div>`;
-            container.appendChild(card);
-          });
-          thankYouModal.show();
-        };
-
-        if (completed.length) {
-          let index = 0;
-          const img = document.getElementById('badgeCompleteImage');
-          const title = document.getElementById('badgeCompleteTitle');
-          const nextBtn = document.getElementById('badgeNextBtn');
-          const showBadge = () => {
-            const b = completed[index];
-            img.src = b.iconUrl;
-            title.textContent = b.badgeName;
-            badgeModal.show();
-          };
-          nextBtn.onclick = () => {
-            index++;
-            if (index < completed.length) {
-              showBadge();
-            } else {
-              badgeModal.hide();
-              showThankYou();
-            }
-          };
-          showBadge();
-        } else {
-          showThankYou();
-        }
-      });
-    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove game-specific check-in modals and scripts from game view
- expand nearbyCheckin.js to handle check-ins with badge completion and progress modals
- extend backend check-in response with badge progress metadata and add badge celebration styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8a712804832692b577f15386b1e4