### PR TITLE
Fix game check-in count

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -198,7 +198,22 @@ exports.showGame = async (req, res, next) => {
       followerWishers = (viewer.followers || []).filter(u => (u.wishlist || []).some(w => String(w) === String(game._id)));
     }
 
-    res.render('game', { game, homeBgColor, awayBgColor, followerWishers, venue });
+    const gameIdCandidates = [];
+    if (game.gameId != null) {
+      gameIdCandidates.push(String(game.gameId));
+    }
+    gameIdCandidates.push(String(game._id));
+
+    const usersCheckedIn = await User.countDocuments({
+      gameEntries: {
+        $elemMatch: {
+          checkedIn: true,
+          gameId: gameIdCandidates.length === 1 ? gameIdCandidates[0] : { $in: gameIdCandidates }
+        }
+      }
+    });
+
+    res.render('game', { game, homeBgColor, awayBgColor, followerWishers, venue, usersCheckedIn });
   } catch (err) {
     next(err);
   }

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -51,6 +51,9 @@
         <h3 class="mb-3"><%= game.awayTeamName %> @ <%= game.homeTeamName %></h3>
         <p class="mb-1">(<%= game.awayRecord || '0-0' %>) vs (<%= game.homeRecord || '0-0' %>)</p>
         <p class="mb-3"><%= game.venue %> - <%= venue && venue.city ? venue.city : '' %></p>
+        <div class="checked-in-count badge bg-light text-dark fs-6 px-3 py-2">
+          <%= usersCheckedIn %> <%= usersCheckedIn === 1 ? 'User' : 'Users' %> Checked In
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- count checked-in users for a game by querying user gameEntries with the permanent gameId
- display the resulting check-in total on the game detail view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdba59b958832694be7ed0d41cda45