### PR TITLE
Add showcase page for profile game entries

### DIFF
--- a/main.js
+++ b/main.js
@@ -241,6 +241,7 @@ app.get('/logout', (req, res) => {
 app.get('/thanks', requireAuth, (req, res) => { res.redirect('/profileBadges/' + req.user.id); });
 app.get('/profile', requireAuth, (req, res) => { res.redirect('/profileBadges/' + req.user.id); });
 app.get('/profileBadges/:user?', requireAuth, profileController.profileBadges);
+app.get('/profileGames/:user/:gameEntry', requireAuth, profileController.profileGameShowcase);
 app.get('/profileGames/:user?', requireAuth, profileController.profileGames);
 app.get('/profileStats/:user?', requireAuth, profileController.profileStats);
 app.get('/profileWaitlist/:user?', requireAuth, profileController.profileWaitlist);

--- a/views/gameEntryShowcase.ejs
+++ b/views/gameEntryShowcase.ejs
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Game Entry Showcase</title>
+  <style>
+    body {
+      background: linear-gradient(to right, #14b8a6, #7e22ce);
+      color: white;
+      font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem 1rem;
+    }
+
+    .showcase-wrapper {
+      width: 100%;
+      max-width: 1100px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
+    .back-link {
+      align-self: flex-start;
+      color: #f8fafc;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: opacity 0.2s ease;
+    }
+
+    .back-link:hover {
+      opacity: 0.8;
+    }
+
+    .frame-container {
+      aspect-ratio: 16 / 9;
+      width: 100%;
+      position: relative;
+      background: black;
+      background-image: url('<%= entry && entry.image ? entry.image : "/images/placeholder.jpg" %>');
+      background-size: cover;
+      background-position: center;
+      filter: grayscale(100%);
+      border-radius: 16px;
+      overflow: hidden;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+    }
+
+    .frame-container::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(20, 184, 166, 0.65), rgba(126, 34, 206, 0.75));
+      mix-blend-mode: screen;
+      opacity: 0.85;
+    }
+
+    .info-box {
+      background: white;
+      width: min(90%, 800px);
+      padding: 2.5rem clamp(1.5rem, 4vw, 3rem);
+      border-radius: 1.25rem;
+      box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+      text-align: center;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      z-index: 1;
+    }
+
+    .user-logo {
+      position: absolute;
+      top: 1.5rem;
+      left: 1.5rem;
+      height: 3.4rem;
+      width: 3.4rem;
+      border-radius: 50%;
+      object-fit: cover;
+      border: 2px solid rgba(20, 184, 166, 0.6);
+    }
+
+    .elo-circle {
+      position: absolute;
+      top: 1.5rem;
+      right: 1.5rem;
+      height: 3.4rem;
+      width: 3.4rem;
+      border-radius: 50%;
+      border: 3px solid transparent;
+      background: linear-gradient(#fff, #fff) padding-box,
+                  linear-gradient(135deg, #14b8a6, #7e22ce) border-box;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-weight: 800;
+      font-size: 1.25rem;
+      color: transparent;
+      background-clip: text;
+      -webkit-background-clip: text;
+    }
+
+    .rating-line {
+      height: 3px;
+      width: 100%;
+      background: linear-gradient(to right, #14b8a6, #7e22ce);
+      border-radius: 999px;
+      opacity: 0.85;
+    }
+
+    .rating-number {
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      font-weight: 800;
+      color: transparent;
+      background: linear-gradient(to right, #14b8a6, #7e22ce);
+      -webkit-background-clip: text;
+      background-clip: text;
+    }
+
+    .game-meta {
+      color: #0f172a;
+      font-weight: 600;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.85rem;
+    }
+
+    .game-meta span {
+      color: rgba(15, 23, 42, 0.7);
+      font-weight: 500;
+      letter-spacing: normal;
+      text-transform: none;
+    }
+
+    .game-title {
+      font-size: clamp(1.6rem, 4vw, 2.4rem);
+      color: #0f172a;
+      margin: 0;
+      font-weight: 800;
+    }
+
+    .comment {
+      color: rgba(15, 23, 42, 0.72);
+      font-size: 1rem;
+      line-height: 1.6;
+      max-width: 32rem;
+    }
+
+    .empty-state {
+      background: rgba(15, 23, 42, 0.18);
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      border-radius: 1rem;
+      padding: 2rem;
+      text-align: center;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+    }
+
+    .empty-state h2 {
+      margin-bottom: 0.75rem;
+      font-size: 1.9rem;
+      letter-spacing: 0.04em;
+    }
+
+    .empty-state p {
+      margin: 0 0 1.25rem;
+      color: rgba(241, 245, 249, 0.85);
+      font-size: 1.05rem;
+    }
+
+    @media (max-width: 768px) {
+      .info-box {
+        padding: 2rem 1.5rem;
+      }
+
+      .user-logo,
+      .elo-circle {
+        position: static;
+        margin-bottom: 0.75rem;
+      }
+
+      .info-box {
+        align-items: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <% const profileSlug = user ? (user.venmo || user._id) : null; %>
+  <% const backHref = profileSlug ? `/profileGames/${profileSlug}` : '/profileGames'; %>
+
+  <div class="showcase-wrapper">
+    <a class="back-link" href="<%= backHref %>">← Back to profile games</a>
+
+    <% if (!entry) { %>
+      <div class="empty-state">
+        <h2>Game entry not found</h2>
+        <p>The showcase you're looking for doesn't exist or may have been removed.</p>
+        <a class="back-link" href="<%= backHref %>">Return to profile</a>
+      </div>
+    <% } else { %>
+      <div class="frame-container"></div>
+      <div class="info-box">
+        <% if (profileImageUrl) { %>
+          <img src="<%= profileImageUrl %>" alt="User avatar" class="user-logo">
+        <% } %>
+
+        <% if (entry.elo != null) { %>
+          <div class="elo-circle"><%= Math.round(entry.elo / 150) %></div>
+        <% } else { %>
+          <div class="elo-circle">?</div>
+        <% } %>
+
+        <% if (gameDetails) { %>
+          <p class="game-meta">
+            <strong>Matchup</strong>
+            <span><%= gameDetails.awayTeamName || 'Away' %> @ <%= gameDetails.homeTeamName || 'Home' %></span>
+            <% if (gameDetails.startDate || gameDetails.StartDate) { %>
+              <% const showcaseDate = new Date(gameDetails.startDate || gameDetails.StartDate); %>
+              <span><%= showcaseDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) %></span>
+            <% } %>
+          </p>
+        <% } %>
+
+        <h1 class="game-title"><%= entry.title || entry.gameTitle || 'Game Highlight' %></h1>
+
+        <div class="rating-line"></div>
+
+        <div class="rating-number">
+          <%= entry.rating != null ? entry.rating : 'No Rating Yet' %>
+        </div>
+
+        <% if (entry.comment) { %>
+          <p class="comment">“<%= entry.comment %>”</p>
+        <% } %>
+      </div>
+    <% } %>
+  </div>
+</body>
+</html>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -139,7 +139,8 @@
             </div>
         </div>
         <% } %>
-        <% if (gameEntries && gameEntries.length > 0) { %>
+        <% const profileIdentifier = (user && (user.venmo || user._id)) || '';
+           if (gameEntries && gameEntries.length > 0) { %>
         <div class="row row-cols-1 row-cols-md-1 row-cols-lg-1 g-4 " id="profileGamesContainer">
             <% gameEntries.forEach(function(entry){
                  const game = entry.game;
@@ -166,7 +167,7 @@
                     </div>
                     <div class="d-flex align-items-center">
                         <div class="position-relative flex-grow-1">
-                            <a href="<%= usePastGameLinks ? '/pastGames/' + game._id : '/games/' + game._id %>" class="game-link d-block">
+                            <a href="/profileGames/<%= profileIdentifier %>/<%= entry._id || entry.gameId %>" class="game-link d-block">
 
                                 <div class="card shadow-sm h-100 game-card p-3 text-center position-relative <%= entry.checkedIn ? 'checked-in-border' : '' %>" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                     <div class="venue-overlay"><%= game.Venue || game.venue %></div>


### PR DESCRIPTION
## Summary
- add a profileGameShowcase controller action and route that resolves users by Venmo handle or id and renders the game entry showcase
- create a stylized `gameEntryShowcase.ejs` view to highlight a single entry with matchup, rating, and fallbacks
- point profile game cards to the new showcase endpoint so each entry opens the dedicated page

## Testing
- npm test *(fails: missing `mongoose` package in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d57133c2288326b1d00de5f3493376