### PR TITLE
style: revamp venue modal with unlockable stadium bubbles

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -317,6 +317,12 @@
   gap: 0.5rem;
 }
 
+#venuesModalBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 
 
 #conferenceBlock .stat-rows {
@@ -371,6 +377,22 @@
 }
 
 .unlocked-team img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.team-dot.locked-venue {
+  opacity: 0.3;
+  filter: grayscale(100%);
+}
+
+.team-dot.unlocked-venue {
+  box-shadow: 0 0 0 2px rgba(20,184,166,0.8), 0 0 6px rgba(126,34,206,0.6);
+}
+
+.team-dot.unlocked-venue img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -555,7 +577,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <div id="venuesModalBody" class="d-grid" style="grid-template-columns: 1fr 3fr 1fr; row-gap:0.5rem; column-gap:0.5rem;"></div>
+                    <div id="venuesModalBody"></div>
                 </div>
             </div>
         </div>
@@ -602,6 +624,8 @@
   const teamEntries = <%- JSON.stringify(teamEntries || []) %>;
   const venueEntries = <%- JSON.stringify(venueEntries || []) %>;
   const stateEntries = <%- JSON.stringify(stateEntries || []) %>;
+  const venuesList = <%- JSON.stringify(venuesList || []) %>;
+  const conferenceTeamMap = <%- JSON.stringify(conferenceTeamMap || {}) %>;
   const teamsCount = <%- typeof teamsCount !== 'undefined' ? teamsCount : 0 %>;
   const venuesCount = <%- typeof venuesCount !== 'undefined' ? venuesCount : 0 %>;
   const statesCount = <%- typeof statesCount !== 'undefined' ? statesCount : 0 %>;
@@ -647,6 +671,38 @@
         <div class="venue-name"><img src="${img}" alt="${name}" class="avatar avatar-sm"><p class="venue-name-text">${name}</p></div>
         <div class="venue-count">${item.count}</div>
       `;
+    }).join('');
+  }
+
+  function buildVenueModalRows() {
+    const venueByTeam = {};
+    (venuesList || []).forEach(v => {
+      if (v && v.team) {
+        const tid = typeof v.team === 'object' && v.team._id ? v.team._id : v.team;
+        venueByTeam[String(tid)] = v;
+      }
+    });
+
+    return Object.entries(conferenceTeamMap).map(([conf, teamIds]) => {
+      const dots = teamIds.map(tid => {
+        const ven = venueByTeam[String(tid)];
+        if (ven) {
+          const img = ven.imgUrl || '/images/stadium.png';
+          const name = ven.name || '';
+          return `<span class="team-dot unlocked-venue" title="${name}"><img src="${img}" alt="${name}"></span>`;
+        }
+        return '<span class="team-dot locked-venue"></span>';
+      }).join('');
+
+      const unlockedCount = teamIds.filter(tid => venueByTeam[String(tid)]).length;
+      const pct = Math.round((unlockedCount / teamIds.length) * 100);
+
+      return `
+        <div class="stat-row">
+          <div class="stat-name-col conference-name-text">${conf}</div>
+          <div class="stat-middle conference-dots-row">${dots}</div>
+          <div class="stat-percent-col conference-percentage-text">${pct}%</div>
+        </div>`;
     }).join('');
   }
 
@@ -798,7 +854,7 @@
     if (hVenues && mVenues) {
       hVenues.addEventListener('click', () => {
         const body = document.getElementById('venuesModalBody');
-        if (body) body.innerHTML = buildVenueRows(window.allRankedVenues || []);
+        if (body) body.innerHTML = buildVenueModalRows();
         bootstrap.Modal.getOrCreateInstance(mVenues).show();
       });
     }
@@ -958,7 +1014,7 @@
             venuesHeader.addEventListener('click', () => {
                 const body = document.getElementById('venuesModalBody');
                 if(body){
-                    body.innerHTML = buildVenueRows(window.allRankedVenues);
+                    body.innerHTML = buildVenueModalRows();
                 }
                 bootstrap.Modal.getOrCreateInstance(venuesModal).show();
             });


### PR DESCRIPTION
## Summary
- Show venue progress in modal with conference-grouped stadium bubbles
- Add styling for locked and unlocked venues with subtle glow
- Rewire modal to build bubble grid using venue data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8efe536dc8326a7ebbac9f6dd6079