### PR TITLE
Refactor profile stats layout for mobile responsiveness

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/css/custom.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-    <style>        @media
+    <style>
 
         #gamesModal, #teamsModal, #statesModal { color: #fff; }
         #gamesModal .gradient-text,
@@ -498,6 +498,91 @@
   z-index: 1;
 }
 
+@media screen and (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .stat-block {
+    min-height: auto;
+  }
+
+  .stat-content {
+    gap: 0.75rem;
+  }
+  .stat-right {
+    width: 100%;
+    padding: 0.5rem;
+  }
+
+  .stat-right .stat-row {
+    gap: 0.25rem;
+  }
+
+  .stat-number {
+    font-size: 3rem;
+  }
+
+  .stat-label {
+    font-size: 1.1rem;
+  }
+
+  .top-list-item {
+    font-size: 1.2rem;
+  }
+
+  .top-list-item img,
+  .game-logo-sm,
+  .team-logo {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .venue-name-text {
+    font-size: 0.9rem;
+  }
+
+  .venue-count,
+  .game-rank,
+  .game-rating {
+    font-size: 1.25rem;
+  }
+
+  #teamsTop,
+  #statesTop {
+    flex-direction: column;
+  }
+
+  .team-stat-col,
+  .state-stat-col {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  #gamesTop .game-matchup .d-flex {
+    flex-wrap: nowrap !important;
+  }
+
+  #gamesTop .game-logo-sm {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  #conferenceBlock .conference-name-text {
+    font-size: 1.125rem;
+  }
+
+  #conferenceBlock .team-dot {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  #conferenceBlock .conference-percentage-text {
+    font-size: 0.9rem;
+  }
+}
+
     </style>
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -815,6 +900,7 @@
   }
 
   function renderStats() {
+    const gradientDirection = window.innerWidth < 768 ? 'to bottom' : 'to right';
     // Games
     const validGames = [];
     const seenGameIds = new Set();
@@ -860,7 +946,7 @@
       return c;
     });
     if(colors.length){
-      teamsTopEl.style.background = `linear-gradient(to right, ${colors.join(',')})`;
+      teamsTopEl.style.background = `linear-gradient(${gradientDirection}, ${colors.join(',')})`;
       teamsTopEl.style.borderRadius = '0.5rem';
     }
     teamsTopEl.innerHTML = topTeams.map(item => {
@@ -886,9 +972,9 @@
       statesTopEl.innerHTML = '';
     } else {
       let gradient;
-      if (stateEntries.length === 1) gradient = 'linear-gradient(to right, #FFD700, white)';
-      else if (stateEntries.length === 2) gradient = 'linear-gradient(to right, #FFD700, #C0C0C0, white)';
-      else gradient = 'linear-gradient(to right, #FFD700, #C0C0C0, #CD7F32)';
+      if (stateEntries.length === 1) gradient = `linear-gradient(${gradientDirection}, #FFD700, white)`;
+      else if (stateEntries.length === 2) gradient = `linear-gradient(${gradientDirection}, #FFD700, #C0C0C0, white)`;
+      else gradient = `linear-gradient(${gradientDirection}, #FFD700, #C0C0C0, #CD7F32)`;
       statesTopEl.style.background = gradient;
       statesTopEl.innerHTML = stateEntries.slice(0, 3).map(s => `
         <div class="state-stat-col">


### PR DESCRIPTION
## Summary
- Keep stat-left and stat-right horizontally aligned on mobile
- Scale stat contents without centering for screens under 768px
- Switch team and state gradients to vertical orientation on mobile
- Shrink game matchup logos and prevent wrapping on narrow screens
- Reduce conference name font sizes by half for better mobile fit
- Halve conference team dot and percentage sizes in mobile view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5145282c8326bb496c26d680c14c