### PR TITLE
Refactor profile stats layout for mobile responsiveness

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/css/custom.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-    <style>        @media
+    <style>
 
         #gamesModal, #teamsModal, #statesModal { color: #fff; }
         #gamesModal .gradient-text,
@@ -496,6 +496,82 @@
   transform: translateX(0); /* No need to center it since it's not 50% */
   background: linear-gradient(to bottom, #14b8a6, #7e22ce);
   z-index: 1;
+}
+
+@media screen and (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .stat-block {
+    min-height: auto;
+  }
+
+  .stat-content {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+  }
+
+  .stat-left {
+    margin-bottom: 0;
+  }
+
+  .stat-right {
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem 0;
+  }
+
+  .stat-right .stat-row {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .stat-number {
+    font-size: 3rem;
+  }
+
+  .stat-label {
+    font-size: 1.1rem;
+  }
+
+  .top-list-item {
+    font-size: 1.2rem;
+  }
+
+  .top-list-item img,
+  .game-logo-sm,
+  .team-logo {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .venue-name-text {
+    font-size: 0.9rem;
+  }
+
+  .venue-count,
+  .game-rank,
+  .game-rating {
+    font-size: 1.25rem;
+  }
+
+  #teamsTop,
+  #statesTop {
+    flex-direction: column;
+  }
+
+  .team-stat-col,
+  .state-stat-col {
+    width: 100%;
+    max-width: 100%;
+  }
 }
 
     </style>


### PR DESCRIPTION
## Summary
- Add mobile-specific media query to `profileStats.ejs`
- Stack stat blocks vertically and scale typography and icons below 768px
- Remove stray `@media` token from style block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af5145282c8326bb496c26d680c14c