### PR TITLE
Refactor check-in flow to use gameEntries with checked-in flag

### DIFF
--- a/main.js
+++ b/main.js
@@ -282,7 +282,9 @@ app.get('/team/:id', async (req, res) => {
     }
 
     const gameIds = games.map(g => g._id);
-    const usersCheckedIn = await User.countDocuments({ gamesList: { $in: gameIds } });
+    const usersCheckedIn = await User.countDocuments({
+        gameEntries: { $elemMatch: { game: { $in: gameIds }, checkedIn: true } }
+    });
 
     const relevantBadges = await Badge.find({
         $or: [

--- a/migrateGamesList.js
+++ b/migrateGamesList.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+const User = require('./models/users');
+require('dotenv').config();
+
+async function migrate(){
+  await mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/sportsapp');
+  const users = await User.find({ gamesList: { $exists: true, $not: { $size: 0 } } });
+  for (const user of users) {
+    const existing = new Set((user.gameEntries || []).map(e => String(e.game)));
+    let changed = false;
+    for (const g of user.gamesList) {
+      const id = String(g);
+      if (!existing.has(id)) {
+        user.gameEntries.push({ game: g, checkedIn: true });
+        changed = true;
+      }
+    }
+    if (changed) {
+      user.gamesList = [];
+      await user.save();
+      console.log(`Migrated user ${user._id}`);
+    }
+  }
+  await mongoose.disconnect();
+}
+
+migrate().then(()=>{console.log('Migration complete');}).catch(err=>{console.error(err); process.exit(1);});

--- a/models/users.js
+++ b/models/users.js
@@ -25,7 +25,8 @@ const userSchema = new mongoose.Schema({
         game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
         elo: Number,
         comment: String,
-        image: String
+        image: String,
+        checkedIn: { type: Boolean, default: false }
     }],
     profileImage: {
         data: Buffer,


### PR DESCRIPTION
## Summary
- add `checkedIn` flag to `gameEntries` subdocuments
- route check-ins through `gameEntries` and calculate badge progress from checked in games
- compute badge progress on profile badges and team views using `gameEntries`
- provide one-time migration script for legacy `gamesList`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af68538ea88326aa15d6d8229d4161