### PR TITLE
Fix Elo-based comparisons to use PastGame Ids

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -88,9 +88,29 @@ async function mergeUserGames(user){
 // Enriches an array of {game, elo} objects with full PastGame info
 async function enrichEloGames(entries){
     if(!entries || !entries.length) return [];
-    
-    const enriched = await enrichGameEntries(entries);
-    
+
+    const normalized = entries.map(e => {
+        const entryObj = e.toObject ? e.toObject() : { ...e };
+        if (entryObj.gameId == null) {
+            const rawGame = entryObj.game;
+            let resolvedId = null;
+            if (rawGame && typeof rawGame === 'object') {
+                if (rawGame.gameId != null) resolvedId = rawGame.gameId;
+                else if (rawGame.Id != null) resolvedId = rawGame.Id;
+            } else if (rawGame != null) {
+                resolvedId = rawGame;
+            }
+            const numericId = Number(resolvedId);
+            entryObj.gameId = Number.isFinite(numericId) ? numericId : null;
+        } else {
+            const numericId = Number(entryObj.gameId);
+            entryObj.gameId = Number.isFinite(numericId) ? numericId : null;
+        }
+        return entryObj;
+    });
+
+    const enriched = await enrichGameEntries(normalized);
+
     return enriched;
 }
 
@@ -1020,19 +1040,25 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
             return res.status(400).json({ error: 'Rating required for initial games' });
         }
 
-        const pastGameDoc = await PastGame.findOne({ gameId: Number(gameId) });
+        const numericGameId = Number(gameId);
+        const pastGameDoc = await PastGame.findOne({ gameId: numericGameId });
         if(!pastGameDoc) {
             return res.status(404).json({ error: 'Game not found' });
         }
 
+        const canonicalGameId = Number(pastGameDoc.gameId ?? pastGameDoc.Id);
+        if(!Number.isFinite(canonicalGameId)){
+            return res.status(400).json({ error: 'Game identifier invalid' });
+        }
+
         const entry = {
-            gameId: String(pastGameDoc.gameId),
+            gameId: String(canonicalGameId),
             elo: finalElo,
             comment: sanitizedComment || null,
             image: req.file ? '/uploads/' + req.file.filename : null
         };
 
