### PR TITLE
feat: add user points and badge rewards

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -19,6 +19,8 @@ const userSchema = new mongoose.Schema({
     gamesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }], default: [] },
     teamsList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Team' }], default: [] },
     venuesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Venue' }], default: [] },
+    badges: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Badge' }],
+    points: { type: Number, default: 0 },
     gameEntries: [{
         game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
         elo: Number,


### PR DESCRIPTION
## Summary
- track user points and earned badges on the User model
- award points for check-ins and newly completed badges
- include updated point totals in check-in responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fae0b53c48326912cba1c37e20498