### PR TITLE
Add in-place rating modal for unrated profile games

### DIFF
--- a/main.js
+++ b/main.js
@@ -250,6 +250,7 @@ app.post('/profile/edit', requireAuth, profileController.updateProfile);
 app.post('/profile/photo', requireAuth, profileController.uploadProfilePhoto);
 app.post('/profile/location', requireAuth, profileController.setLocation);
 app.post('/profile/games', requireAuth, profileController.addGame);
+app.post('/profile/games/:id/rate', requireAuth, profileController.rateExistingGame);
 app.put('/gameEntry/:id', requireAuth, profileController.updateGameEntry);
 app.delete('/gameEntry/:id', requireAuth, profileController.deleteGameEntry);
 app.get('/welcome', requireAuth, (req, res) => {

--- a/models/users.js
+++ b/models/users.js
@@ -26,6 +26,7 @@ const userSchema = new mongoose.Schema({
     gameEntries: [{
         gameId: String,
         elo: Number,
+        rating: mongoose.Schema.Types.Mixed,
         comment: String,
         image: String,
         checkedIn: { type: Boolean, default: false },

--- a/public/js/rateGameModal.js
+++ b/public/js/rateGameModal.js
@@ -1,0 +1,476 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const modalEl = document.getElementById('rateGameModal');
+    if(!modalEl) return;
+
+    const modal = new bootstrap.Modal(modalEl);
+    const form = modalEl.querySelector('#rateGameForm');
+    const manualSection = modalEl.querySelector('#rateManualSection');
+    const eloSection = modalEl.querySelector('#rateEloSection');
+    const ratingRange = modalEl.querySelector('#rateRatingRange');
+    const ratingValue = modalEl.querySelector('#rateRatingValue');
+    const commentInput = modalEl.querySelector('#rateCommentInput');
+    const commentCounter = modalEl.querySelector('#rateCommentCounter');
+    const photoInput = modalEl.querySelector('#ratePhotoInput');
+    const photoPreview = modalEl.querySelector('#ratePhotoPreview');
+    const photoPreviewImg = photoPreview ? photoPreview.querySelector('img') : null;
+    const submitBtn = modalEl.querySelector('#rateSubmitBtn');
+    const errorBox = modalEl.querySelector('#rateError');
+    const modalTitle = modalEl.querySelector('#rateModalTitle');
+    const newGameCard = modalEl.querySelector('#rateNewGameCard');
+    const existingGameCard = modalEl.querySelector('#rateExistingGameCard');
+    const comparisonPrompt = modalEl.querySelector('#rateComparisonPrompt');
+    const comparisonButtons = modalEl.querySelector('#rateComparisonButtons');
+    const betterBtn = modalEl.querySelector('#rateBetterBtn');
+    const worseBtn = modalEl.querySelector('#rateWorseBtn');
+    const compareInputs = [
+      modalEl.querySelector('#rateCompareGameId1'),
+      modalEl.querySelector('#rateCompareGameId2'),
+      modalEl.querySelector('#rateCompareGameId3')
+    ];
+    const winnerInputs = [
+      modalEl.querySelector('#rateWinner1'),
+      modalEl.querySelector('#rateWinner2'),
+      modalEl.querySelector('#rateWinner3')
+    ];
+    const entryIdInput = modalEl.querySelector('#rateEntryId');
+
+    const gameEntriesData = Array.isArray(window.gameEntriesData) ? window.gameEntriesData : [];
+    const eloGamesData = Array.isArray(window.eloGamesData) ? window.eloGamesData : [];
+    const profileUserId = (window.profileUserId || '').toString();
+    const loggedInUserId = (window.loggedInUserId || '').toString();
+
+    let currentEntry = null;
+    let currentEntryKey = null;
+    let currentEntryGameId = null;
+    let currentEntryId = null;
+    let currentMode = 'manual';
+    let comparisonStep = 0;
+    let randomComparisons = [];
+    let finalizedGames = [];
+    let minRange = 1000;
+    let maxRange = 2000;
+
+    function normalizeId(value){
+      if(value === undefined || value === null) return null;
+      const str = String(value);
+      return str && str !== 'null' && str !== 'undefined' ? str : null;
+    }
+
+    function parseNumericId(value){
+      const num = Number(value);
+      return Number.isFinite(num) ? num : null;
+    }
+
+    function getEntryByKey(key){
+      if(!key) return null;
+      const strKey = String(key);
+      return gameEntriesData.find(e => {
+        const entryId = normalizeId(e._id || e.id || e.entryId);
+        if(entryId && entryId === strKey) return true;
+        const gameId = normalizeId(e.gameId);
+        return gameId && gameId === strKey;
+      }) || null;
+    }
+
+    function getEloEntryId(entry){
+      if(!entry) return null;
+      if(entry.gameId != null){
+        const num = parseNumericId(entry.gameId);
+        if(num != null) return String(num);
+      }
+      const game = entry.game;
+      if(game && typeof game === 'object'){
+        if(game.gameId != null){
+          const num = parseNumericId(game.gameId);
+          if(num != null) return String(num);
+        }
+        if(game.Id != null){
+          const num = parseNumericId(game.Id);
+          if(num != null) return String(num);
+        }
+        if(game._id != null){
+          return normalizeId(game._id);
+        }
+      } else if(game != null){
+        return normalizeId(game);
+      }
+      return null;
+    }
+
+    function updateRatingDisplay(){
+      if(!ratingRange || !ratingValue) return;
+      const val = parseFloat(ratingRange.value);
+      ratingValue.textContent = Number.isNaN(val) ? '' : val.toFixed(1);
+    }
+
+    function updateCommentCounter(){
+      if(!commentInput || !commentCounter) return;
+      commentCounter.textContent = `${commentInput.value.length}/100`;
+    }
+
+    function resetHiddenFields(){
+      compareInputs.forEach(input => { if(input) input.value = ''; });
+      winnerInputs.forEach(input => { if(input) input.value = ''; });
+    }
+
+    function clearError(){
+      if(!errorBox) return;
+      errorBox.classList.add('d-none');
+      errorBox.textContent = '';
+    }
+
+    function showError(message){
+      if(!errorBox) return;
+      errorBox.textContent = message || 'Something went wrong.';
+      errorBox.classList.remove('d-none');
+    }
+
+    function renderCard(container, data){
+      if(!container) return;
+      if(!data){
+        container.innerHTML = '';
+        return;
+      }
+      const date = data.gameDate ? new Date(data.gameDate) : null;
+      const dateStr = date ? date.toLocaleDateString() : '';
+      const awayLogo = data.awayLogo || '/images/placeholder.jpg';
+      const homeLogo = data.homeLogo || '/images/placeholder.jpg';
+      const awayPoints = data.awayPoints != null ? data.awayPoints : '';
+      const homePoints = data.homePoints != null ? data.homePoints : '';
+      container.innerHTML = `
+        <div class="elo-game-grid">
+          <div></div><div>${dateStr}</div><div></div>
+          <div><img src="${awayLogo}" alt="Away"></div><div>@</div><div><img src="${homeLogo}" alt="Home"></div>
+          <div>${awayPoints}</div><div></div><div>${homePoints}</div>
+        </div>
+      `;
+    }
+
+    function pickComparisonCandidate(excludeIds){
+      const exclude = new Set((excludeIds || []).map(String));
+      const eligible = finalizedGames.filter(g => {
+        const id = getEloEntryId(g);
+        if(!id || exclude.has(id)) return false;
+        const elo = g.elo;
+        if(typeof elo !== 'number' || Number.isNaN(elo)) return false;
+        if(elo < minRange || elo > maxRange) return false;
+        return true;
+      });
+      if(!eligible.length) return null;
+      const midpoint = Math.floor((minRange + maxRange) / 2);
+      let best = eligible[0];
+      let bestDist = Math.abs((best.elo || 0) - midpoint);
+      for(let i=1;i<eligible.length;i++){
+        const candidate = eligible[i];
+        const dist = Math.abs((candidate.elo || 0) - midpoint);
+        if(dist < bestDist){
+          best = candidate;
+          bestDist = dist;
+        }
+      }
+      return best;
+    }
+
+    function startComparisons(){
+      resetHiddenFields();
+      randomComparisons = [null, null, null];
+      comparisonStep = 0;
+      if(submitBtn) submitBtn.disabled = true;
+      proceedToNextComparison();
+    }
+
+    function proceedToNextComparison(){
+      if(comparisonButtons) comparisonButtons.style.display = 'none';
+      comparisonPrompt && (comparisonPrompt.textContent = '');
+
+      const exclude = [currentEntryGameId];
+      randomComparisons.forEach(item => {
+        const id = item ? getEloEntryId(item) : null;
+        if(id) exclude.push(id);
+      });
+
+      const nextSlot = randomComparisons.findIndex(item => !item);
+      if(nextSlot === -1){
+        finalizeComparisons();
+        return;
+      }
+
+      const candidate = pickComparisonCandidate(exclude);
+      if(!candidate){
+        finalizeComparisons();
+        return;
+      }
+
+      randomComparisons[nextSlot] = candidate;
+      const compareInput = compareInputs[nextSlot];
+      if(compareInput){
+        compareInput.value = getEloEntryId(candidate) || '';
+      }
+
+      const compGame = candidate.game || {};
+      const compData = {
+        awayLogo: compGame.awayTeam && compGame.awayTeam.logos ? compGame.awayTeam.logos[0] : compGame.awayLogo,
+        homeLogo: compGame.homeTeam && compGame.homeTeam.logos ? compGame.homeTeam.logos[0] : compGame.homeLogo,
+        awayPoints: compGame.AwayPoints ?? compGame.awayPoints,
+        homePoints: compGame.HomePoints ?? compGame.homePoints,
+        gameDate: compGame.StartDate || compGame.startDate
+      };
+
+      renderCard(newGameCard, currentEntry);
+      renderCard(existingGameCard, compData);
+      if(comparisonPrompt){
+        comparisonPrompt.textContent = 'Which game was better?';
+      }
+      if(comparisonButtons){
+        comparisonButtons.style.display = 'flex';
+      }
+      comparisonStep = nextSlot + 1;
+    }
+
+    function finalizeComparisons(){
+      if(comparisonButtons) comparisonButtons.style.display = 'none';
+      if(comparisonPrompt){
+        comparisonPrompt.textContent = 'All comparisons complete. Submit your rating!';
+      }
+      if(submitBtn) submitBtn.disabled = false;
+    }
+
+    function handleComparisonResult(result){
+      if(!comparisonStep) return;
+      const idx = comparisonStep - 1;
+      const target = randomComparisons[idx];
+      if(!target) return;
+      const elo = target.elo;
+      if(result === 'new' && typeof elo === 'number'){
+        minRange = elo;
+      } else if(result === 'existing' && typeof elo === 'number'){
+        maxRange = elo;
+      }
+      const winnerInput = winnerInputs[idx];
+      if(winnerInput){
+        winnerInput.value = result;
+      }
+      proceedToNextComparison();
+    }
+
+    function populateFromEntry(entry, link){
+      currentEntry = null;
+      currentEntryKey = link.getAttribute('data-entry-key') || null;
+      currentEntryId = normalizeId(entry?._id || link.getAttribute('data-entry-id'));
+      currentEntryGameId = normalizeId(entry?.gameId || link.getAttribute('data-game-id'));
+
+      if(entryIdInput){
+        entryIdInput.value = currentEntryId || '';
+      }
+
+      const manualRating = typeof entry?.rating === 'number' ? entry.rating : null;
+      if(ratingRange){
+        ratingRange.value = manualRating != null ? manualRating : 5;
+        updateRatingDisplay();
+      }
+
+      if(commentInput){
+        commentInput.value = entry?.comment || '';
+        updateCommentCounter();
+      }
+
+      if(photoPreview && photoPreviewImg){
+        if(entry?.image){
+          photoPreviewImg.src = entry.image;
+          photoPreview.classList.remove('d-none');
+        } else {
+          photoPreviewImg.src = '';
+          photoPreview.classList.add('d-none');
+        }
+      }
+
+      currentEntry = {
+        awayLogo: link.getAttribute('data-away-logo'),
+        homeLogo: link.getAttribute('data-home-logo'),
+        awayPoints: link.getAttribute('data-away-score'),
+        homePoints: link.getAttribute('data-home-score'),
+        gameDate: link.getAttribute('data-game-date')
+      };
+    }
+
+    function determineMode(entry){
+      const entryIdStr = normalizeId(entry?._id);
+      const ratedCount = gameEntriesData.reduce((acc, item) => {
+        if(normalizeId(item._id) === entryIdStr) return acc;
+        return item.elo != null ? acc + 1 : acc;
+      }, 0);
+
+      const currentGameIdStr = currentEntryGameId ? String(currentEntryGameId) : null;
+      finalizedGames = eloGamesData.filter(g => {
+        if(!g || !g.finalized) return false;
+        const id = getEloEntryId(g);
+        if(!id) return false;
+        return !currentGameIdStr || id !== currentGameIdStr;
+      });
+
+      const hasComparisons = finalizedGames.length > 0;
+      return ratedCount >= 5 && hasComparisons ? 'elo' : 'manual';
+    }
+
+    function prepareEloState(entry){
+      const entryGameIdStr = currentEntryGameId ? String(currentEntryGameId) : null;
+      const existingRecord = eloGamesData.find(g => getEloEntryId(g) === entryGameIdStr);
+      minRange = typeof existingRecord?.minElo === 'number' ? existingRecord.minElo : 1000;
+      maxRange = typeof existingRecord?.maxElo === 'number' ? existingRecord.maxElo : 2000;
+      if(Number.isNaN(minRange) || Number.isNaN(maxRange)){
+        minRange = 1000;
+        maxRange = 2000;
+      }
+      if(minRange > maxRange){
+        const tmp = minRange;
+        minRange = maxRange;
+        maxRange = tmp;
+      }
+      startComparisons();
+    }
+
+    function showManualSection(){
+      if(manualSection) manualSection.style.display = '';
+      if(eloSection) eloSection.style.display = 'none';
+      if(submitBtn) submitBtn.disabled = false;
+    }
+
+    function showEloSection(){
+      if(manualSection) manualSection.style.display = 'none';
+      if(eloSection) eloSection.style.display = '';
+      prepareEloState(currentEntry);
+    }
+
+    function handleLinkClick(event){
+      const link = event.currentTarget;
+      if(!link) return;
+      const canRate = link.getAttribute('data-can-rate');
+      if(canRate !== 'true' || profileUserId !== loggedInUserId){
+        return;
+      }
+      event.preventDefault();
+
+      const key = link.getAttribute('data-entry-key');
+      const entry = getEntryByKey(key) || null;
+      populateFromEntry(entry, link);
+      clearError();
+
+      if(modalTitle){
+        const awayTeam = link.getAttribute('data-away-team') || 'Away';
+        const homeTeam = link.getAttribute('data-home-team') || 'Home';
+        modalTitle.textContent = `Rate ${awayTeam} vs ${homeTeam}!`;
+      }
+
+      currentMode = determineMode(entry);
+      if(currentMode === 'elo'){
+        showEloSection();
+      } else {
+        showManualSection();
+      }
+
+      modal.show();
+    }
+
+    function resetForm(){
+      form && form.reset();
+      if(ratingRange){
+        ratingRange.value = 5;
+        updateRatingDisplay();
+      }
+      if(commentInput){
+        commentInput.value = '';
+        updateCommentCounter();
+      }
+      if(photoPreview && photoPreviewImg){
+        photoPreviewImg.src = '';
+        photoPreview.classList.add('d-none');
+      }
+      clearError();
+      resetHiddenFields();
+      if(manualSection) manualSection.style.display = '';
+      if(eloSection) eloSection.style.display = 'none';
+      if(comparisonButtons) comparisonButtons.style.display = 'none';
+      if(comparisonPrompt) comparisonPrompt.textContent = '';
+      if(submitBtn) submitBtn.disabled = false;
+      currentEntry = null;
+      currentEntryKey = null;
+      currentEntryId = null;
+      currentEntryGameId = null;
+      currentMode = 'manual';
+    }
+
+    document.querySelectorAll('.game-link').forEach(link => {
+      link.addEventListener('click', handleLinkClick);
+    });
+
+    if(ratingRange){
+      ratingRange.addEventListener('input', updateRatingDisplay);
+      updateRatingDisplay();
+    }
+
+    if(commentInput){
+      commentInput.addEventListener('input', updateCommentCounter);
+      updateCommentCounter();
+    }
+
+    if(photoInput && photoPreview && photoPreviewImg){
+      photoInput.addEventListener('change', function(){
+        const file = this.files && this.files[0];
+        if(!file){
+          photoPreviewImg.src = '';
+          photoPreview.classList.add('d-none');
+          return;
+        }
+        const reader = new FileReader();
+        reader.onload = function(ev){
+          photoPreviewImg.src = ev.target.result;
+          photoPreview.classList.remove('d-none');
+        };
+        reader.readAsDataURL(file);
+      });
+    }
+
+    if(betterBtn){
+      betterBtn.addEventListener('click', function(){ handleComparisonResult('new'); });
+    }
+    if(worseBtn){
+      worseBtn.addEventListener('click', function(){ handleComparisonResult('existing'); });
+    }
+
+    modalEl.addEventListener('hidden.bs.modal', resetForm);
+
+    if(form){
+      form.addEventListener('submit', async function(event){
+        event.preventDefault();
+        clearError();
+        if(!currentEntryId){
+          showError('Unable to determine which entry to rate.');
+          return;
+        }
+        const url = `/profile/games/${encodeURIComponent(currentEntryId)}/rate`;
+        const formData = new FormData(form);
+        formData.set('entryId', currentEntryId);
+        if(submitBtn) submitBtn.disabled = true;
+        try {
+          const response = await fetch(url, {
+            method: 'POST',
+            body: formData
+          });
+          if(!response.ok){
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data && data.error ? data.error : 'Failed to submit rating.');
+          }
+          const redirectTarget = currentEntryKey
+            ? `/profileGames/${encodeURIComponent(profileUserId)}/${encodeURIComponent(currentEntryKey)}`
+            : `/profileGames/${encodeURIComponent(profileUserId)}`;
+          modal.hide();
+          window.location.href = redirectTarget;
+        } catch (err){
+          showError(err.message);
+          if(submitBtn) submitBtn.disabled = false;
+        }
+      });
+    }
+  });
+})();

--- a/views/profileGames.ejs
+++ b/views/profileGames.ejs
@@ -152,7 +152,11 @@
                  const game = entry.game;
                  if(!game){ return; }
                  const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
-                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
+                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
+                 const entryKey = entry._id || entry.gameId;
+                 const normalizedGameId = game.gameId || game.Id || game._id || entry.gameId;
+                 const canRate = isCurrentUser && (entry.elo === null || entry.elo === undefined);
+            %>
             <div class="col">
 
                 <div class="game-container">
@@ -179,7 +183,20 @@
                     </div>
                     <div class="d-flex align-items-center">
                         <div class="position-relative flex-grow-1">
-                            <a href="/profileGames/<%= profileIdentifier %>/<%= entry._id || entry.gameId %>" class="game-link d-block">
+                            <a href="/profileGames/<%= profileIdentifier %>/<%= entryKey %>"
+                               class="game-link d-block <%= canRate ? 'game-link-unrated' : '' %>"
+                               data-entry-key="<%= entryKey %>"
+                               data-entry-id="<%= entry._id %>"
+                               data-game-id="<%= normalizedGameId %>"
+                               data-can-rate="<%= canRate ? 'true' : 'false' %>"
+                               data-away-team="<%= game.awayTeamName %>"
+                               data-home-team="<%= game.homeTeamName %>"
+                               data-game-date="<%= game.startDate || game.StartDate %>"
+                               data-away-logo="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>"
+                               data-home-logo="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>"
+                               data-away-score="<%= game.AwayPoints != null ? game.AwayPoints : '' %>"
+                               data-home-score="<%= game.HomePoints != null ? game.HomePoints : '' %>"
+                               data-entry-elo="<%= entry.elo %>">
 
                                 <div class="card shadow-sm h-100 game-card p-3 text-center position-relative <%= entry.checkedIn ? 'checked-in-border' : '' %>" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                                     <div class="venue-overlay"><%= game.Venue || game.venue %></div>
@@ -236,6 +253,69 @@
     </div>
 
     <% if(isCurrentUser){ %>
+    <div class="modal fade user-search-modal" id="rateGameModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content p-3">
+                <form id="rateGameForm" enctype="multipart/form-data">
+                    <input type="hidden" name="entryId" id="rateEntryId">
+                    <input type="hidden" name="compareGameId1" id="rateCompareGameId1">
+                    <input type="hidden" name="winner1" id="rateWinner1">
+                    <input type="hidden" name="compareGameId2" id="rateCompareGameId2">
+                    <input type="hidden" name="winner2" id="rateWinner2">
+                    <input type="hidden" name="compareGameId3" id="rateCompareGameId3">
+                    <input type="hidden" name="winner3" id="rateWinner3">
+                    <div class="modal-header border-0">
+                        <h3 class="text-white fw-bold mb-0" id="rateModalTitle">Rate this game!</h3>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="rateManualSection">
+                            <div class="mb-3 position-relative">
+                                <label class="form-label d-flex justify-content-between">
+                                    <span>Rating:</span>
+                                    <span id="rateRatingValue" class="fw-bold text-white">5</span>
+                                </label>
+                                <div class="glass-range-wrapper">
+                                    <input type="range" id="rateRatingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.1" value="5">
+                                </div>
+                            </div>
+                        </div>
+                        <div id="rateEloSection" style="display:none;">
+                            <div class="mb-3">
+                                <div class="d-flex justify-content-between mb-3">
+                                    <div id="rateNewGameCard" class="elo-game-card flex-fill me-2"></div>
+                                    <div id="rateExistingGameCard" class="elo-game-card flex-fill ms-2"></div>
+                                </div>
+                                <p id="rateComparisonPrompt" class="mb-2 fw-bold text-center"></p>
+                                <div id="rateComparisonButtons" class="d-flex justify-content-around" style="display:none;">
+                                    <button type="button" class="btn btn-primary btn-sm" id="rateBetterBtn">New Game</button>
+                                    <button type="button" class="btn btn-secondary btn-sm" id="rateWorseBtn">Existing Game</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Photo</label>
+                            <input type="file" name="photo" class="form-control glass-control" id="ratePhotoInput">
+                            <div id="ratePhotoPreview" class="mt-2 d-none">
+                                <img src="" alt="Preview" class="img-fluid rounded">
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label d-flex justify-content-between">
+                                <span>Comment</span>
+                                <small id="rateCommentCounter">0/100</small>
+                            </label>
+                            <textarea id="rateCommentInput" class="form-control glass-control" name="comment" rows="3" maxlength="100"></textarea>
+                        </div>
+                        <div id="rateError" class="alert alert-danger d-none" role="alert"></div>
+                    </div>
+                    <div class="modal-footer border-0">
+                        <button type="submit" class="btn btn-primary" id="rateSubmitBtn">Submit</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
     <div class="modal fade user-search-modal" id="editGameModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content p-3">
@@ -284,9 +364,12 @@
         })) %>;
         window.gameEntriesData = <%- JSON.stringify(gameEntries || []) %>;
         window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
+        window.profileUserId = "<%= user._id %>";
+        window.loggedInUserId = "<%= viewer ? viewer._id : '' %>";
     </script>
     <script src="/js/addGameModal.js"></script>
     <script src="/js/editGameModal.js"></script>
+    <script src="/js/rateGameModal.js"></script>
     <script>
         const followBtn = document.getElementById('followBtn');
         if(followBtn){


### PR DESCRIPTION
## Summary
- add a backend handler and schema support so unrated game entries can be finalized with manual or Elo-derived values
- add a profile page modal that mirrors the add-game styling and opens when clicking an unrated entry
- implement client logic to drive manual ratings or This-or-That matchups and submit the results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac906c1b08326a963717f585d04c3