### PR TITLE
Align social feed cards with games styling

### DIFF
--- a/views/social.ejs
+++ b/views/social.ejs
@@ -72,9 +72,9 @@
                   <%= ev.milestone %> fans have checked in, it ranks <%= ev.rank %> today
                 </div>
               <% } %>
-              <div>
+              <div class="position-relative">
                 <a href="/pastGames/<%= ev.game._id %>" class="game-link">
-                  <div class="card shadow-sm h-100 game-card plain-card p-3 text-center position-relative">
+                  <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= ev.awayColor %>" data-home-color="<%= ev.homeColor %>" style="background: linear-gradient(to right, <%= ev.awayColor %>, <%= ev.homeColor %>);">
                     <div class="game-date mb-2" data-start="<%= ev.game.StartDate.toISOString() %>"></div>
                     <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                       <div class="logo-wrapper me-3">


### PR DESCRIPTION
## Summary
- include team colors alongside logos when building social timeline events
- render timeline game cards with the same gradient styling as the games page cards

## Testing
- npm test --silent *(fails: missing dev dependency mongoose in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd837b6d988326af1a5d83b90fa829