### PR TITLE
Fix badge progress to include past games

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -371,10 +371,11 @@ exports.profileBadges = async (req, res, next) => {
             return b;
         });
 
-        const games = (profileUser.gameEntries || [])
-            .filter(e => e.checkedIn)
-            .map(e => e.game)
-            .filter(Boolean);
+        // Gather all checked-in games using the permanent gameIds stored on
+        // the user. This allows badge progress to account for games that have
+        // moved from `Game` to `PastGame` collections.
+        const gameIds = profileUser.gamesList || [];
+        const games = await fetchGamesByIds(gameIds);
 
         const userProgress = {};
         badges.forEach(badge => {

--- a/lib/gameUtils.js
+++ b/lib/gameUtils.js
@@ -4,54 +4,55 @@ const Team = require('../models/Team');
 const Venue = require('../models/Venue');
 
 /**
- * Fetch games by their permanent gameIds from both the `Game` and `PastGame`
- * collections. Returned documents are lean and have `homeTeam`, `awayTeam`, and
+ * Fetch a single game by its permanent `gameId`. The lookup will search the
+ * `Game` collection first and then fall back to the `PastGame` collection if
+ * necessary. Returned documents are lean and have `homeTeam`, `awayTeam`, and
  * `venue` populated when possible so they can be used by badge/stat logic.
  */
-async function fetchGamesByIds(ids = []) {
-  if (!Array.isArray(ids) || !ids.length) return [];
-  const numericIds = ids.map(id => Number(id)).filter(n => !isNaN(n));
-  if (!numericIds.length) return [];
+async function getGameById(gameId) {
+  const numericId = Number(gameId);
+  if (!Number.isFinite(numericId)) return null;
 
-  // Lookup active games first
-  let games = await Game.find({ gameId: { $in: numericIds } })
+  // Try to find an active/upcoming game first
+  let game = await Game.findOne({ gameId: numericId })
     .populate('homeTeam')
     .populate('awayTeam')
     .lean();
+  if (game) return game;
 
-  const foundIds = new Set(games.map(g => g.gameId));
-  const missing = numericIds.filter(id => !foundIds.has(id));
+  // Fallback to past games
+  const pg = await PastGame.findOne({ gameId: numericId }).lean();
+  if (!pg) return null;
 
-  if (missing.length) {
-    let pastGames = await PastGame.find({ gameId: { $in: missing } }).lean();
-    if (pastGames.length) {
-      const teamIds = [...new Set(pastGames.flatMap(pg => [pg.HomeId, pg.AwayId]))];
-      const teams = await Team.find({ teamId: { $in: teamIds } })
-        .select('teamId logos color alternateColor leagueId conferenceId')
-        .lean();
-      const teamMap = {};
-      teams.forEach(t => { teamMap[t.teamId] = t; });
+  const [teams, venue] = await Promise.all([
+    Team.find({ teamId: { $in: [pg.HomeId, pg.AwayId].filter(Boolean) } })
+      .select('teamId logos color alternateColor leagueId conferenceId')
+      .lean(),
+    pg.VenueId ? Venue.findOne({ venueId: pg.VenueId }).lean() : Promise.resolve(null)
+  ]);
 
-      const venueIds = [...new Set(pastGames.map(pg => pg.VenueId).filter(v => v !== undefined))];
-      const venues = await Venue.find({ venueId: { $in: venueIds } }).lean();
-      const venueMap = {};
-      venues.forEach(v => { venueMap[v.venueId] = v; });
+  const teamMap = {};
+  teams.forEach(t => { teamMap[t.teamId] = t; });
 
-      pastGames = pastGames.map(pg => ({
-        ...pg,
-        homeTeam: teamMap[pg.HomeId] || null,
-        awayTeam: teamMap[pg.AwayId] || null,
-        venue: venueMap[pg.VenueId] || null,
-        startDate: pg.StartDate,
-        homeTeamName: pg.HomeTeam,
-        awayTeamName: pg.AwayTeam
-      }));
-
-      games = games.concat(pastGames);
-    }
-  }
-
-  return games;
+  return {
+    ...pg,
+    homeTeam: teamMap[pg.HomeId] || null,
+    awayTeam: teamMap[pg.AwayId] || null,
+    venue: venue || null,
+    startDate: pg.StartDate,
+    homeTeamName: pg.HomeTeam,
+    awayTeamName: pg.AwayTeam
+  };
 }
 
-module.exports = { fetchGamesByIds };
+/**
+ * Fetch multiple games by their `gameId`s. Uses `getGameById` under the hood
+ * and resolves lookups in parallel via `Promise.all`.
+ */
+async function fetchGamesByIds(ids = []) {
+  if (!Array.isArray(ids) || !ids.length) return [];
+  const games = await Promise.all(ids.map(id => getGameById(id)));
+  return games.filter(Boolean);
+}
+
+module.exports = { fetchGamesByIds, getGameById };

--- a/models/PastGame.js
+++ b/models/PastGame.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const pastGameSchema = new mongoose.Schema({
   // Preserve original `Id` but introduce `gameId` as the canonical key so
   // current and past games can be referenced uniformly.
-  gameId: { type: Number, required: true, unique: true },
+  gameId: { type: Number, required: true, unique: true, sparse: true },
   Id: { type: Number, required: true, unique: true },
   Season: { type: Number, required: true },
   Week: { type: Number, required: true },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interactive social sporting event app",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"No tests defined\" && exit 0",
+    "test": "node --test",
     "start": "nodemon main.js",
     "seed": "node importCsv.js"
   },

--- a/tests/gameUtils.test.js
+++ b/tests/gameUtils.test.js
@@ -1,0 +1,75 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getGameById } = require('../lib/gameUtils');
+const { computeBadgeProgress } = require('../lib/badgeUtils');
+const Game = require('../models/Game');
+const PastGame = require('../models/PastGame');
+const Team = require('../models/Team');
+const Venue = require('../models/Venue');
+
+// Helper to create a mongoose-like query chain
+function mockQuery(result) {
+  return {
+    populate() { return this; },
+    select() { return this; },
+    lean() { return Promise.resolve(result); }
+  };
+}
+
+// Helper to restore original mongoose methods after each test
+function withMocks(mocks, fn) {
+  return async () => {
+    const originals = mocks.map(([obj, method]) => [obj, method, obj[method]]);
+    mocks.forEach(([obj, method, impl]) => { obj[method] = impl; });
+    try {
+      await fn();
+    } finally {
+      originals.forEach(([obj, method, orig]) => { obj[method] = orig; });
+    }
+  };
+}
+
+test('getGameById returns active game', withMocks([
+  [Game, 'findOne', () => mockQuery({ gameId: 1, homeTeam: { _id: 'h' }, awayTeam: { _id: 'a' } })],
+  [PastGame, 'findOne', () => mockQuery(null)]
+], async () => {
+  const game = await getGameById(1);
+  assert.equal(game.gameId, 1);
+  assert.equal(game.homeTeam._id, 'h');
+}));
+
+test('getGameById falls back to past games', withMocks([
+  [Game, 'findOne', () => mockQuery(null)],
+  [PastGame, 'findOne', () => mockQuery({
+    gameId: 2,
+    HomeId: 10,
+    AwayId: 20,
+    VenueId: 5,
+    StartDate: new Date('2023-01-01'),
+    HomeTeam: 'Home',
+    AwayTeam: 'Away'
+  })],
+  [Team, 'find', () => mockQuery([
+    { teamId: 10, _id: 'T10', leagueId: 1, conferenceId: 1 },
+    { teamId: 20, _id: 'T20', leagueId: 1, conferenceId: 2 }
+  ])],
+  [Venue, 'findOne', () => ({ lean: () => Promise.resolve({ venueId: 5, _id: 'V5' }) })]
+], async () => {
+  const game = await getGameById(2);
+  assert.equal(game.gameId, 2);
+  assert.equal(game.homeTeam._id, 'T10');
+  assert.equal(game.awayTeam._id, 'T20');
+  assert.equal(game.venue._id, 'V5');
+  assert.ok(game.startDate instanceof Date);
+}));
+
+test('computeBadgeProgress counts games from both sources', async () => {
+  const games = [
+    { homeTeam: { _id: 'T10', leagueId: 1, conferenceId: 1 }, awayTeam: { _id: 'T20', leagueId: 1, conferenceId: 2 }, startDate: new Date('2023-01-01') },
+    { homeTeam: { _id: 'T10', leagueId: 1, conferenceId: 1 }, awayTeam: { _id: 'T30', leagueId: 1, conferenceId: 2 }, startDate: new Date('2023-01-02') }
+  ];
+  const badge = { reqGames: 2, teamConstraints: ['T10'], homeTeamOnly: true };
+  const progress = computeBadgeProgress(badge, games);
+  assert.equal(progress, 2);
+});


### PR DESCRIPTION
## Summary
- add `getGameById` utility that checks both current and past game collections
- compute profile badge progress using all gameIds via `fetchGamesByIds`
- add unit tests for game lookup and badge progress across present and past games
- make past games `gameId` unique index sparse to avoid duplicate key errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb17ad1bc88326ad07a52ce4ae11fe