-        const alreadyExists = user.gameEntries.some(e => String(e.gameId) === String(pastGameDoc.gameId));
+        const alreadyExists = user.gameEntries.some(e => String(e.gameId) === String(canonicalGameId));
         if (alreadyExists) {
             const enrichedEntries = await mergeUserGames(user);
             const eloGames = await enrichEloGames(user.gameElo || []);
@@ -1055,11 +1081,46 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
         const newGameObjectId = pastGameDoc._id;
 
         const finalizedGames = (user.gameElo || []).filter(g => g.finalized);
+        const missingGameRefs = finalizedGames
+            .filter(g => g.gameId == null && g.game)
+            .map(g => g.game);
+        if(missingGameRefs.length){
+            const pastGameDocs = await PastGame.find({ _id: { $in: missingGameRefs } })
+                .select('_id gameId Id')
+                .lean();
+            const pastGameMap = {};
+            pastGameDocs.forEach(doc => {
+                pastGameMap[String(doc._id)] = doc;
+            });
+            finalizedGames.forEach(g => {
+                if(g.gameId == null){
+                    const pg = pastGameMap[String(g.game)];
+                    if(pg){
+                        const derivedId = Number(pg.gameId ?? pg.Id);
+                        if(Number.isFinite(derivedId)){
+                            g.gameId = derivedId;
+                        }
+                    }
+                }
+            });
+        }
         let minElo = 1000;
         let maxElo = 2000;
 
+        const parseGameId = value => {
+            if (value === undefined || value === null || value === '') return null;
+            const num = Number(value);
+            return Number.isFinite(num) ? num : null;
+        };
+        const entryGameId = canonicalGameId;
+        const findComparisonEntry = id => {
+            const numericId = parseGameId(id);
+            if (numericId == null) return null;
+            return finalizedGames.find(g => parseGameId(g.gameId) === numericId);
+        };
+
         if(!isInitial){
-            const comp1 = finalizedGames.find(g => String(g.game) === String(compareGameId1));
+            const comp1 = findComparisonEntry(compareGameId1);
             if (comp1 && (winner1 === 'new' || winner1 === 'existing')) {
                 await GameComparison.create({
                     userId: user._id,
@@ -1074,7 +1135,7 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
                 }
             }
 
-            const comp2 = finalizedGames.find(g => String(g.game) === String(compareGameId2));
+            const comp2 = findComparisonEntry(compareGameId2);
             if (comp2 && (winner2 === 'new' || winner2 === 'existing')) {
                 await GameComparison.create({
                     userId: user._id,
@@ -1089,7 +1150,7 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
                 }
             }
 
-            const comp3 = finalizedGames.find(g => String(g.game) === String(compareGameId3));
+            const comp3 = findComparisonEntry(compareGameId3);
             if (comp3 && (winner3 === 'new' || winner3 === 'existing')) {
                 await GameComparison.create({
                     userId: user._id,
@@ -1138,6 +1199,7 @@ exports.addGame = [uploadDisk.single('photo'), async (req, res, next) => {
 
         const newEloEntry = {
             game: newGameObjectId,
+            gameId: entryGameId,
             elo: finalElo,
             finalized: true,
             comparisonHistory: []
@@ -1217,7 +1279,8 @@ exports.updateGameEntry = [uploadDisk.single('photo'), async (req, res, next) =>
             entry.image = '/uploads/' + req.file.filename;
         }
 
-        const pastGameDoc = await PastGame.findOne({ gameId: entry.gameId });
+        const entryGameIdNumeric = Number(entry.gameId);
+        const pastGameDoc = await PastGame.findOne({ gameId: entryGameIdNumeric });
         if(pastGameDoc){
             let updated = false;
             const commentObj = pastGameDoc.comments.find(c => String(c.userId) === String(user._id));
@@ -1233,7 +1296,14 @@ exports.updateGameEntry = [uploadDisk.single('photo'), async (req, res, next) =>
             }
         }
 
-        const eloEntry = pastGameDoc ? user.gameElo.find(e => String(e.game) === String(pastGameDoc._id)) : null;
+        const targetGameId = pastGameDoc && Number.isFinite(pastGameDoc.gameId)
+            ? pastGameDoc.gameId
+            : entryGameIdNumeric;
+        const eloEntry = user.gameElo.find(e => {
+            if (e.gameId == null) return false;
+            const numericId = Number(e.gameId);
+            return Number.isFinite(numericId) && Number.isFinite(targetGameId) && numericId === targetGameId;
+        });
         if(eloEntry){
             eloEntry.elo = newElo;
         }
@@ -1257,7 +1327,8 @@ exports.deleteGameEntry = async (req, res, next) => {
         const entry = user.gameEntries.id(entryId);
         if(!entry) return res.status(404).json({ error:'Entry not found' });
 
-        const pastGameDoc = await PastGame.findOne({ gameId: entry.gameId });
+        const entryGameIdNumeric = Number(entry.gameId);
+        const pastGameDoc = await PastGame.findOne({ gameId: entryGameIdNumeric });
 
         const teamsToRemove = [];
         const venuesToRemove = [];
@@ -1295,7 +1366,14 @@ exports.deleteGameEntry = async (req, res, next) => {
             if(idx >= 0) user.venuesList.splice(idx,1);
         });
 
-        const idx = pastGameDoc ? user.gameElo.findIndex(e => String(e.game) === String(pastGameDoc._id)) : -1;
+        const targetGameId = pastGameDoc && Number.isFinite(pastGameDoc.gameId)
+            ? pastGameDoc.gameId
+            : entryGameIdNumeric;
+        const idx = user.gameElo.findIndex(e => {
+            if (e.gameId == null) return false;
+            const numericId = Number(e.gameId);
+            return Number.isFinite(numericId) && Number.isFinite(targetGameId) && numericId === targetGameId;
+        });
         if(idx >= 0){
             user.gameElo.splice(idx,1);
         }

--- a/models/users.js
+++ b/models/users.js
@@ -57,6 +57,7 @@ const userSchema = new mongoose.Schema({
     gameElo: {
         type: [{
           game: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame' },
+          gameId: { type: Number, index: true },
           elo: Number,
           comparisonHistory: [{
             againstGame: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame' },

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -49,6 +49,18 @@
     const gameEntryNames = window.gameEntryNames || [];
     let rankingDone = gameEntryCount < 5 ? true : finalizedGames.length === 0;
 
+    function getEloEntryId(entry){
+      if(!entry) return null;
+      if(entry.gameId != null && entry.gameId !== ''){
+        return String(entry.gameId);
+      }
+      const game = entry.game || {};
+      if(game.gameId != null && game.gameId !== '') return String(game.gameId);
+      if(game.Id != null && game.Id !== '') return String(game.Id);
+      if(entry.game != null && entry.game !== '') return String(entry.game);
+      return null;
+    }
+
     function resetForm(){
       if(!form.length) return;
       form[0].reset();
@@ -106,8 +118,8 @@
       exclude = exclude || [];
       if(isNaN(min) || isNaN(max) || min > max) return null;
       const eligible = finalizedGames.filter(g => {
-        const id = String(g.game && g.game._id ? g.game._id : g.game);
-        return g.elo >= min && g.elo <= max && !exclude.includes(id);
+        const id = getEloEntryId(g);
+        return g.elo >= min && g.elo <= max && (!id || !exclude.includes(String(id)));
       });
       if (!eligible.length) return null;
       const midpoint = Math.floor((min + max) / 2);
@@ -131,7 +143,8 @@
         return;
       }
       const comp = randomGame1.game || {};
-      compareGameInput1.val(comp._id ? comp._id : randomGame1.game);
+      const compId = getEloEntryId(randomGame1);
+      compareGameInput1.val(compId || '');
       const compData = {
         awayLogo: comp.awayTeam && comp.awayTeam.logos && comp.awayTeam.logos[0],
         homeLogo: comp.homeTeam && comp.homeTeam.logos && comp.homeTeam.logos[0],
@@ -147,13 +160,16 @@
     }
 
     function showComparison2(){
-      randomGame2 = pickRandomGame(minRange,maxRange,[String(randomGame1.game && randomGame1.game._id ? randomGame1.game._id : randomGame1.game)]);
+      const firstId = getEloEntryId(randomGame1);
+      const excludeIds = firstId ? [String(firstId)] : [];
+      randomGame2 = pickRandomGame(minRange,maxRange,excludeIds);
       if(!randomGame2){
         finalize();
         return;
       }
       const comp = randomGame2.game || {};
-      compareGameInput2.val(comp._id ? comp._id : randomGame2.game);
+      const compId = getEloEntryId(randomGame2);
+      compareGameInput2.val(compId || '');
       const compData = {
         awayLogo: comp.awayTeam && comp.awayTeam.logos && comp.awayTeam.logos[0],
         homeLogo: comp.homeTeam && comp.homeTeam.logos && comp.homeTeam.logos[0],
@@ -169,17 +185,19 @@
     }
 
     function showComparison3(){
-      const exclude = [
-        String(randomGame1 && (randomGame1.game && randomGame1.game._id ? randomGame1.game._id : randomGame1.game)),
-        String(randomGame2 && (randomGame2.game && randomGame2.game._id ? randomGame2.game._id : randomGame2.game))
-      ];
+      const exclude = [];
+      const excludeId1 = getEloEntryId(randomGame1);
+      const excludeId2 = getEloEntryId(randomGame2);
+      if(excludeId1) exclude.push(String(excludeId1));
+      if(excludeId2) exclude.push(String(excludeId2));
       randomGame3 = pickRandomGame(minRange, maxRange, exclude);
       if(!randomGame3){
         finalize();
         return;
       }
       const comp = randomGame3.game || {};
-      compareGameInput3.val(comp._id ? comp._id : randomGame3.game);
+      const compId = getEloEntryId(randomGame3);
+      compareGameInput3.val(compId || '');
       const compData = {
         awayLogo: comp.awayTeam && comp.awayTeam.logos && comp.awayTeam.logos[0],
         homeLogo: comp.homeTeam && comp.homeTeam.logos && comp.homeTeam.logos[0],

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -155,7 +155,14 @@
                                     </div>
                                 </a>
                             </div>
-                            <% const eloEntry = (eloGames || []).find(e => String(e.game && (e.game._id || e.game)) === String(game._id));
+                            <% const targetGameId = String(game.gameId ?? game.Id ?? game._id);
+                               const eloEntry = (eloGames || []).find(e => {
+                                 if (e.gameId != null) return String(e.gameId) === targetGameId;
+                                 const g = e.game || {};
+                                 if (g.gameId != null) return String(g.gameId) === targetGameId;
+                                 if (g.Id != null) return String(g.Id) === targetGameId;
+                                 return String(g._id || e.game) === targetGameId;
+                               });
                                if(eloEntry && typeof eloEntry.elo === 'number'){ const elo = eloEntry.elo; const rating = Math.round(((elo - 1000) * 9 / 100) + 1); %>
                             <div class="rating-wrapper ms-md-4">
                                 <span class="rating-number"><%= rating %>/10</span>

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -203,10 +203,13 @@
                             </a>
                         </div>
                         <%
-      const gameId = String(game._id);
+      const targetGameId = String(game.gameId ?? game.Id ?? game._id);
       const eloEntry = (eloGames || []).find(e => {
-        const entryId = String(e.game && (e.game._id || e.game)); // Handle ObjectId vs populated object
-        return entryId === gameId;
+        if (e.gameId != null) return String(e.gameId) === targetGameId;
+        const g = e.game || {};
+        if (g.gameId != null) return String(g.gameId) === targetGameId;
+        if (g.Id != null) return String(g.Id) === targetGameId;
+        return String(g._id || e.game) === targetGameId;
       });
     
       


### PR DESCRIPTION
## Summary
- normalize stored Elo entries with canonical PastGame identifiers and guard lookups with the new gameId field
- update the +Game modal and comparison controller so comparisons and submissions match on PastGame.Id/gameId instead of Mongo _id
- refresh Elo-related views and aggregates to consume the normalized identifiers and keep ratings visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dab72e8840832687e697945683f603