### PR TITLE
Refine waitlist coordination UI

### DIFF
--- a/views/profileWaitlist.ejs
+++ b/views/profileWaitlist.ejs
@@ -8,10 +8,130 @@
     <link rel="stylesheet" href="/css/custom.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-    <style>        .team-name {
-    color: white !important;
-}
-        @media    </style>
+    <style>
+        .team-name {
+            color: white !important;
+        }
+
+        .waitlist-game-wrapper {
+            margin-bottom: 2rem;
+        }
+
+        .game-coordination-card {
+            border-radius: 1rem;
+            overflow: hidden;
+            background: rgba(255, 255, 255, 0.9);
+        }
+
+        .game-coordination-card .game-link {
+            border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+        }
+
+        .compact-game-card {
+            padding: 1rem 0.75rem;
+            border-radius: 1rem 1rem 0 0;
+        }
+
+        .compact-game-card .game-date {
+            margin-bottom: 0.5rem !important;
+            font-size: 0.95rem;
+        }
+
+        .compact-game-card .logo-wrapper {
+            width: 92px;
+        }
+
+        .compact-game-card .team-logo-container {
+            width: 52px;
+            height: 52px;
+            margin-bottom: 0.15rem;
+        }
+
+        .compact-game-card .team-logo-container img {
+            width: 46px;
+            height: 46px;
+        }
+
+        .compact-game-card .team-name {
+            font-size: 0.9rem;
+        }
+
+        .compact-game-card .at-symbol {
+            font-size: 2rem;
+        }
+
+        .game-coordination-body {
+            padding: 1.25rem 1.25rem 1.5rem;
+            background: rgba(255, 255, 255, 0.92);
+        }
+
+        .game-coordination-body .invite-area {
+            margin-bottom: 1rem;
+        }
+
+        .invite-option {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .invite-option-avatar {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            object-fit: cover;
+            border: 2px solid rgba(255, 255, 255, 0.6);
+            background: rgba(255, 255, 255, 0.8);
+        }
+
+        .waitlist-coordination .select2-results__options {
+            max-height: 220px;
+            overflow-y: auto;
+        }
+
+        .waitlist-coordination .select2-results__option {
+            padding: 0.5rem 0.75rem;
+        }
+
+        .waitlist-coordination .select2-container--default .select2-selection--single {
+            border-radius: 0.75rem;
+            padding: 0.35rem 0.75rem;
+            height: auto;
+        }
+
+        .waitlist-coordination .select2-selection__rendered {
+            padding-left: 0 !important;
+        }
+
+        .waitlist-coordination .select2-selection__arrow {
+            top: 50%;
+            transform: translateY(-50%);
+        }
+
+        @media (max-width: 576px) {
+            .compact-game-card .logo-wrapper {
+                width: 80px;
+            }
+
+            .compact-game-card .team-logo-container {
+                width: 48px;
+                height: 48px;
+            }
+
+            .compact-game-card .team-logo-container img {
+                width: 42px;
+                height: 42px;
+            }
+
+            .compact-game-card .at-symbol {
+                font-size: 1.75rem;
+            }
+
+            .game-coordination-body {
+                padding: 1rem;
+            }
+        }
+    </style>
 </head>
 <body class="d-flex flex-column min-vh-100" data-viewer-id="<%= viewer ? viewer.id : '' %>" data-profile-owner-id="<%= user._id %>">
     <%- include('partials/header') %>
@@ -36,60 +156,60 @@
                  const chatCollapseId = `chat-${game._id}`;
             %>
             <div class="waitlist-game-wrapper" data-game-id="<%= game._id %>">
-                <div class="position-relative">
+                <div class="game-coordination-card card shadow-sm">
                     <a href="<%= usePastGameLinks ? '/pastGames/' + game._id : '/games/' + game._id %>" class="game-link d-block">
-                        <div class="card shadow-sm game-card p-3 text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
-                            <div class="game-date mb-2" data-start="<%= game.startDate.toISOString() %>"></div>
-                            <div class="d-flex justify-content-between align-items-center position-relative mb-2 px-3">
-                                <div class="logo-wrapper me-3">
+                        <div class="game-card compact-game-card text-center position-relative" data-away-color="<%= awayColor %>" data-home-color="<%= homeColor %>" style="background: linear-gradient(to right, <%= awayColor %>, <%= homeColor %>);">
+                            <div class="game-date" data-start="<%= game.startDate.toISOString() %>"></div>
+                            <div class="d-flex justify-content-between align-items-center position-relative px-3">
+                                <div class="logo-wrapper me-2">
                                     <div class="team-logo-container">
                                         <img loading="lazy" src="<%= game.awayTeam && game.awayTeam.logos && game.awayTeam.logos[0] ? game.awayTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.awayTeamName %>">
                                     </div>
                                     <span class="team-name"><%= game.awayTeamName %></span>
                                 </div>
-                                <div class="logo-wrapper ms-3">
+                                <div class="logo-wrapper ms-2">
                                     <div class="team-logo-container">
                                         <img loading="lazy" src="<%= game.homeTeam && game.homeTeam.logos && game.homeTeam.logos[0] ? game.homeTeam.logos[0] : '/images/placeholder.jpg' %>" alt="<%= game.homeTeamName %>">
                                     </div>
                                     <span class="team-name"><%= game.homeTeamName %></span>
                                 </div>
-                                <div class="position-absolute top-50 start-50 translate-middle fw-bold fs-4 at-symbol">@</div>
+                                <div class="position-absolute top-50 start-50 translate-middle fw-bold at-symbol">@</div>
                             </div>
                         </div>
                     </a>
-                </div>
-                <div class="waitlist-coordination glass-panel mt-3" data-game-id="<%= game._id %>" data-owner-id="<%= user._id %>" data-chat-target="<%= chatCollapseId %>">
-                    <% if (isCurrentUser) { %>
-                    <div class="invite-area mb-3">
-                        <label class="form-label gradient-text small text-uppercase tracking-wide">Invite friends</label>
-                        <select class="form-select invite-select" data-placeholder="Invite by username"></select>
-                    </div>
-                    <% } %>
-                    <div class="response-controls card glassy-card mb-3 d-none">
-                        <div class="card-body py-2 d-flex flex-wrap align-items-center gap-2">
-                            <span class="response-label text-uppercase small fw-semibold">Your response</span>
-                            <div class="btn-group btn-group-sm response-buttons" role="group">
+                    <div class="waitlist-coordination glass-panel game-coordination-body" data-game-id="<%= game._id %>" data-owner-id="<%= user._id %>" data-chat-target="<%= chatCollapseId %>">
+                        <% if (isCurrentUser) { %>
+                        <div class="invite-area">
+                            <label class="form-label gradient-text small text-uppercase tracking-wide mb-1">Invite friends</label>
+                            <select class="form-select invite-select" data-placeholder="Search by username"></select>
+                        </div>
+                        <% } %>
+                        <div class="response-controls card glassy-card mb-3 d-none">
+                            <div class="card-body py-2 d-flex flex-wrap align-items-center gap-2">
+                                <span class="response-label text-uppercase small fw-semibold">Your response</span>
+                                <div class="btn-group btn-group-sm response-buttons" role="group">
                                 <button type="button" class="btn glassy-btn response-btn" data-response="yes">Yes</button>
                                 <button type="button" class="btn glassy-btn response-btn" data-response="maybe">Maybe</button>
                                 <button type="button" class="btn glassy-btn response-btn" data-response="no">No</button>
                             </div>
                         </div>
                     </div>
-                    <div class="invited-users d-flex flex-wrap gap-3"></div>
-                    <div class="empty-invites text-muted small py-2 d-none">No invites yet. Start by adding friends above.</div>
-                    <div class="chat-wrapper mt-3 d-none">
-                        <button class="btn gradient-glass-btn chat-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#<%= chatCollapseId %>" aria-expanded="false" aria-controls="<%= chatCollapseId %>">
-                            Coordinate with attendees
-                        </button>
-                        <div class="collapse chat-section mt-3" id="<%= chatCollapseId %>">
-                            <div class="chat-messages glassy-card mb-3">
-                                <div class="chat-empty text-muted small py-3 text-center">No messages yet. Be the first to plan logistics!</div>
-                                <div class="chat-message-stream"></div>
+                        <div class="invited-users d-flex flex-wrap gap-3"></div>
+                        <div class="empty-invites text-muted small py-2 d-none">No invites yet. Start by adding friends above.</div>
+                        <div class="chat-wrapper mt-3 d-none">
+                            <button class="btn gradient-glass-btn chat-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#<%= chatCollapseId %>" aria-expanded="false" aria-controls="<%= chatCollapseId %>">
+                                Coordinate with attendees
+                            </button>
+                            <div class="collapse chat-section mt-3" id="<%= chatCollapseId %>">
+                                <div class="chat-messages glassy-card mb-3">
+                                    <div class="chat-empty text-muted small py-3 text-center">No messages yet. Be the first to plan logistics!</div>
+                                    <div class="chat-message-stream"></div>
+                                </div>
+                                <form class="chat-form d-flex flex-column flex-md-row gap-2">
+                                    <input type="text" class="form-control glass-control chat-input" placeholder="Share your plan...">
+                                    <button type="submit" class="btn gradient-glass-btn chat-send">Send</button>
+                                </form>
                             </div>
-                            <form class="chat-form d-flex flex-column flex-md-row gap-2">
-                                <input type="text" class="form-control glass-control chat-input" placeholder="Share your plan...">
-                                <button type="submit" class="btn gradient-glass-btn chat-send">Send</button>
-                            </form>
                         </div>
                     </div>
                 </div>
@@ -104,6 +224,36 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script>
+        if(window.jQuery && window.jQuery.fn && window.jQuery.fn.select2){
+            (function($){
+                const renderOption = (data) => {
+                    if(!data.id){
+                        return data.text;
+                    }
+                    const username = data.text || '';
+                    const avatarUrl = `/users/${data.id}/profile-image`;
+                    const $container = $('<div>', { class: 'invite-option' });
+                    $('<img>', {
+                        class: 'invite-option-avatar',
+                        src: avatarUrl,
+                        alt: username,
+                        loading: 'lazy'
+                    }).appendTo($container);
+                    $('<span>', { text: username }).appendTo($container);
+                    return $container;
+                };
+
+                $.fn.select2.defaults.set('templateResult', renderOption);
+                $.fn.select2.defaults.set('templateSelection', (data) => {
+                    if(!data.id){
+                        return data.text;
+                    }
+                    return data.text;
+                });
+            })(window.jQuery);
+        }
+    </script>
     <script src="/js/profileModals.js"></script>
     <script>
         window.existingGameIds = <%- JSON.stringify((user.gameEntries || []).map(e => String(e.gameId))) %>;


### PR DESCRIPTION
## Summary
- compact the waitlist game cards and wrap the coordination tools in a single cohesive container
- position the invite and chat controls directly beneath each matchup while preserving existing functionality
- enhance the invite dropdown with avatar-backed search results and scrollable suggestions for easier attendee selection

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dae1f88c4483268fa79720065757e5