### PR TITLE
Refine checked-in profile game highlight

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -197,6 +197,40 @@
     color: inherit;
     text-decoration: none;
   }
+
+.game-container {
+    border-radius: 0.75rem;
+    padding: 0.5rem;
+}
+
+.checked-in-border {
+    border: 3px solid transparent;
+    border-radius: 0.75rem;
+    border-image: linear-gradient(130deg, #8a6d1d, #f6e27a, #cfa12f, #fff3b0, #8a6d1d) 1;
+    box-shadow: 0 0 10px rgba(212, 175, 55, 0.35), 0 0 0 3px rgba(249, 242, 149, 0.25) inset;
+    animation: metallic-glimmer 2s ease-in-out infinite;
+}
+
+.checked-in-status {
+    display: inline-flex;
+    align-items: center;
+}
+
+.checked-in-status i {
+    font-size: 1.1rem;
+}
+
+@keyframes metallic-glimmer {
+    0% {
+        box-shadow: 0 0 6px rgba(249, 240, 145, 0.25), 0 0 0 3px rgba(215, 170, 57, 0.18) inset;
+    }
+    50% {
+        box-shadow: 0 0 16px rgba(249, 240, 145, 0.55), 0 0 0 3px rgba(215, 170, 57, 0.32) inset;
+    }
+    100% {
+        box-shadow: 0 0 6px rgba(249, 240, 145, 0.25), 0 0 0 3px rgba(215, 170, 57, 0.18) inset;
+    }
+}
   
   
 

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -147,57 +147,65 @@
                  const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
                  const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
             <div class="col">
-                <div class="game-date-banner mb-1 d-flex align-items-center">
-                    <% const dateObj = new Date(game.startDate || game.StartDate); %>
-                    <span><%= (dateObj.getMonth() + 1).toString().padStart(2, '0') %>/<%= dateObj.getDate().toString().padStart(2, '0') %>/<%= dateObj.getFullYear() %></span>
-                    <% if(isCurrentUser){ %>
-                        <i class="bi bi-pencil-square ms-2 text-black edit-entry-icon" role="button" data-entry-id="<%= entry._id %>"></i>
-                        <i class="bi bi-trash ms-2 text-black delete-entry-icon" role="button" data-entry-id="<%= entry._id %>"></i>
-                    <% } %>
-                </div>
-                <div class="d-flex align-items-center">
-                    <div class="position-relative flex-grow-1">
-                        <a href="<%= usePastGameLinks ? '/pastGames/' + game._id : '/games/' + game._id %>" class="game-link d-block">
-                            <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-                                <div class="venue-overlay"><%= game.Venue || game.venue %></div>
-                                <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
-                                    <div class="logo-wrapper me-3">
-                                        <div class="team-logo-container">
-                                            <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
-                                        </div>
-                                        <span class="team-name"><%= game.awayTeamName %></span>
-                                    </div>
-                                    <div class="logo-wrapper ms-3">
-                                        <div class="team-logo-container">
-                                            <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
-                                        </div>
-                                        <span class="team-name"><%= game.homeTeamName %></span>
-                                    </div>
-                                    <div class="position-absolute top-50 start-50 translate-middle fw-bold score-text text-white"><%= game.AwayPoints %> – <%= game.HomePoints %></div>
-                                </div>
-                            </div>
-                        </a>
+                <div class="game-container">
+                    <div class="game-date-banner mb-1 d-flex align-items-center">
+                        <% const dateObj = new Date(game.startDate || game.StartDate); %>
+                        <span><%= (dateObj.getMonth() + 1).toString().padStart(2, '0') %>/<%= dateObj.getDate().toString().padStart(2, '0') %>/<%= dateObj.getFullYear() %></span>
+                        <% if (entry.checkedIn) { %>
+                            <span class="checked-in-status ms-2" title="Checked in">
+                                <i class="bi bi-check-circle-fill text-black" aria-hidden="true"></i>
+                                <span class="visually-hidden">Checked in</span>
+                            </span>
+                        <% } %>
+                        <% if(isCurrentUser){ %>
+                            <i class="bi bi-pencil-square ms-2 text-black edit-entry-icon" role="button" data-entry-id="<%= entry._id %>"></i>
+                            <i class="bi bi-trash ms-2 text-black delete-entry-icon" role="button" data-entry-id="<%= entry._id %>"></i>
+                        <% } %>
                     </div>
-                    <%
-  const gameId = String(game._id);
-  const eloEntry = (eloGames || []).find(e => {
-    const entryId = String(e.game && (e.game._id || e.game)); // Handle ObjectId vs populated object
-    return entryId === gameId;
-  });
-
-  
-
-  if (eloEntry && typeof eloEntry.elo === 'number') {
-    const elo = eloEntry.elo;
-    const rawScore = ((elo - 1000) / 1000) * 9 + 1;
-    const normalizedRating = Math.max(1.0, Math.min(10.0, Math.round(rawScore * 10) / 10));
-%>
-                        <div class="rating-wrapper gradient-overlay" data-entry-id="<%= entry._id %>">
-                            <img class="bw-img" src="<%= game.venue && game.venue.imgUrl ? game.venue.imgUrl : '/images/stadium.png' %>" alt="<%= game.Venue || game.venue %>">
-                            <span class="rating-number"><%= normalizedRating %>/10</span>
-                            <% if(entry.comment){ %><span class="rating-comment"><%= entry.comment %></span><% } %>
+                    <div class="d-flex align-items-center">
+                        <div class="position-relative flex-grow-1">
+                            <a href="<%= usePastGameLinks ? '/pastGames/' + game._id : '/games/' + game._id %>" class="game-link d-block">
+                                <div class="card shadow-sm h-100 game-card p-3 text-center position-relative <%= entry.checkedIn ? 'checked-in-border' : '' %>" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                                    <div class="venue-overlay"><%= game.Venue || game.venue %></div>
+                                    <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
+                                        <div class="logo-wrapper me-3">
+                                            <div class="team-logo-container">
+                                                <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
+                                            </div>
+                                            <span class="team-name"><%= game.awayTeamName %></span>
+                                        </div>
+                                        <div class="logo-wrapper ms-3">
+                                            <div class="team-logo-container">
+                                                <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
+                                            </div>
+                                            <span class="team-name"><%= game.homeTeamName %></span>
+                                        </div>
+                                        <div class="position-absolute top-50 start-50 translate-middle fw-bold score-text text-white"><%= game.AwayPoints %> – <%= game.HomePoints %></div>
+                                    </div>
+                                </div>
+                            </a>
                         </div>
-                    <% } %>
+                        <%
+      const gameId = String(game._id);
+      const eloEntry = (eloGames || []).find(e => {
+        const entryId = String(e.game && (e.game._id || e.game)); // Handle ObjectId vs populated object
+        return entryId === gameId;
+      });
+    
+      
+    
+      if (eloEntry && typeof eloEntry.elo === 'number') {
+        const elo = eloEntry.elo;
+        const rawScore = ((elo - 1000) / 1000) * 9 + 1;
+        const normalizedRating = Math.max(1.0, Math.min(10.0, Math.round(rawScore * 10) / 10));
+    %>
+                            <div class="rating-wrapper gradient-overlay" data-entry-id="<%= entry._id %>">
+                                <img class="bw-img" src="<%= game.venue && game.venue.imgUrl ? game.venue.imgUrl : '/images/stadium.png' %>" alt="<%= game.Venue || game.venue %>">
+                                <span class="rating-number"><%= normalizedRating %>/10</span>
+                                <% if(entry.comment){ %><span class="rating-comment"><%= entry.comment %></span><% } %>
+                            </div>
+                        <% } %>
+                    </div>
                 </div>
             </div>
             <% }); %>


### PR DESCRIPTION
## Summary
- keep the checked-in highlight on profile games but constrain the special class to the matchup card itself
- retune the glitter animation to a richer metallic gold palette for better visual emphasis
- show a black check-circle indicator beside the game date whenever the entry is checked in

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdaf04ef808326b1d883ddbd97fcd2