### PR TITLE
Add fallback imagery and unrated game alerts to profile views

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -709,7 +709,8 @@ exports.profileGameShowcase = async (req, res, next) => {
                 entry: null,
                 profileImageUrl: null,
                 gameDetails: null,
-                normalizedEloRating: null
+                normalizedEloRating: null,
+                homeVenueImage: null
 
             });
         }
@@ -726,7 +727,8 @@ exports.profileGameShowcase = async (req, res, next) => {
                 profileImageUrl: null,
 
                 gameDetails: null,
-                normalizedEloRating: null
+                normalizedEloRating: null,
+                homeVenueImage: null
 
             });
         }
@@ -749,10 +751,19 @@ exports.profileGameShowcase = async (req, res, next) => {
                 profileImageUrl,
 
                 gameDetails: null,
-                normalizedEloRating: null
+                normalizedEloRating: null,
+                homeVenueImage: null
 
             });
         }
+
+        const homeVenueImage = (entry.game && (
+            (entry.game.homeVenue && entry.game.homeVenue.imgUrl) ||
+            (entry.game.venue && entry.game.venue.imgUrl) ||
+            entry.game.venueImgUrl ||
+            entry.game.imgUrl ||
+            entry.game.VenueImgUrl
+        )) || null;
 
         res.render('gameEntryShowcase', {
             user: targetUser,
@@ -760,7 +771,8 @@ exports.profileGameShowcase = async (req, res, next) => {
             profileImageUrl,
 
             gameDetails: entry.game || null,
-            normalizedEloRating: eloToRating(entry.elo)
+            normalizedEloRating: eloToRating(entry.elo),
+            homeVenueImage
 
         });
     } catch (err) {

--- a/views/gameEntryShowcase.ejs
+++ b/views/gameEntryShowcase.ejs
@@ -42,7 +42,6 @@
     }
 
     .frame-container {
-
       width: min(88vw, 430px);
       aspect-ratio: 9 / 16;
       position: relative;
@@ -51,19 +50,17 @@
       box-shadow: 0 22px 48px rgba(15, 23, 42, 0.45);
       display: flex;
       justify-content: center;
-
       align-items: center;
-
     }
 
-    .entry-image {
+    .frame-background {
       position: absolute;
       inset: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      filter: grayscale(100%);
+      background-size: cover;
+      background-position: center;
+      background-repeat: no-repeat;
       transform: scale(1.05);
+      filter: grayscale(100%);
     }
 
     .frame-overlay {
@@ -283,8 +280,15 @@
       </div>
     <% } else { %>
 
+      <%
+        const frameImage = (entry && entry.image)
+          || homeVenueImage
+          || (entry && entry.game && entry.game.homeVenue && entry.game.homeVenue.imgUrl)
+          || (entry && entry.game && entry.game.venue && entry.game.venue.imgUrl)
+          || '/images/placeholder.jpg';
+      %>
       <div class="frame-container">
-        <img class="entry-image" src="<%= entry && entry.image ? entry.image : '/images/placeholder.jpg' %>" alt="Game highlight image">
+        <div class="frame-background" style="background-image: url('<%= frameImage %>');"></div>
         <div class="frame-overlay"></div>
         <%
           const pickScore = (obj, keys) => {

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -95,6 +95,12 @@
         .rating-wrapper:hover::after { opacity: 0; }
         .rating-wrapper:hover .rating-comment { display: block; }
 
+        .unrated-icon {
+            color: red;
+            margin-left: 0.25rem;
+            cursor: pointer;
+        }
+
         /* Mobile-specific adjustments */
         @media (max-width: 768px) {
             #profileGamesWrapper .team-logo-container {
@@ -158,6 +164,12 @@
                                 <i class="bi bi-check-circle-fill text-black" aria-hidden="true"></i>
                                 <span class="visually-hidden">Checked in</span>
                             </span>
+                        <% } %>
+
+                        <% if (isCurrentUser && (entry.elo === null || entry.elo === undefined)) { %>
+                            <i class="bi bi-exclamation-circle-fill unrated-icon"
+                               data-bs-toggle="tooltip"
+                               title="This game is unrated, click the game to rate it"></i>
                         <% } %>
 
                         <% if(isCurrentUser){ %>
@@ -342,6 +354,17 @@
             const color=chooseTextColor([away,home]);
             card.querySelectorAll('.team-name, .score-text, .text-white').forEach(e=>{e.style.color=color;});
         });
+
+        const initTooltips = () => {
+            const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+            tooltipTriggerList.map(el => new bootstrap.Tooltip(el));
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initTooltips);
+        } else {
+            initTooltips();
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- pass along venue imagery for profile game showcases and use it when a user image is missing
- render the showcase frame with a styled background fallback instead of an empty photo slot
- surface unrated profile games with a tooltip icon so users know to finish their ratings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daae366b1c832694486cfea3cf9ae2