### PR TITLE
Add social page showing yesterday's most checked-in game

### DIFF
--- a/controllers/socialController.js
+++ b/controllers/socialController.js
@@ -1,0 +1,63 @@
+const PastGame = require('../models/PastGame');
+const User = require('../models/users');
+const Team = require('../models/Team');
+
+exports.showMostCheckedIn = async (req, res, next) => {
+  try {
+    const now = new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const startOfYesterday = new Date(startOfToday);
+    startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+
+    const pastGames = await PastGame.find({
+      StartDate: { $gte: startOfYesterday, $lt: startOfToday }
+    }).lean();
+
+    if (!pastGames.length) {
+      return res.render('social', { pastgame: null, count: 0, homeLogo: '', awayLogo: '', homeColor: '#ffffff', awayColor: '#ffffff' });
+    }
+
+    const ids = pastGames.map(g => String(g.gameId));
+
+    const checkins = await User.aggregate([
+      { $unwind: '$gameEntries' },
+      { $match: { 'gameEntries.checkedIn': true, 'gameEntries.gameId': { $in: ids } } },
+      { $group: { _id: '$gameEntries.gameId', users: { $addToSet: '$_id' } } },
+      { $project: { count: { $size: '$users' } } }
+    ]);
+
+    const countMap = {};
+    checkins.forEach(c => { countMap[c._id] = c.count; });
+
+    let selected = pastGames[0];
+    let max = 0;
+    pastGames.forEach(g => {
+      const c = countMap[String(g.gameId)] || 0;
+      if (c > max) {
+        max = c;
+        selected = g;
+      }
+    });
+
+    const [homeTeam, awayTeam] = await Promise.all([
+      Team.findOne({ teamId: selected.HomeId }).lean(),
+      Team.findOne({ teamId: selected.AwayId }).lean()
+    ]);
+
+    const homeLogo = homeTeam && homeTeam.logos && homeTeam.logos[0] ? homeTeam.logos[0] : 'https://via.placeholder.com/60';
+    const awayLogo = awayTeam && awayTeam.logos && awayTeam.logos[0] ? awayTeam.logos[0] : 'https://via.placeholder.com/60';
+    const homeColor = homeTeam && homeTeam.color ? homeTeam.color : '#ffffff';
+    const awayColor = awayTeam && awayTeam.color ? awayTeam.color : '#ffffff';
+
+    res.render('social', {
+      pastgame: selected,
+      count: max,
+      homeLogo,
+      awayLogo,
+      homeColor,
+      awayColor
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const express = require("express"),
     messagesController = require('./controllers/messagesController'),
     comparisonController = require('./controllers/comparisonController'),
     badgeController = require('./controllers/badgeController'),
+    socialController = require('./controllers/socialController'),
     Message = require('./models/Message'),
     User = require('./models/users'),
     Team = require('./models/Team'),
@@ -282,6 +283,7 @@ app.get('/about', requireAuth, homeController.showAbout);
 app.get('/projects', requireAuth, projectsController.getProjects);
 app.get('/newProject', requireAuth, projectsController.getNewProject);
 
+app.get('/social', socialController.showMostCheckedIn);
 app.get('/games', gamesController.listGames);
 app.get('/teams/search', gamesController.searchTeams);
 app.get('/games/searchGames', gamesController.searchGames);

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -7,7 +7,7 @@
       <li>
         <a href="/games" class="text-decoration-none px-3 py-1 rounded-pill <%= currentPath.startsWith('/games') ? 'bg-primary text-white' : 'text-body' %>">Games</a>
       </li>
-      <li><a href="#" class="text-decoration-none px-3 py-1 rounded <%= currentPath.startsWith('/social') ? 'bg-primary text-white' : 'text-body' %>">Social</a></li>
+      <li><a href="/social" class="text-decoration-none px-3 py-1 rounded-pill <%= currentPath.startsWith('/social') ? 'bg-primary text-white' : 'text-body' %>">Social</a></li>
       
     </ul>
     <div class="text-nowrap d-flex align-items-center">

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Social</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/custom.css">
+</head>
+<body class="d-flex flex-column min-vh-100 gradient-bg">
+  <%- include('partials/header') %>
+  <div class="container my-4 flex-grow-1">
+    <h1 class="text-center text-white fw-bold mb-4">Most Checked-In Game Yesterday</h1>
+    <% if (pastgame) { %>
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="position-relative">
+          <a href="/pastGames/<%= pastgame._id %>" class="game-link">
+            <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+              <div class="game-date mb-2" data-start="<%= pastgame.StartDate.toISOString() %>"></div>
+              <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                <div class="logo-wrapper me-3">
+                  <div class="team-logo-container">
+                    <img loading="lazy" src="<%= awayLogo %>" alt="<%= pastgame.AwayTeam %>">
+                  </div>
+                  <span class="team-name"><%= pastgame.AwayTeam %></span>
+                </div>
+                <div class="logo-wrapper ms-3">
+                  <div class="team-logo-container">
+                    <img loading="lazy" src="<%= homeLogo %>" alt="<%= pastgame.HomeTeam %>">
+                  </div>
+                  <span class="team-name"><%= pastgame.HomeTeam %></span>
+                </div>
+                <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
+              </div>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+    <p class="text-center text-white fw-bold mt-4"><%= count %> users checked into <%= pastgame.AwayTeam %> vs <%= pastgame.HomeTeam %></p>
+    <% } else { %>
+    <p class="text-center text-white fw-bold">No past games found for yesterday.</p>
+    <% } %>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    function formatDates(){
+      document.querySelectorAll('.game-date[data-start]').forEach(function(el){
+        var date = new Date(el.dataset.start);
+        el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+      });
+    }
+    function hexToRgb(hex){
+      if(!hex) return [255,255,255];
+      hex = hex.replace('#','');
+      if(hex.length===3) hex = hex.split('').map(c=>c+c).join('');
+      const num = parseInt(hex,16);
+      return [(num>>16)&255,(num>>8)&255,num&255];
+    }
+    function luminance(r,g,b){
+      const a=[r,g,b].map(v=>{
+        v/=255;
+        return v<=0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4);
+      });
+      return 0.2126*a[0] + 0.7152*a[1] + 0.0722*a[2];
+    }
+    function chooseTextColor(colors){
+      const lums = colors.map(c=>{
+        const [r,g,b] = hexToRgb(c);
+        return luminance(r,g,b);
+      });
+      const avg = lums.reduce((a,b)=>a+b,0)/lums.length;
+      return avg > 0.5 ? '#333333' : '#ffffff';
+    }
+    function applyTextColors(){
+      document.querySelectorAll('.game-card').forEach(card=>{
+        const away = card.dataset.awayColor;
+        const home = card.dataset.homeColor;
+        const textColor = chooseTextColor([away, home]);
+        card.querySelectorAll('.game-date, .team-name').forEach(el=>{
+          el.style.color = textColor;
+        });
+      });
+    }
+    function adjustTeamNames(){
+      document.querySelectorAll('.team-name').forEach(el=>{
+        el.style.fontSize = '';
+        let size = parseFloat(getComputedStyle(el).fontSize);
+        while(el.scrollWidth > el.clientWidth && size > 10){
+          size -= 0.5;
+          el.style.fontSize = size + 'px';
+        }
+      });
+    }
+    formatDates();
+    applyTextColors();
+    adjustTeamNames();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/social` route and controller to compute yesterday's most checked-in game
- Introduce `social.ejs` with gradient background and game card display
- Link new social page from the top navigation bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c46fc13abc8326a3a1374936b7caa7