### PR TITLE
Align social feed cards with games styling

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -407,11 +407,15 @@
   background: #ffffff;
 }
 
-.timeline-event *:not(.game-card):not(img) {
+.timeline-event *:not(.game-card):not(img):not(.at-symbol) {
   background-image: linear-gradient(to right,#14b8a6,#7e22ce);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+}
+
+.timeline-description {
+  font-size: 1.5em;
 }
 
 /* Game detail page */

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -57,7 +57,7 @@
                   <span class="me-auto"><%= ev.user.username %></span>
                   <span class="timestamp"><%= new Date(ev.timestamp).toLocaleString() %></span>
                 </div>
-                <div class="text-center mb-2">
+                <div class="text-center mb-2 timeline-description">
                   <% if(ev.type === 'checkin'){ %>
                     Has checked into a game
                   <% } else { %>
@@ -68,13 +68,13 @@
                 <div class="d-flex justify-content-end mb-2">
                   <span class="timestamp"><%= new Date(ev.timestamp).toLocaleString() %></span>
                 </div>
-                <div class="text-center mb-2">
+                <div class="text-center mb-2 timeline-description">
                   <%= ev.milestone %> fans have checked in, it ranks <%= ev.rank %> today
                 </div>
               <% } %>
-              <div>
+              <div class="position-relative">
                 <a href="/pastGames/<%= ev.game._id %>" class="game-link">
-                  <div class="card shadow-sm h-100 game-card plain-card p-3 text-center position-relative">
+                  <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= ev.awayColor %>" data-home-color="<%= ev.homeColor %>" style="background: linear-gradient(to right, <%= ev.awayColor %>, <%= ev.homeColor %>);">
                     <div class="game-date mb-2" data-start="<%= ev.game.StartDate.toISOString() %>"></div>
                     <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                       <div class="logo-wrapper me-3">


### PR DESCRIPTION
## Summary
- include team colors alongside logos when building social timeline events
- render timeline game cards with the same gradient styling as the games page cards
- enlarge social timeline descriptions and ensure the matchup separator uses a white "@" symbol

## Testing
- npm test --silent


------
https://chatgpt.com/codex/tasks/task_e_68cd837b6d988326af1a5d83b90fa829