### PR TITLE
Style social feed cards with gradient text and full width

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -386,8 +386,6 @@
 
 /* Social timeline */
 .timeline-wrapper {
-  max-height: 60vh;
-  overflow-y: auto;
 }
 
 .timeline-event {
@@ -398,7 +396,6 @@
     linear-gradient(to right,#14b8a6,#7e22ce) border-box;
   padding: 1rem;
   margin-bottom: 1rem;
-  color: #fff;
   font-weight: 700;
 }
 
@@ -410,10 +407,11 @@
   background: #ffffff;
 }
 
-.timeline-event .plain-card .game-date,
-.timeline-event .plain-card .team-name,
-.timeline-event .plain-card .at-symbol {
-  color: #000 !important;
+.timeline-event *:not(.game-card):not(img) {
+  background-image: linear-gradient(to right,#14b8a6,#7e22ce);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 /* Game detail page */

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -46,7 +46,8 @@
     <p class="text-center text-white fw-bold">No past games found for yesterday.</p>
       <% } %>
 
-      <div class="timeline-wrapper mt-5">
+      <div class="row justify-content-center mt-5">
+        <div class="col-md-6 timeline-wrapper">
         <% if (events && events.length) { %>
           <% events.forEach(function(ev){ %>
             <div class="timeline-event">
@@ -88,7 +89,7 @@
                         </div>
                         <span class="team-name"><%= ev.game.HomeTeam %></span>
                       </div>
-                      <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol" style="color:#000">@</div>
+                      <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
                     </div>
                   </div>
                 </a>
@@ -98,6 +99,7 @@
         <% } else { %>
           <p class="text-center text-white fw-bold">No recent activity.</p>
         <% } %>
+        </div>
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Give social feed cards full-width layout matching the highlighted game section
- Remove restrictive timeline height to allow natural page scrolling
- Apply teal-purple gradient text to all feed content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c48766b46c8326815cc92ffa98134c