### PR TITLE
Fix social username links to use user ids

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -6,6 +6,18 @@
     display: block;
 }
 
+.username-link {
+    color: transparent;
+    background: linear-gradient(to right, #7e22ce, #14b8a6);
+    -webkit-background-clip: text;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.username-link:hover {
+    text-decoration: underline;
+}
+
 /* profile icon in navigation bar */
 .nav-profile-icon {
     border-radius: 50%;

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -54,7 +54,7 @@
               <% if(ev.type === 'checkin' || ev.type === 'fanMilestone'){ %>
                 <div class="d-flex align-items-center mb-2">
                   <img src="/users/<%= ev.user._id %>/profile-image" alt="<%= ev.user.username %>" class="avatar avatar-sm me-2">
-                  <span class="me-auto"><%= ev.user.username %></span>
+                  <a href="/users/<%= ev.user._id %>" class="me-auto username-link">@<%= ev.user.username %></a>
                   <span class="timestamp"><%= new Date(ev.timestamp).toLocaleString() %></span>
                 </div>
                 <div class="text-center mb-2 timeline-description">


### PR DESCRIPTION
## Summary
- point social timeline username links to each member's `/users/:id` profile route to avoid blank `/user/` destinations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd976d29b483268f9627c67f786693