### PR TITLE
Preserve user progress across game lifecycle

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -6,6 +6,7 @@ const User = require('../models/users');
 const mongoose = require('mongoose');
 const Badge = require('../models/Badge');
 const { computeBadgeProgress, formatBadgeForClient } = require('../lib/badgeUtils');
+const { fetchGamesByIds } = require('../lib/gameUtils');
 
 function hexToRgb(hex) {
   if (!hex) return null;
@@ -366,20 +367,37 @@ exports.apiCheckIn = async (req, res, next) => {
     if (!user) return res.status(404).json({ error: 'User not found' });
 
     user.badges = user.badges || [];
+    user.gamesList = user.gamesList || [];
 
     const gameMongoId = String(gameDoc._id);
+    const gameIdStr = String(gameDoc.gameId);
+
     const alreadyEntry = user.gameEntries.find(e => String(e.game?._id || e.game) === gameMongoId && e.checkedIn);
+    const alreadyInGames = user.gamesList.includes(gameIdStr);
 
-    const beforeGames = user.gameEntries
+    // Track games/venues/teams for profile and badge progress
+    const beforeIds = [...user.gamesList];
+    if (!alreadyInGames) user.gamesList.push(gameIdStr);
 
-      .filter(e => e.checkedIn && e.game)
+    if (gameDoc.venueId != null) {
+      const venueDoc = await Venue.findOne({ venueId: gameDoc.venueId }).select('_id');
+      if (venueDoc) {
+        const venueExists = user.venuesList.some(v => String(v) === String(venueDoc._id));
+        if (!venueExists) user.venuesList.push(venueDoc._id);
+      }
+    }
+    const homeId = gameDoc.homeTeam?._id;
+    const awayId = gameDoc.awayTeam?._id;
+    if (homeId && !user.teamsList.some(t => String(t) === String(homeId))) user.teamsList.push(homeId);
+    if (awayId && !user.teamsList.some(t => String(t) === String(awayId))) user.teamsList.push(awayId);
 
-      .map(e => e.game);
     if (!alreadyEntry) {
       user.gameEntries.push({ game: gameDoc._id, checkedIn: true });
       user.points = (user.points || 0) + 225;
     }
-    const afterGames = alreadyEntry ? beforeGames : [...beforeGames, gameDoc];
+
+    const beforeGames = await fetchGamesByIds(beforeIds);
+    const afterGames = alreadyInGames ? beforeGames : [...beforeGames, gameDoc];
 
     // Load badges (lean), convert buffer icons, attach style + progress
     const badges = await Badge.find().lean();
@@ -436,20 +454,39 @@ exports.checkIn = async (req, res, next) => {
     const user = await User.findById(req.user.id)
       .populate({ path: 'gameEntries.game', populate: [{ path: 'homeTeam' }, { path: 'awayTeam' }] });
     const hasEntry = user && user.gameEntries.some(e => String(e.game?._id || e.game) === String(gameDoc._id) && e.checkedIn);
-    if (user && !hasEntry) {
-      const beforeGames = user.gameEntries
 
-        .filter(e => e.checkedIn && e.game)
+    if (user) {
+      user.gamesList = user.gamesList || [];
+      const gameIdStr = String(gameDoc.gameId);
+      const alreadyInGames = user.gamesList.includes(gameIdStr);
+      const beforeIds = [...user.gamesList];
+      if (!alreadyInGames) user.gamesList.push(gameIdStr);
 
-        .map(e => e.game);
-      user.gameEntries.push({ game: gameDoc._id, checkedIn: true });
-      user.points = (user.points || 0) + 225;
+      if (gameDoc.venueId != null) {
+        const venueDoc = await Venue.findOne({ venueId: gameDoc.venueId }).select('_id');
+        if (venueDoc) {
+          const venueExists = user.venuesList.some(v => String(v) === String(venueDoc._id));
+          if (!venueExists) user.venuesList.push(venueDoc._id);
+        }
+      }
+      const homeId = gameDoc.homeTeam?._id;
+      const awayId = gameDoc.awayTeam?._id;
+      if (homeId && !user.teamsList.some(t => String(t) === String(homeId))) user.teamsList.push(homeId);
+      if (awayId && !user.teamsList.some(t => String(t) === String(awayId))) user.teamsList.push(awayId);
+
+      if (!hasEntry) {
+        user.gameEntries.push({ game: gameDoc._id, checkedIn: true });
+        user.points = (user.points || 0) + 225;
+      }
+
+      const beforeGames = await fetchGamesByIds(beforeIds);
+      const afterGames = alreadyInGames ? beforeGames : [...beforeGames, gameDoc];
+
       user.badges = user.badges || [];
-
       const badges = await Badge.find().lean();
       for (const badge of badges) {
         const progressBefore = computeBadgeProgress(badge, beforeGames);
-        const progressAfter = computeBadgeProgress(badge, [...beforeGames, gameDoc]);
+        const progressAfter = computeBadgeProgress(badge, afterGames);
         if (progressAfter > progressBefore && progressAfter >= (badge.reqGames || 0) && progressBefore < (badge.reqGames || 0)) {
           const alreadyEarned = user.badges.some(id => String(id) === String(badge._id));
           if (!alreadyEarned) {
@@ -460,6 +497,7 @@ exports.checkIn = async (req, res, next) => {
       }
       await user.save();
     }
+
     res.redirect(`/games/${gameDoc._id}`);
   } catch (err) {
     console.error('[checkin] checkIn error', err);

--- a/lib/gameUtils.js
+++ b/lib/gameUtils.js
@@ -1,0 +1,57 @@
+const Game = require('../models/Game');
+const PastGame = require('../models/PastGame');
+const Team = require('../models/Team');
+const Venue = require('../models/Venue');
+
+/**
+ * Fetch games by their permanent gameIds from both the `Game` and `PastGame`
+ * collections. Returned documents are lean and have `homeTeam`, `awayTeam`, and
+ * `venue` populated when possible so they can be used by badge/stat logic.
+ */
+async function fetchGamesByIds(ids = []) {
+  if (!Array.isArray(ids) || !ids.length) return [];
+  const numericIds = ids.map(id => Number(id)).filter(n => !isNaN(n));
+  if (!numericIds.length) return [];
+
+  // Lookup active games first
+  let games = await Game.find({ gameId: { $in: numericIds } })
+    .populate('homeTeam')
+    .populate('awayTeam')
+    .lean();
+
+  const foundIds = new Set(games.map(g => g.gameId));
+  const missing = numericIds.filter(id => !foundIds.has(id));
+
+  if (missing.length) {
+    let pastGames = await PastGame.find({ gameId: { $in: missing } }).lean();
+    if (pastGames.length) {
+      const teamIds = [...new Set(pastGames.flatMap(pg => [pg.HomeId, pg.AwayId]))];
+      const teams = await Team.find({ teamId: { $in: teamIds } })
+        .select('teamId logos color alternateColor leagueId conferenceId')
+        .lean();
+      const teamMap = {};
+      teams.forEach(t => { teamMap[t.teamId] = t; });
+
+      const venueIds = [...new Set(pastGames.map(pg => pg.VenueId).filter(v => v !== undefined))];
+      const venues = await Venue.find({ venueId: { $in: venueIds } }).lean();
+      const venueMap = {};
+      venues.forEach(v => { venueMap[v.venueId] = v; });
+
+      pastGames = pastGames.map(pg => ({
+        ...pg,
+        homeTeam: teamMap[pg.HomeId] || null,
+        awayTeam: teamMap[pg.AwayId] || null,
+        venue: venueMap[pg.VenueId] || null,
+        startDate: pg.StartDate,
+        homeTeamName: pg.HomeTeam,
+        awayTeamName: pg.AwayTeam
+      }));
+
+      games = games.concat(pastGames);
+    }
+  }
+
+  return games;
+}
+
+module.exports = { fetchGamesByIds };

--- a/models/PastGame.js
+++ b/models/PastGame.js
@@ -1,6 +1,9 @@
 const mongoose = require('mongoose');
 
 const pastGameSchema = new mongoose.Schema({
+  // Preserve original `Id` but introduce `gameId` as the canonical key so
+  // current and past games can be referenced uniformly.
+  gameId: { type: Number, required: true, unique: true },
   Id: { type: Number, required: true, unique: true },
   Season: { type: Number, required: true },
   Week: { type: Number, required: true },

--- a/models/users.js
+++ b/models/users.js
@@ -16,7 +16,10 @@ const userSchema = new mongoose.Schema({
     following: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     newFollowers: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     wishlist: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }],
-    gamesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Game' }], default: [] },
+    // Track game check-ins using the permanent gameId. Using strings allows us to
+    // reference games after they migrate from the `Game` collection to
+    // `PastGame` without losing the association.
+    gamesList: { type: [String], default: [] },
     teamsList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Team' }], default: [] },
     venuesList: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Venue' }], default: [] },
     badges: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Badge' }],

--- a/pastGameScheduler.js
+++ b/pastGameScheduler.js
@@ -51,6 +51,13 @@ async function ensureIndexes(db) {
     console.warn('[indexes] Id unique index:', e.message);
   }
 
+  // Ensure new canonical gameId index exists
+  try {
+    await past.createIndex({ gameId: 1 }, { unique: true });
+  } catch (e) {
+    console.warn('[indexes] gameId unique index:', e.message);
+  }
+
   try {
     await games.createIndex({ startDate: 1 });
   } catch (e) {
@@ -64,7 +71,8 @@ async function ensureIndexes(db) {
  */
 function buildPastGameDoc(gameDoc, homeMeta, awayMeta) {
   return {
-    Id: numOrNull(gameDoc.gameId),                 // required & unique
+    gameId: numOrNull(gameDoc.gameId),             // permanent key
+    Id: numOrNull(gameDoc.gameId),                 // legacy key (kept for compat)
     Season: numOrNull(gameDoc.season),             // required
     Week: numOrNull(gameDoc.week),                 // required
     SeasonType: gameDoc.seasonType ?? null,        // required (string)

--- a/validateUserGames.js
+++ b/validateUserGames.js
@@ -1,0 +1,35 @@
+const db = require('./db');
+const User = require('./models/users');
+const Game = require('./models/Game');
+const PastGame = require('./models/PastGame');
+
+/**
+ * Fallback validator that ensures every gameId in each user's gamesList exists
+ * in either the `Game` or `PastGame` collections. Logs any missing ids so they
+ * can be investigated separately.
+ */
+async function validate() {
+  try {
+    const users = await User.find({}).select('username gamesList').lean();
+    for (const u of users) {
+      const ids = (u.gamesList || []).map(id => Number(id)).filter(n => !isNaN(n));
+      if (!ids.length) continue;
+
+      const [live, past] = await Promise.all([
+        Game.find({ gameId: { $in: ids } }).select('gameId').lean(),
+        PastGame.find({ gameId: { $in: ids } }).select('gameId').lean()
+      ]);
+      const found = new Set([...live, ...past].map(g => String(g.gameId)));
+      const missing = ids.filter(id => !found.has(String(id)));
+      if (missing.length) {
+        console.warn(`User ${u.username} has missing gameIds: ${missing.join(', ')}`);
+      }
+    }
+  } catch (err) {
+    console.error('validateUserGames error', err);
+  } finally {
+    db.close();
+  }
+}
+
+db.once('open', validate);


### PR DESCRIPTION
## Summary
- Track checked-in games by permanent `gameId` and persist associated venues and teams
- Migrate games to past collection while keeping stable `gameId` with indexing
- Add helpers and validators for cross-collection lookups and user list integrity
- Fix venue tracking by looking up `Venue` documents before adding to user progress

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e88a4154832699be6a34ecfd6580