### PR TITLE
Add waitlist coordination invites and chat

### DIFF
--- a/controllers/coordinationController.js
+++ b/controllers/coordinationController.js
@@ -1,0 +1,293 @@
+const mongoose = require('mongoose');
+const Game = require('../models/Game');
+const User = require('../models/users');
+const GameCoordination = require('../models/GameCoordination');
+const Notification = require('../models/Notification');
+const GameChatMessage = require('../models/GameChatMessage');
+
+const isValidObjectId = (value) => mongoose.Types.ObjectId.isValid(String(value));
+
+async function ensureCoordination(ownerId, gameId) {
+    const existing = await GameCoordination.findOne({ ownerId, gameId });
+    if (existing) return existing;
+    return GameCoordination.create({ ownerId, gameId, invitedUsers: [] });
+}
+
+function mapInvite(invite) {
+    const user = invite.userId;
+    const userId = user && user._id ? user._id : invite.userId;
+    return {
+        _id: userId,
+        username: user && user.username ? user.username : undefined,
+        profileImageUrl: `/users/${userId}/profile-image`,
+        response: invite.response || null
+    };
+}
+
+exports.getCoordination = async (req, res, next) => {
+    try {
+        const { gameId } = req.params;
+        const ownerId = req.query.owner;
+        if (!isValidObjectId(gameId) || !isValidObjectId(ownerId)) {
+            return res.status(400).json({ error: 'Invalid identifiers' });
+        }
+
+        const game = await Game.findById(gameId).select('_id');
+        if (!game) {
+            return res.status(404).json({ error: 'Game not found' });
+        }
+
+        const isOwner = String(req.user.id) === String(ownerId);
+        let coordination = await GameCoordination.findOne({ ownerId, gameId })
+            .populate('invitedUsers.userId', 'username');
+
+        if (!coordination && isOwner) {
+            coordination = await ensureCoordination(ownerId, gameId);
+            coordination = await coordination.populate('invitedUsers.userId', 'username');
+        }
+
+        if (!coordination) {
+            return res.json({
+                invitedUsers: [],
+                isOwner: false,
+                canInvite: false,
+                canRespond: false,
+                currentUserResponse: null,
+                chatEnabled: false,
+                canSendChat: false
+            });
+        }
+
+        const invite = coordination.findInviteForUser(req.user.id);
+        const canRespond = !!invite;
+        const currentUserResponse = invite ? invite.response : null;
+        const chatEnabled = isOwner || (invite && invite.response === 'yes');
+        const canSendChat = chatEnabled && (isOwner || (invite && invite.response === 'yes'));
+
+        const populatedInvites = coordination.invitedUsers.map(mapInvite);
+
+        res.json({
+            invitedUsers: populatedInvites,
+            isOwner,
+            canInvite: isOwner,
+            canRespond,
+            currentUserResponse,
+            chatEnabled,
+            canSendChat
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.inviteUser = async (req, res, next) => {
+    try {
+        const { gameId } = req.params;
+        const { userId, ownerId } = req.body;
+
+        if (!isValidObjectId(gameId) || !isValidObjectId(userId) || !isValidObjectId(ownerId)) {
+            return res.status(400).json({ error: 'Invalid identifiers' });
+        }
+
+        if (String(ownerId) !== String(req.user.id)) {
+            return res.status(403).json({ error: 'Only the waitlist owner can invite users' });
+        }
+
+        if (String(userId) === String(ownerId)) {
+            return res.status(400).json({ error: 'You cannot invite yourself' });
+        }
+
+        const [game, targetUser] = await Promise.all([
+            Game.findById(gameId).select('awayTeamName homeTeamName startDate'),
+            User.findById(userId).select('username')
+        ]);
+
+        if (!game || !targetUser) {
+            return res.status(404).json({ error: 'Game or user not found' });
+        }
+
+        const coordination = await ensureCoordination(ownerId, gameId);
+        const alreadyInvited = coordination.findInviteForUser(userId);
+        if (alreadyInvited) {
+            return res.status(409).json({ error: 'User already invited' });
+        }
+
+        coordination.invitedUsers.push({ userId, response: null });
+        await coordination.save();
+
+        const inviterName = req.user.username || (await User.findById(req.user.id).select('username'))?.username || 'Someone';
+        const message = `${inviterName} invited you to ${game.awayTeamName} @ ${game.homeTeamName}`;
+
+        await Notification.findOneAndUpdate(
+            {
+                recipientId: userId,
+                senderId: ownerId,
+                gameId,
+                type: 'game-invite'
+            },
+            {
+                recipientId: userId,
+                senderId: ownerId,
+                gameId,
+                type: 'game-invite',
+                message,
+                status: 'pending',
+                response: null
+            },
+            { upsert: true, new: true, setDefaultsOnInsert: true }
+        );
+
+        res.json({
+            invitedUser: {
+                _id: userId,
+                username: targetUser.username,
+                profileImageUrl: `/users/${userId}/profile-image`,
+                response: null
+            }
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.respondToInvite = async (req, res, next) => {
+    try {
+        const { gameId } = req.params;
+        const { response, ownerId } = req.body;
+        const normalized = (response || '').toLowerCase();
+        if (!['yes', 'no', 'maybe'].includes(normalized)) {
+            return res.status(400).json({ error: 'Invalid response' });
+        }
+        if (!isValidObjectId(gameId)) {
+            return res.status(400).json({ error: 'Invalid game id' });
+        }
+
+        const query = { gameId };
+        if (ownerId && isValidObjectId(ownerId)) {
+            query.ownerId = ownerId;
+        }
+        query['invitedUsers.userId'] = req.user.id;
+
+        const update = await GameCoordination.findOneAndUpdate(
+            query,
+            { $set: { 'invitedUsers.$.response': normalized } },
+            { new: true }
+        );
+
+        if (!update) {
+            return res.status(404).json({ error: 'Invitation not found' });
+        }
+
+        await Notification.updateMany(
+            {
+                recipientId: req.user.id,
+                gameId,
+                ...(ownerId && isValidObjectId(ownerId) ? { senderId: ownerId } : {})
+            },
+            {
+                status: 'read',
+                response: normalized
+            }
+        );
+
+        res.json({ success: true, response: normalized });
+    } catch (err) {
+        next(err);
+    }
+};
+
+async function getCoordinationForChat(req, ownerId, gameId) {
+    if (!isValidObjectId(ownerId) || !isValidObjectId(gameId)) {
+        return null;
+    }
+    return GameCoordination.findOne({ ownerId, gameId });
+}
+
+function canAccessChat(userId, coordination, ownerId) {
+    if (!coordination) return false;
+    if (String(userId) === String(ownerId)) return true;
+    const invite = coordination.findInviteForUser(userId);
+    return invite && invite.response === 'yes';
+}
+
+exports.getChatMessages = async (req, res, next) => {
+    try {
+        const { gameId } = req.params;
+        const ownerId = req.query.owner;
+        if (!isValidObjectId(gameId) || !isValidObjectId(ownerId)) {
+            return res.status(400).json({ error: 'Invalid identifiers' });
+        }
+
+        const coordination = await getCoordinationForChat(req, ownerId, gameId);
+        if (!coordination) {
+            return res.status(404).json({ error: 'Coordination not found' });
+        }
+
+        if (!canAccessChat(req.user.id, coordination, ownerId)) {
+            return res.status(403).json({ error: 'Not authorized for chat' });
+        }
+
+        const messages = await GameChatMessage.find({ coordinationId: coordination._id })
+            .sort({ timestamp: 1 })
+            .limit(200)
+            .populate('senderId', 'username');
+
+        res.json({
+            messages: messages.map(msg => ({
+                _id: msg._id,
+                message: msg.message,
+                timestamp: msg.timestamp,
+                sender: msg.senderId ? {
+                    _id: msg.senderId._id,
+                    username: msg.senderId.username
+                } : null
+            }))
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.postChatMessage = async (req, res, next) => {
+    try {
+        const { gameId } = req.params;
+        const ownerId = req.body.ownerId;
+        const message = (req.body.message || '').trim();
+        if (!message) {
+            return res.status(400).json({ error: 'Message required' });
+        }
+        if (!isValidObjectId(gameId) || !isValidObjectId(ownerId)) {
+            return res.status(400).json({ error: 'Invalid identifiers' });
+        }
+
+        const coordination = await getCoordinationForChat(req, ownerId, gameId);
+        if (!coordination) {
+            return res.status(404).json({ error: 'Coordination not found' });
+        }
+
+        if (!canAccessChat(req.user.id, coordination, ownerId)) {
+            return res.status(403).json({ error: 'Not authorized for chat' });
+        }
+
+        const newMessage = await GameChatMessage.create({
+            coordinationId: coordination._id,
+            gameId,
+            senderId: req.user.id,
+            message
+        });
+
+        const sender = await User.findById(req.user.id).select('username');
+
+        res.status(201).json({
+            _id: newMessage._id,
+            message: newMessage.message,
+            timestamp: newMessage.timestamp,
+            sender: {
+                _id: req.user.id,
+                username: sender ? sender.username : 'You'
+            }
+        });
+    } catch (err) {
+        next(err);
+    }
+};

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const express = require("express"),
     gamesController = require("./controllers/gamesController"),
     venuesController = require('./controllers/venuesController'),
     messagesController = require('./controllers/messagesController'),
+    coordinationController = require('./controllers/coordinationController'),
     comparisonController = require('./controllers/comparisonController'),
     badgeController = require('./controllers/badgeController'),
     socialController = require('./controllers/socialController'),
@@ -293,6 +294,11 @@ app.get('/pastGames/leagues', gamesController.listPastGameLeagues);
 app.get('/pastGames/seasons', gamesController.listPastGameSeasons);
 app.get('/pastGames/teams', gamesController.listPastGameTeams);
 app.get('/pastGames/search', gamesController.searchPastGames);
+app.get('/games/:gameId/coordination', requireAuth, coordinationController.getCoordination);
+app.post('/games/:gameId/invite', requireAuth, coordinationController.inviteUser);
+app.post('/games/:gameId/respond', requireAuth, coordinationController.respondToInvite);
+app.get('/games/:gameId/chat', requireAuth, coordinationController.getChatMessages);
+app.post('/games/:gameId/chat', requireAuth, coordinationController.postChatMessage);
 app.get('/pastGames/:id', gamesController.showPastGame);
 app.get('/games/:id', gamesController.showGame);
 app.get('/team/:id', async (req, res) => {

--- a/models/GameChatMessage.js
+++ b/models/GameChatMessage.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const gameChatMessageSchema = new mongoose.Schema({
+    coordinationId: { type: mongoose.Schema.Types.ObjectId, ref: 'GameCoordination', required: true },
+    gameId: { type: String, required: true },
+    senderId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    message: { type: String, required: true, maxlength: 1000 },
+    timestamp: { type: Date, default: Date.now }
+});
+
+gameChatMessageSchema.index({ coordinationId: 1, timestamp: 1 });
+
+gameChatMessageSchema.pre('save', function(next){
+    this.timestamp = this.timestamp || new Date();
+    next();
+});
+
+module.exports = mongoose.model('GameChatMessage', gameChatMessageSchema);

--- a/models/GameCoordination.js
+++ b/models/GameCoordination.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+const invitedUserSchema = new mongoose.Schema({
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    response: { type: String, enum: ['yes', 'no', 'maybe', null], default: null }
+}, { _id: false });
+
+const gameCoordinationSchema = new mongoose.Schema({
+    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    gameId: { type: mongoose.Schema.Types.ObjectId, ref: 'Game', required: true },
+    invitedUsers: { type: [invitedUserSchema], default: [] }
+}, { timestamps: true });
+
+gameCoordinationSchema.index({ ownerId: 1, gameId: 1 }, { unique: true });
+
+gameCoordinationSchema.methods.findInviteForUser = function(userId){
+    if(!userId) return null;
+    const idStr = String(userId);
+    return this.invitedUsers.find(invite => String(invite.userId) === idStr) || null;
+};
+
+module.exports = mongoose.model('GameCoordination', gameCoordinationSchema);

--- a/models/Notification.js
+++ b/models/Notification.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const notificationSchema = new mongoose.Schema({
+    recipientId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    senderId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    gameId: { type: mongoose.Schema.Types.ObjectId, ref: 'Game', required: true },
+    type: { type: String, default: 'game-invite' },
+    message: { type: String, required: true },
+    status: { type: String, enum: ['pending', 'read'], default: 'pending' },
+    response: { type: String, enum: ['yes', 'no', 'maybe', null], default: null }
+}, { timestamps: true });
+
+notificationSchema.index({ recipientId: 1, createdAt: -1 });
+
+module.exports = mongoose.model('Notification', notificationSchema);

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -881,6 +881,178 @@
   transition:left .3s;
 }
 
+/* Waitlist coordination layout */
+.waitlist-column{
+  display:flex;
+  flex-direction:column;
+  gap:2.5rem;
+  align-items:center;
+}
+
+.waitlist-game-wrapper{
+  width:80%;
+  max-width:960px;
+}
+
+.waitlist-game-wrapper .game-card{
+  border-radius:1.25rem;
+  min-height:260px;
+}
+
+.glass-panel{
+  background:rgba(255,255,255,0.12);
+  border:1px solid rgba(255,255,255,0.22);
+  border-radius:1.25rem;
+  padding:1.5rem;
+  backdrop-filter:blur(16px);
+  box-shadow:0 20px 45px rgba(15,23,42,0.25);
+}
+
+.glassy-card{
+  background:rgba(15,23,42,0.35);
+  border:1px solid rgba(255,255,255,0.15);
+  border-radius:1rem;
+  backdrop-filter:blur(12px);
+}
+
+.tracking-wide{
+  letter-spacing:0.15em;
+}
+
+.response-label{
+  color:rgba(255,255,255,0.85);
+}
+
+.response-controls .response-btn{
+  min-width:72px;
+  text-transform:uppercase;
+  font-weight:600;
+}
+
+.response-controls .response-btn.active{
+  background:linear-gradient(120deg,#14b8a6,#7e22ce);
+  border-color:transparent;
+}
+
+.invited-users{
+  min-height:60px;
+}
+
+.invited-tile{
+  display:flex;
+  align-items:center;
+  gap:0.75rem;
+  padding:0.85rem 1.1rem;
+  border-radius:1rem;
+  min-width:220px;
+  color:#fff;
+  box-shadow:0 10px 24px rgba(15,23,42,0.25);
+  border:1px solid rgba(255,255,255,0.2);
+  backdrop-filter:blur(12px);
+}
+
+.invited-tile--yes{
+  background:linear-gradient(135deg,rgba(20,184,166,0.85),rgba(126,34,206,0.85));
+}
+
+.invited-tile--no{
+  background:rgba(220,38,38,0.45);
+}
+
+.invited-tile--maybe,
+.invited-tile--pending{
+  background:rgba(148,163,184,0.35);
+}
+
+.invited-avatar img{
+  width:48px;
+  height:48px;
+  border-radius:50%;
+  object-fit:cover;
+  border:2px solid rgba(255,255,255,0.55);
+}
+
+.invited-name{
+  font-weight:700;
+}
+
+.invited-status{
+  font-size:0.75rem;
+  opacity:0.85;
+  display:block;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+}
+
+.chat-wrapper .chat-toggle{
+  width:100%;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+}
+
+.chat-messages{
+  padding:1.1rem;
+  max-height:280px;
+  overflow-y:auto;
+}
+
+.chat-message-stream{
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+}
+
+.chat-bubble{
+  background:rgba(148,163,184,0.25);
+  border-radius:1rem;
+  padding:0.85rem 1rem;
+  color:#f8fafc;
+  border:1px solid rgba(255,255,255,0.18);
+  backdrop-filter:blur(12px);
+}
+
+.chat-bubble--own{
+  background:linear-gradient(135deg,rgba(20,184,166,0.8),rgba(126,34,206,0.8));
+  align-self:flex-end;
+}
+
+.chat-bubble-header{
+  font-size:0.75rem;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  opacity:0.8;
+}
+
+.chat-bubble-name{
+  font-weight:600;
+}
+
+.chat-bubble-body{
+  margin-top:0.35rem;
+  white-space:pre-wrap;
+  word-break:break-word;
+}
+
+@media (max-width: 992px){
+  .waitlist-game-wrapper{
+    width:90%;
+  }
+}
+
+@media (max-width: 768px){
+  .waitlist-game-wrapper{
+    width:100%;
+  }
+  .invited-tile{
+    min-width:0;
+    width:100%;
+  }
+  .chat-wrapper .chat-toggle{
+    font-size:0.85rem;
+  }
+}
+
 .inbox-follower-badge{
   width:0.5rem;
   height:0.5rem;

--- a/public/js/waitlistCoordination.js
+++ b/public/js/waitlistCoordination.js
@@ -1,0 +1,316 @@
+(function(){
+    const body = document.body;
+    if(!body) return;
+
+    const viewerId = body.dataset.viewerId || '';
+    const coordinationBlocks = document.querySelectorAll('.waitlist-coordination');
+    if(!coordinationBlocks.length) return;
+
+    const pollers = new Map();
+
+    const responseLabels = {
+        yes: 'Going',
+        no: 'Not going',
+        maybe: 'Maybe',
+        null: 'Awaiting response',
+        undefined: 'Awaiting response'
+    };
+
+    const classForResponse = (response) => {
+        switch(response){
+            case 'yes':
+                return 'invited-tile invited-tile--yes';
+            case 'no':
+                return 'invited-tile invited-tile--no';
+            case 'maybe':
+                return 'invited-tile invited-tile--maybe';
+            default:
+                return 'invited-tile invited-tile--pending';
+        }
+    };
+
+    function renderInvitedUsers(container, invitedUsers){
+        const list = container.querySelector('.invited-users');
+        const emptyState = container.querySelector('.empty-invites');
+        if(!list) return;
+        list.innerHTML = '';
+        if(!invitedUsers || !invitedUsers.length){
+            if(emptyState) emptyState.classList.remove('d-none');
+            return;
+        }
+        if(emptyState) emptyState.classList.add('d-none');
+        invitedUsers.forEach(user => {
+            const tile = document.createElement('div');
+            tile.className = classForResponse(user.response);
+            tile.innerHTML = `
+                <div class="invited-avatar">
+                    <img src="${user.profileImageUrl}" alt="${user.username || 'User'}">
+                </div>
+                <div class="invited-meta">
+                    <span class="invited-name">${user.username || 'User'}</span>
+                    <span class="invited-status">${responseLabels[user.response || 'undefined']}</span>
+                </div>
+            `;
+            list.appendChild(tile);
+        });
+    }
+
+    function updateResponseControls(container, data){
+        const controls = container.querySelector('.response-controls');
+        if(!controls) return;
+        const ownerId = container.dataset.ownerId;
+        if(!data.canRespond || !viewerId || String(ownerId) === String(viewerId)){
+            controls.classList.add('d-none');
+            return;
+        }
+        controls.classList.remove('d-none');
+        const current = data.currentUserResponse || '';
+        controls.querySelectorAll('.response-btn').forEach(btn => {
+            const btnResp = btn.dataset.response;
+            if(btnResp === current){
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        });
+        if(!controls.dataset.bound){
+            controls.addEventListener('click', async (event) => {
+                const target = event.target.closest('.response-btn');
+                if(!target) return;
+                const desired = target.dataset.response;
+                if(!desired) return;
+                if(target.classList.contains('disabled')) return;
+                try{
+                    target.classList.add('disabled');
+                    await submitResponse(container, desired);
+                } catch (err){
+                    console.error(err);
+                    alert('Unable to update your response right now.');
+                } finally {
+                    target.classList.remove('disabled');
+                }
+            });
+            controls.dataset.bound = 'true';
+        }
+    }
+
+    async function submitResponse(container, response){
+        const gameId = container.dataset.gameId;
+        const ownerId = container.dataset.ownerId;
+        const res = await fetch(`/games/${gameId}/respond`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ response, ownerId })
+        });
+        if(!res.ok){
+            throw new Error('Failed to update response');
+        }
+        await loadCoordination(container);
+    }
+
+    function stopPolling(key){
+        const interval = pollers.get(key);
+        if(interval){
+            clearInterval(interval);
+            pollers.delete(key);
+        }
+    }
+
+    function renderChatMessages(container, messages){
+        const stream = container.querySelector('.chat-message-stream');
+        const empty = container.querySelector('.chat-empty');
+        if(!stream) return;
+        stream.innerHTML = '';
+        if(!messages || !messages.length){
+            if(empty) empty.classList.remove('d-none');
+            return;
+        }
+        if(empty) empty.classList.add('d-none');
+        messages.forEach(msg => {
+            const bubble = document.createElement('div');
+            const senderId = msg.sender && msg.sender._id ? String(msg.sender._id) : '';
+            const isOwn = viewerId && senderId === String(viewerId);
+            bubble.className = `chat-bubble${isOwn ? ' chat-bubble--own' : ''}`;
+            const senderName = msg.sender && msg.sender.username ? msg.sender.username : 'User';
+            const timestamp = msg.timestamp ? new Date(msg.timestamp) : new Date();
+            const formatted = timestamp.toLocaleString(undefined, { hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
+            bubble.innerHTML = `
+                <div class="chat-bubble-header d-flex justify-content-between">
+                    <span class="chat-bubble-name">${senderName}</span>
+                    <span class="chat-bubble-time">${formatted}</span>
+                </div>
+                <div class="chat-bubble-body">${escapeHtml(msg.message || '')}</div>
+            `;
+            stream.appendChild(bubble);
+        });
+        stream.scrollTop = stream.scrollHeight;
+    }
+
+    function escapeHtml(text){
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    async function fetchChatMessages(container){
+        const state = container.__coordinationState;
+        if(!state || !state.chatEnabled) return;
+        const gameId = container.dataset.gameId;
+        const ownerId = container.dataset.ownerId;
+        try{
+            const res = await fetch(`/games/${gameId}/chat?owner=${ownerId}`);
+            if(!res.ok) return;
+            const data = await res.json();
+            renderChatMessages(container, data.messages || []);
+        } catch (err){
+            console.error('Failed to fetch chat messages', err);
+        }
+    }
+
+    function setupChat(container, data){
+        const wrapper = container.querySelector('.chat-wrapper');
+        if(!wrapper) return;
+        const chatKey = `${container.dataset.gameId}-${container.dataset.ownerId}`;
+        if(!data.chatEnabled){
+            wrapper.classList.add('d-none');
+            stopPolling(chatKey);
+            return;
+        }
+        wrapper.classList.remove('d-none');
+
+        const collapse = wrapper.querySelector('.chat-section');
+        if(collapse && !collapse.dataset.bound){
+            collapse.addEventListener('show.bs.collapse', () => {
+                fetchChatMessages(container);
+                if(!pollers.has(chatKey)){
+                    const interval = setInterval(() => fetchChatMessages(container), 7000);
+                    pollers.set(chatKey, interval);
+                }
+            });
+            collapse.addEventListener('hide.bs.collapse', () => {
+                stopPolling(chatKey);
+            });
+            collapse.dataset.bound = 'true';
+        }
+
+        const form = wrapper.querySelector('.chat-form');
+        const input = wrapper.querySelector('.chat-input');
+        const sendBtn = wrapper.querySelector('.chat-send');
+        const canSend = !!data.canSendChat;
+        if(form){
+            form.classList.toggle('d-none', !canSend);
+            form.dataset.enabled = canSend ? 'true' : 'false';
+            if(!form.dataset.bound){
+                form.addEventListener('submit', async (event) => {
+                    event.preventDefault();
+                    if(form.dataset.enabled !== 'true') return;
+                    const value = input.value.trim();
+                    if(!value) return;
+                    try{
+                        if(sendBtn) sendBtn.disabled = true;
+                        await sendChatMessage(container, value);
+                        input.value = '';
+                        fetchChatMessages(container);
+                    } catch (err){
+                        console.error(err);
+                        alert('Unable to send message right now.');
+                    } finally {
+                        if(sendBtn) sendBtn.disabled = false;
+                    }
+                });
+                form.dataset.bound = 'true';
+            }
+        }
+        if(input){
+            input.disabled = !canSend;
+            input.placeholder = canSend ? 'Share your plan...' : 'Waiting for invite confirmation...';
+        }
+        if(sendBtn){
+            sendBtn.disabled = !canSend;
+        }
+    }
+
+    async function sendChatMessage(container, message){
+        const gameId = container.dataset.gameId;
+        const ownerId = container.dataset.ownerId;
+        const res = await fetch(`/games/${gameId}/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ownerId, message })
+        });
+        if(!res.ok){
+            throw new Error('Failed to send message');
+        }
+    }
+
+    function setupInviteSelect(container){
+        const select = container.querySelector('.invite-select');
+        if(!select || typeof $ === 'undefined' || !$.fn.select2) return;
+        const gameId = container.dataset.gameId;
+        const ownerId = container.dataset.ownerId;
+        $(select).select2({
+            placeholder: select.dataset.placeholder || 'Invite by username',
+            dropdownParent: $(select).closest('.waitlist-coordination'),
+            width: '100%',
+            ajax: {
+                url: '/users/search',
+                dataType: 'json',
+                delay: 200,
+                data: params => ({ q: params.term || '' }),
+                processResults: data => ({
+                    results: data.map(user => ({ id: user._id, text: user.username }))
+                })
+            },
+            minimumInputLength: 1
+        });
+
+        $(select).on('select2:select', async (event) => {
+            const userId = event.params.data.id;
+            try {
+                $(select).prop('disabled', true);
+                const res = await fetch(`/games/${gameId}/invite`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ownerId, userId })
+                });
+                if(res.ok){
+                    await loadCoordination(container);
+                } else if(res.status === 409){
+                    alert('That user has already been invited.');
+                } else {
+                    alert('Unable to invite that user right now.');
+                }
+            } catch (err){
+                console.error(err);
+                alert('Unable to invite that user right now.');
+            } finally {
+                $(select).val(null).trigger('change');
+                $(select).prop('disabled', false);
+            }
+        });
+    }
+
+    async function loadCoordination(container){
+        const gameId = container.dataset.gameId;
+        const ownerId = container.dataset.ownerId;
+        try{
+            const res = await fetch(`/games/${gameId}/coordination?owner=${ownerId}`);
+            if(!res.ok){
+                throw new Error('Failed to fetch coordination data');
+            }
+            const data = await res.json();
+            container.__coordinationState = data;
+            renderInvitedUsers(container, data.invitedUsers || []);
+            updateResponseControls(container, data);
+            setupChat(container, data);
+        } catch (err){
+            console.error(err);
+        }
+    }
+
+    coordinationBlocks.forEach(container => {
+        container.dataset.gameId = container.dataset.gameId || container.closest('[data-game-id]')?.dataset.gameId || '';
+        setupInviteSelect(container);
+        loadCoordination(container);
+    });
+})();

--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -13,7 +13,7 @@
 }
         @media    </style>
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100" data-viewer-id="<%= viewer ? viewer.id : '' %>" data-profile-owner-id="<%= user._id %>">
     <%- include('partials/header') %>
     <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'waitlist' }) %>
     <div class="container my-4 flex-grow-1">
@@ -29,14 +29,16 @@
         </div>
         <% } %>
         <% if (wishlistGames && wishlistGames.length > 0) { %>
-            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 " id="gamesContainer">
+            <div class="waitlist-column" id="gamesContainer">
             <% wishlistGames.forEach(function(game){
                  const awayColor = game.awayTeam && game.awayTeam.color ? game.awayTeam.color : '#ffffff';
-                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff'; %>
-            <div class="col">
+                 const homeColor = game.homeTeam && game.homeTeam.color ? game.homeTeam.color : '#ffffff';
+                 const chatCollapseId = `chat-${game._id}`;
+            %>
+            <div class="waitlist-game-wrapper" data-game-id="<%= game._id %>">
                 <div class="position-relative">
                     <a href="<%= usePastGameLinks ? '/pastGames/' + game._id : '/games/' + game._id %>" class="game-link d-block">
-                        <div class="card shadow-sm h-100 game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                        <div class="card shadow-sm game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
                             <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
                             <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
                                 <div class="logo-wrapper me-3">
@@ -56,6 +58,41 @@
                         </div>
                     </a>
                 </div>
+                <div class="waitlist-coordination glass-panel mt-3" data-game-id="<%= game._id %>" data-owner-id="<%= user._id %>" data-chat-target="<%= chatCollapseId %>">
+                    <% if (isCurrentUser) { %>
+                    <div class="invite-area mb-3">
+                        <label class="form-label gradient-text small text-uppercase tracking-wide">Invite friends</label>
+                        <select class="form-select invite-select" data-placeholder="Invite by username"></select>
+                    </div>
+                    <% } %>
+                    <div class="response-controls card glassy-card mb-3 d-none">
+                        <div class="card-body py-2 d-flex flex-wrap align-items-center gap-2">
+                            <span class="response-label text-uppercase small fw-semibold">Your response</span>
+                            <div class="btn-group btn-group-sm response-buttons" role="group">
+                                <button type="button" class="btn glassy-btn response-btn" data-response="yes">Yes</button>
+                                <button type="button" class="btn glassy-btn response-btn" data-response="maybe">Maybe</button>
+                                <button type="button" class="btn glassy-btn response-btn" data-response="no">No</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="invited-users d-flex flex-wrap gap-3"></div>
+                    <div class="empty-invites text-muted small py-2 d-none">No invites yet. Start by adding friends above.</div>
+                    <div class="chat-wrapper mt-3 d-none">
+                        <button class="btn gradient-glass-btn chat-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#<%= chatCollapseId %>" aria-expanded="false" aria-controls="<%= chatCollapseId %>">
+                            Coordinate with attendees
+                        </button>
+                        <div class="collapse chat-section mt-3" id="<%= chatCollapseId %>">
+                            <div class="chat-messages glassy-card mb-3">
+                                <div class="chat-empty text-muted small py-3 text-center">No messages yet. Be the first to plan logistics!</div>
+                                <div class="chat-message-stream"></div>
+                            </div>
+                            <form class="chat-form d-flex flex-column flex-md-row gap-2">
+                                <input type="text" class="form-control glass-control chat-input" placeholder="Share your plan...">
+                                <button type="submit" class="btn gradient-glass-btn chat-send">Send</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
             </div>
             <% }); %>
         </div>
@@ -74,6 +111,7 @@
         window.eloGamesData = <%- JSON.stringify(eloGames || []) %>;
     </script>
     <script src="/js/addGameModal.js"></script>
+    <script src="/js/waitlistCoordination.js"></script>
     <script>
         const followBtn = document.getElementById('followBtn');
         if(followBtn){


### PR DESCRIPTION
## Summary
- refactor the waitlist profile view into a centered single-column layout with invite and chat sections under each game
- add coordination, notification, and chat models plus routes to manage invites, RSVP responses, and lightweight per-game messaging
- implement front-end coordination script and glassy styling for invite tiles, RSVP controls, and group chat interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad8e0eeb083269225115d2858d0c5