### PR TITLE
Add profile links to social usernames

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -6,6 +6,18 @@
     display: block;
 }
 
+.username-link {
+    color: transparent;
+    background: linear-gradient(to right, #7e22ce, #14b8a6);
+    -webkit-background-clip: text;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.username-link:hover {
+    text-decoration: underline;
+}
+
 /* profile icon in navigation bar */
 .nav-profile-icon {
     border-radius: 50%;

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -54,7 +54,7 @@
               <% if(ev.type === 'checkin' || ev.type === 'fanMilestone'){ %>
                 <div class="d-flex align-items-center mb-2">
                   <img src="/users/<%= ev.user._id %>/profile-image" alt="<%= ev.user.username %>" class="avatar avatar-sm me-2">
-                  <span class="me-auto"><%= ev.user.username %></span>
+                  <a href="/user/<%= ev.user.venmo %>" class="me-auto username-link">@<%= ev.user.username %></a>
                   <span class="timestamp"><%= new Date(ev.timestamp).toLocaleString() %></span>
                 </div>
                 <div class="text-center mb-2 timeline-description">


### PR DESCRIPTION
## Summary
- wrap social timeline usernames in profile links prefixed with `@`
- add a gradient text style for the new username link class to match existing theming

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd976d29b483268f9627c67f786693