### PR TITLE
Group profile badges into prioritized buckets

### DIFF
--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -227,17 +227,7 @@
         </div>
     </div>
 
-    <% if (badges && badges.length) { 
-        const completed = [], inProgress = [], untouched = [];
-        badges.forEach(b => {
-            const progress = userProgress[b.badgeID] || 0;
-            if (progress >= b.reqGames) completed.push(b);
-            else if (progress > 0) inProgress.push(b);
-            else untouched.push(b);
-        });
-        untouched.sort(() => Math.random() - 0.5);
-        const sortedBadges = [...completed, ...inProgress, ...untouched];
-    %>
+    <% if (sortedBadges && sortedBadges.length) { %>
 
     <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4" id="badgeGrid">
         <% sortedBadges.forEach(function(badge, index) {


### PR DESCRIPTION
## Summary
- compute badge progress buckets on the server and sort them by completion, percent progress, or random order as required
- surface the ordered badge collections to the profile badges view and render them in the new prioritized order

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd94c5a1448326990e3a8495922a85