### PR TITLE
Set ratingPrompted flag when ELO provided on new game entries

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -388,7 +388,9 @@ exports.apiCheckIn = async (req, res, next) => {
     if (awayId && !user.teamsList.some(t => String(t) === String(awayId))) user.teamsList.push(awayId);
 
     if (!alreadyEntry) {
-      user.gameEntries.push({ gameId: gameIdStr, checkedIn: true, elo: null, comment: null });
+      const newEntry = { gameId: gameIdStr, checkedIn: true, elo: null, comment: null };
+      if (newEntry.elo != null) newEntry.ratingPrompted = true;
+      user.gameEntries.push(newEntry);
       user.points = (user.points || 0) + 225;
     }
 
@@ -468,7 +470,9 @@ exports.checkIn = async (req, res, next) => {
       if (awayId && !user.teamsList.some(t => String(t) === String(awayId))) user.teamsList.push(awayId);
 
       if (!hasEntry) {
-        user.gameEntries.push({ gameId: gameIdStr, checkedIn: true, elo: null, comment: null });
+        const newEntry = { gameId: gameIdStr, checkedIn: true, elo: null, comment: null };
+        if (newEntry.elo != null) newEntry.ratingPrompted = true;
+        user.gameEntries.push(newEntry);
         user.points = (user.points || 0) + 225;
       }
 
@@ -544,7 +548,9 @@ exports.toggleGameList = async (req, res, next) => {
       entry.checkedIn = !entry.checkedIn;
       action = entry.checkedIn ? 'added' : 'removed';
     } else {
-      user.gameEntries.push({ gameId: gameIdStr, checkedIn: true, elo: null, comment: null });
+      const newEntry = { gameId: gameIdStr, checkedIn: true, elo: null, comment: null };
+      if (newEntry.elo != null) newEntry.ratingPrompted = true;
+      user.gameEntries.push(newEntry);
       action = 'added';
     }
     await user.save();

--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -934,6 +934,9 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
         }
 
         entry.elo = finalElo;
+        if (entry.elo != null) {
+            entry.ratingPrompted = true;
+        }
 
         const newEloEntry = {
             game: newGameObjectId,

--- a/models/users.js
+++ b/models/users.js
@@ -29,7 +29,12 @@ const userSchema = new mongoose.Schema({
         comment: String,
         image: String,
         checkedIn: { type: Boolean, default: false },
-        ratingPrompted: { type: Boolean, default: false }
+        // Automatically flag entries as having been prompted for a rating
+        // whenever an initial elo value is present at creation time
+        ratingPrompted: {
+            type: Boolean,
+            default: function() { return this.elo != null; }
+        }
     }],
     profileImage: {
         data: Buffer,


### PR DESCRIPTION
## Summary
- Auto-set `ratingPrompted` to true in `gameEntries` when an ELO rating is provided at creation
- Apply rating flagging in check-in flows, manual additions, and list toggles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb36983a58832681f25f13050aa162