### PR TITLE
Add social timeline feed

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -384,6 +384,38 @@
     flex: 0 0 45%;
 }
 
+/* Social timeline */
+.timeline-wrapper {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.timeline-event {
+  border: 2px solid transparent;
+  border-radius: 0.75rem;
+  background:
+    linear-gradient(#ffffff,#ffffff) padding-box,
+    linear-gradient(to right,#14b8a6,#7e22ce) border-box;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  color: #fff;
+  font-weight: 700;
+}
+
+.timeline-event .timestamp {
+  font-size: 0.85rem;
+}
+
+.timeline-event .plain-card {
+  background: #ffffff;
+}
+
+.timeline-event .plain-card .game-date,
+.timeline-event .plain-card .team-name,
+.timeline-event .plain-card .at-symbol {
+  color: #000 !important;
+}
+
 /* Game detail page */
 .team-diagonal-square {
     position: relative;

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -44,61 +44,116 @@
 
     <% } else { %>
     <p class="text-center text-white fw-bold">No past games found for yesterday.</p>
-    <% } %>
-  </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <script>
-    function formatDates(){
-      document.querySelectorAll('.game-date[data-start]').forEach(function(el){
-        var date = new Date(el.dataset.start);
-        el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
-      });
-    }
-    function hexToRgb(hex){
-      if(!hex) return [255,255,255];
-      hex = hex.replace('#','');
-      if(hex.length===3) hex = hex.split('').map(c=>c+c).join('');
-      const num = parseInt(hex,16);
-      return [(num>>16)&255,(num>>8)&255,num&255];
-    }
-    function luminance(r,g,b){
-      const a=[r,g,b].map(v=>{
-        v/=255;
-        return v<=0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4);
-      });
-      return 0.2126*a[0] + 0.7152*a[1] + 0.0722*a[2];
-    }
-    function chooseTextColor(colors){
-      const lums = colors.map(c=>{
-        const [r,g,b] = hexToRgb(c);
-        return luminance(r,g,b);
-      });
-      const avg = lums.reduce((a,b)=>a+b,0)/lums.length;
-      return avg > 0.5 ? '#333333' : '#ffffff';
-    }
-    function applyTextColors(){
-      document.querySelectorAll('.game-card').forEach(card=>{
-        const away = card.dataset.awayColor;
-        const home = card.dataset.homeColor;
-        const textColor = chooseTextColor([away, home]);
-        card.querySelectorAll('.game-date, .team-name').forEach(el=>{
-          el.style.color = textColor;
+      <% } %>
+
+      <div class="timeline-wrapper mt-5">
+        <% if (events && events.length) { %>
+          <% events.forEach(function(ev){ %>
+            <div class="timeline-event">
+              <% if(ev.type === 'checkin' || ev.type === 'fanMilestone'){ %>
+                <div class="d-flex align-items-center mb-2">
+                  <img src="/users/<%= ev.user._id %>/profile-image" alt="<%= ev.user.username %>" class="avatar avatar-sm me-2">
+                  <span class="me-auto"><%= ev.user.username %></span>
+                  <span class="timestamp"><%= new Date(ev.timestamp).toLocaleString() %></span>
+                </div>
+                <div class="text-center mb-2">
+                  <% if(ev.type === 'checkin'){ %>
+                    Has checked into a game
+                  <% } else { %>
+                    Was the <%= ev.ordinal %> fan to check in
+                  <% } %>
+                </div>
+              <% } else if(ev.type === 'gameMilestone'){ %>
+                <div class="d-flex justify-content-end mb-2">
+                  <span class="timestamp"><%= new Date(ev.timestamp).toLocaleString() %></span>
+                </div>
+                <div class="text-center mb-2">
+                  <%= ev.milestone %> fans have checked in, it ranks <%= ev.rank %> today
+                </div>
+              <% } %>
+              <div>
+                <a href="/pastGames/<%= ev.game._id %>" class="game-link">
+                  <div class="card shadow-sm h-100 game-card plain-card p-3 text-center position-relative">
+                    <div class="game-date mb-2" data-start="<%= ev.game.StartDate.toISOString() %>"></div>
+                    <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                      <div class="logo-wrapper me-3">
+                        <div class="team-logo-container">
+                          <img loading="lazy" src="<%= ev.awayLogo %>" alt="<%= ev.game.AwayTeam %>">
+                        </div>
+                        <span class="team-name"><%= ev.game.AwayTeam %></span>
+                      </div>
+                      <div class="logo-wrapper ms-3">
+                        <div class="team-logo-container">
+                          <img loading="lazy" src="<%= ev.homeLogo %>" alt="<%= ev.game.HomeTeam %>">
+                        </div>
+                        <span class="team-name"><%= ev.game.HomeTeam %></span>
+                      </div>
+                      <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol" style="color:#000">@</div>
+                    </div>
+                  </div>
+                </a>
+              </div>
+            </div>
+          <% }); %>
+        <% } else { %>
+          <p class="text-center text-white fw-bold">No recent activity.</p>
+        <% } %>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      function formatDates(){
+        document.querySelectorAll('.game-date[data-start]').forEach(function(el){
+          var date = new Date(el.dataset.start);
+          el.textContent = new Intl.DateTimeFormat(navigator.language, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
         });
-      });
-    }
-    function adjustTeamNames(){
-      document.querySelectorAll('.team-name').forEach(el=>{
-        el.style.fontSize = '';
-        let size = parseFloat(getComputedStyle(el).fontSize);
-        while(el.scrollWidth > el.clientWidth && size > 10){
-          size -= 0.5;
-          el.style.fontSize = size + 'px';
-        }
-      });
-    }
-    formatDates();
-    applyTextColors();
-    adjustTeamNames();
-  </script>
+      }
+      function hexToRgb(hex){
+        if(!hex) return [255,255,255];
+        hex = hex.replace('#','');
+        if(hex.length===3) hex = hex.split('').map(c=>c+c).join('');
+        const num = parseInt(hex,16);
+        return [(num>>16)&255,(num>>8)&255,num&255];
+      }
+      function luminance(r,g,b){
+        const a=[r,g,b].map(v=>{
+          v/=255;
+          return v<=0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4);
+        });
+        return 0.2126*a[0] + 0.7152*a[1] + 0.0722*a[2];
+      }
+      function chooseTextColor(colors){
+        const lums = colors.map(c=>{
+          const [r,g,b] = hexToRgb(c);
+          return luminance(r,g,b);
+        });
+        const avg = lums.reduce((a,b)=>a+b,0)/lums.length;
+        return avg > 0.5 ? '#333333' : '#ffffff';
+      }
+      function applyTextColors(){
+        document.querySelectorAll('.game-card').forEach(card=>{
+          if(card.classList.contains('plain-card')) return;
+          const away = card.dataset.awayColor;
+          const home = card.dataset.homeColor;
+          const textColor = chooseTextColor([away, home]);
+          card.querySelectorAll('.game-date, .team-name').forEach(el=>{
+            el.style.color = textColor;
+          });
+        });
+      }
+      function adjustTeamNames(){
+        document.querySelectorAll('.team-name').forEach(el=>{
+          el.style.fontSize = '';
+          let size = parseFloat(getComputedStyle(el).fontSize);
+          while(el.scrollWidth > el.clientWidth && size > 10){
+            size -= 0.5;
+            el.style.fontSize = size + 'px';
+          }
+        });
+      }
+      formatDates();
+      applyTextColors();
+      adjustTeamNames();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build timeline events in social controller for follow check-ins, fan milestones, and game milestones
- render scrollable timeline on social page with plain game cards
- style timeline containers with gradient borders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47b6da7c88326aaa3758dad8a6519