### PR TITLE
Add login-queued invite modal for waitlist game groups

### DIFF
--- a/controllers/coordinationController.js
+++ b/controllers/coordinationController.js
@@ -4,6 +4,9 @@ const User = require('../models/users');
 const GameCoordination = require('../models/GameCoordination');
 const Notification = require('../models/Notification');
 const GameChatMessage = require('../models/GameChatMessage');
+const { getGameById } = require('../lib/gameUtils');
+
+const PLACEHOLDER_LOGO = '/images/placeholder.jpg';
 
 const isValidObjectId = (value) => mongoose.Types.ObjectId.isValid(String(value));
 
@@ -21,6 +24,132 @@ function mapInvite(invite) {
         username: user && user.username ? user.username : undefined,
         profileImageUrl: `/users/${userId}/profile-image`,
         response: invite.response || null
+    };
+}
+
+function pickFirstString(...values) {
+    for (const value of values) {
+        if (typeof value === 'string' && value.trim()) {
+            return value.trim();
+        }
+    }
+    return '';
+}
+
+function extractTeamLogo(team) {
+    if (!team) return PLACEHOLDER_LOGO;
+    if (Array.isArray(team.logos) && team.logos.length) {
+        return team.logos[0];
+    }
+    if (typeof team.logo === 'string' && team.logo) {
+        return team.logo;
+    }
+    return PLACEHOLDER_LOGO;
+}
+
+async function buildInviteGameDetails(invite) {
+    const canonicalGameId = Number(invite.gameId);
+    if (Number.isFinite(canonicalGameId)) {
+        const game = await getGameById(canonicalGameId);
+        if (game) {
+            const venueName = pickFirstString(
+                game.venue && game.venue.name,
+                game.venue && game.venue.fullName,
+                game.venue,
+                game.Venue
+            );
+            return {
+                gameMongoId: invite.game ? String(invite.game._id || invite.game) : (game._id ? String(game._id) : null),
+                permanentGameId: canonicalGameId,
+                startDate: game.startDate ? new Date(game.startDate).toISOString() : null,
+                venue: venueName,
+                homeTeam: {
+                    name: pickFirstString(
+                        game.homeTeamName,
+                        game.homeTeam && (game.homeTeam.teamName || game.homeTeam.school),
+                        game.HomeTeam
+                    ),
+                    logo: extractTeamLogo(game.homeTeam)
+                },
+                awayTeam: {
+                    name: pickFirstString(
+                        game.awayTeamName,
+                        game.awayTeam && (game.awayTeam.teamName || game.awayTeam.school),
+                        game.AwayTeam
+                    ),
+                    logo: extractTeamLogo(game.awayTeam)
+                }
+            };
+        }
+    }
+
+    if (invite.game) {
+        const game = invite.game;
+        return {
+            gameMongoId: String(game._id || game),
+            permanentGameId: Number.isFinite(canonicalGameId) ? canonicalGameId : (Number(game.gameId) || null),
+            startDate: game.startDate ? new Date(game.startDate).toISOString() : null,
+            venue: pickFirstString(
+                game.venue && game.venue.name,
+                game.venue && game.venue.fullName,
+                game.venue
+            ),
+            homeTeam: {
+                name: pickFirstString(game.homeTeamName, game.homeTeam && (game.homeTeam.teamName || game.homeTeam.school)),
+                logo: extractTeamLogo(game.homeTeam)
+            },
+            awayTeam: {
+                name: pickFirstString(game.awayTeamName, game.awayTeam && (game.awayTeam.teamName || game.awayTeam.school)),
+                logo: extractTeamLogo(game.awayTeam)
+            }
+        };
+    }
+
+    if (invite.pastGame) {
+        const game = invite.pastGame;
+        return {
+            gameMongoId: null,
+            permanentGameId: Number.isFinite(canonicalGameId) ? canonicalGameId : (Number(game.gameId) || Number(game.Id) || null),
+            startDate: game.StartDate ? new Date(game.StartDate).toISOString() : null,
+            venue: pickFirstString(game.Venue),
+            homeTeam: {
+                name: pickFirstString(game.HomeTeam),
+                logo: PLACEHOLDER_LOGO
+            },
+            awayTeam: {
+                name: pickFirstString(game.AwayTeam),
+                logo: PLACEHOLDER_LOGO
+            }
+        };
+    }
+
+    return null;
+}
+
+async function serializeInviteForModal(invite) {
+    const details = await buildInviteGameDetails(invite);
+    if (!details || !details.gameMongoId) {
+        return null;
+    }
+
+    const inviter = invite.fromUser || {};
+    const inviterId = inviter && inviter._id ? inviter._id : invite.fromUser;
+    const inviterName = pickFirstString(inviter.displayName, inviter.username, 'Someone');
+
+    return {
+        id: String(invite._id),
+        ownerId: inviterId ? String(inviterId) : null,
+        ownerName: inviter && inviter.username ? inviter.username : inviterName,
+        ownerDisplayName: inviterName,
+        response: invite.response || null,
+        gameId: details.gameMongoId,
+        permanentGameId: details.permanentGameId,
+        game: {
+            startDate: details.startDate,
+            venue: details.venue,
+            homeTeam: details.homeTeam,
+            awayTeam: details.awayTeam
+        }
     };
 }
 
@@ -115,6 +244,50 @@ exports.inviteUser = async (req, res, next) => {
         coordination.invitedUsers.push({ userId, response: null });
         await coordination.save();
 
+        const inviteRecord = {
+            fromUser: ownerId,
+            game: gameId,
+            invitedAt: new Date(),
+            response: null,
+            modalQueued: true
+        };
+        if (Number.isFinite(Number(game.gameId))) {
+            inviteRecord.gameId = Number(game.gameId);
+        }
+
+        const inviteQuery = { _id: userId, 'invites.fromUser': ownerId, 'invites.game': gameId };
+        const inviteSet = {
+            'invites.$.invitedAt': inviteRecord.invitedAt,
+            'invites.$.response': null,
+            'invites.$.modalQueued': true
+        };
+        if (inviteRecord.gameId != null) {
+            inviteSet['invites.$.gameId'] = inviteRecord.gameId;
+        }
+
+        const updateExistingInvite = await User.updateOne(
+            inviteQuery,
+            {
+                $set: inviteSet,
+                $unset: { 'invites.$.respondedAt': '' }
+            }
+        );
+
+        const matchedCount = updateExistingInvite && typeof updateExistingInvite.matchedCount === 'number'
+            ? updateExistingInvite.matchedCount
+            : (updateExistingInvite && typeof updateExistingInvite.n === 'number' ? updateExistingInvite.n : 0);
+
+        if (!matchedCount) {
+            await User.updateOne(
+                { _id: userId },
+                {
+                    $push: {
+                        invites: inviteRecord
+                    }
+                }
+            );
+        }
+
         const inviterName = req.user.username || (await User.findById(req.user.id).select('username'))?.username || 'Someone';
         const message = `${inviterName} invited you to ${game.awayTeamName} @ ${game.homeTeamName}`;
 
@@ -190,7 +363,73 @@ exports.respondToInvite = async (req, res, next) => {
             }
         );
 
+        const effectiveOwnerId = ownerId && isValidObjectId(ownerId) ? ownerId : (update ? update.ownerId : null);
+        const inviteMatch = { _id: req.user.id, 'invites.game': gameId };
+        if (effectiveOwnerId) {
+            inviteMatch['invites.fromUser'] = effectiveOwnerId;
+        }
+        await User.updateOne(
+            inviteMatch,
+            {
+                $set: {
+                    'invites.$.response': normalized,
+                    'invites.$.respondedAt': new Date(),
+                    'invites.$.modalQueued': false
+                }
+            }
+        );
+
         res.json({ success: true, response: normalized });
+    } catch (err) {
+        next(err);
+    }
+};
+
+exports.getQueuedInvites = async (req, res, next) => {
+    try {
+        const user = await User.findById(req.user.id)
+            .select('invites')
+            .populate({
+                path: 'invites.fromUser',
+                select: 'username displayName'
+            })
+            .populate({
+                path: 'invites.game',
+                populate: [
+                    { path: 'homeTeam', select: 'teamName school logos logo' },
+                    { path: 'awayTeam', select: 'teamName school logos logo' }
+                ]
+            })
+            .populate('invites.pastGame')
+            .lean();
+
+        if (!user) {
+            return res.status(404).json({ invites: [] });
+        }
+
+        const queuedInvites = (user.invites || []).filter(invite => invite.modalQueued);
+        if (!queuedInvites.length) {
+            return res.json({ invites: [] });
+        }
+
+        const serialized = (await Promise.all(queuedInvites.map(serializeInviteForModal))).filter(Boolean);
+
+        const queuedIds = queuedInvites.map(invite => invite._id).filter(Boolean);
+        if (queuedIds.length) {
+            await User.updateOne(
+                { _id: req.user.id },
+                {
+                    $set: { 'invites.$[invite].modalQueued': false }
+                },
+                {
+                    arrayFilters: [
+                        { 'invite._id': { $in: queuedIds } }
+                    ]
+                }
+            );
+        }
+
+        res.json({ invites: serialized });
     } catch (err) {
         next(err);
     }

--- a/models/users.js
+++ b/models/users.js
@@ -1,6 +1,17 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 
+const userInviteSchema = new mongoose.Schema({
+    fromUser: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    game: { type: mongoose.Schema.Types.ObjectId, ref: 'Game' },
+    pastGame: { type: mongoose.Schema.Types.ObjectId, ref: 'PastGame' },
+    gameId: { type: Number },
+    invitedAt: { type: Date, default: Date.now },
+    respondedAt: { type: Date },
+    response: { type: String, enum: ['yes', 'no', 'maybe', null], default: null },
+    modalQueued: { type: Boolean, default: true }
+});
+
 const userSchema = new mongoose.Schema({
     username: {
         type: String,
@@ -71,7 +82,8 @@ const userSchema = new mongoose.Schema({
           updatedAt: { type: Date }
         }],
         default: []
-      }
+      },
+    invites: { type: [userInviteSchema], default: [] }
 });
 
 // Automatically hash a password before saving

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1613,3 +1613,119 @@
     box-shadow: 0 0 0 3px rgba(204, 204, 204, 0.5) !important;
     border-color: #bbb !important;
 }
+
+.game-invite-modal .invite-modal-content{
+  background:#fff;
+  border-radius:1.25rem;
+  border:2px solid transparent;
+  background-image:linear-gradient(#ffffff,#ffffff),linear-gradient(135deg,#14b8a6,#7e22ce);
+  background-origin:border-box;
+  background-clip:padding-box,border-box;
+  box-shadow:0 24px 48px rgba(15,23,42,0.2);
+  overflow:hidden;
+}
+
+.game-invite-modal .modal-header{
+  background:linear-gradient(135deg,#0f172a,#1e293b);
+}
+
+.game-invite-modal .invite-modal-title{
+  color:#fff;
+  letter-spacing:0.04em;
+}
+
+.game-invite-modal .invite-game-card{
+  background:rgba(15,23,42,0.04);
+  border-radius:1rem;
+  border:1px solid rgba(20,184,166,0.2);
+  padding:1.25rem;
+}
+
+.game-invite-modal .invite-team-logo{
+  width:84px;
+  height:84px;
+  border-radius:50%;
+  border:2px solid rgba(20,184,166,0.35);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:linear-gradient(135deg,rgba(20,184,166,0.15),rgba(126,34,206,0.15));
+  margin:0 auto 0.75rem;
+}
+
+.game-invite-modal .invite-team-logo img{
+  max-width:66px;
+  max-height:66px;
+  object-fit:contain;
+}
+
+.game-invite-modal .invite-team-name{
+  font-weight:600;
+  color:#0f172a;
+}
+
+.game-invite-modal .invite-at-symbol{
+  font-size:2.5rem;
+  font-weight:700;
+  color:rgba(79,70,229,0.75);
+}
+
+.game-invite-modal .invite-game-datetime{
+  color:#0f172a;
+  font-size:1rem;
+}
+
+.game-invite-modal .invite-game-venue{
+  color:#475569;
+  font-size:0.95rem;
+}
+
+.game-invite-modal .invite-option{
+  min-width:96px;
+  padding:0.6rem 1.5rem;
+  border-radius:999px;
+  border:2px solid rgba(15,23,42,0.12);
+  background:#f8fafc;
+  font-weight:700;
+  color:#0f172a;
+  transition:all 0.2s ease;
+  text-transform:uppercase;
+}
+
+.game-invite-modal .invite-option:hover{
+  border-color:rgba(20,184,166,0.35);
+  color:#0f172a;
+}
+
+.game-invite-modal .invite-option.active{
+  border-image:linear-gradient(135deg,#14b8a6,#7e22ce) 1;
+  background:#fff;
+  color:#111827;
+  box-shadow:0 10px 20px rgba(20,184,166,0.15);
+}
+
+.game-invite-modal .invite-submit-btn{
+  min-width:160px;
+  padding:0.75rem 2rem;
+  border-radius:999px;
+  border:0;
+  background:rgba(15,23,42,0.1);
+  color:#fff;
+  font-weight:700;
+  text-transform:uppercase;
+  transition:all 0.2s ease;
+}
+
+.game-invite-modal .invite-submit-btn.enabled{
+  background:linear-gradient(135deg,#14b8a6,#7e22ce);
+  box-shadow:0 16px 32px rgba(126,34,206,0.25);
+}
+
+.game-invite-modal .invite-submit-btn.enabled:hover{
+  filter:brightness(1.05);
+}
+
+.game-invite-modal .invite-feedback{
+  min-height:1.5rem;
+}
+

--- a/public/js/gameInviteModal.js
+++ b/public/js/gameInviteModal.js
@@ -1,0 +1,211 @@
+(function () {
+  const modalId = 'gameInviteModal';
+  let invitesQueue = [];
+  let activeInvite = null;
+  let selectedResponse = null;
+  let modalInstance = null;
+  let modalEl = null;
+  let optionButtons = [];
+  let submitButton = null;
+  let feedbackEl = null;
+  let titleEl = null;
+  let teamBlocks = [];
+  let datetimeEl = null;
+  let venueEl = null;
+
+  function initElements() {
+    if (modalEl) return true;
+    modalEl = document.getElementById(modalId);
+    if (!modalEl) return false;
+    modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+    optionButtons = Array.from(modalEl.querySelectorAll('.invite-option'));
+    submitButton = modalEl.querySelector('.invite-submit-btn');
+    feedbackEl = modalEl.querySelector('.invite-feedback');
+    titleEl = modalEl.querySelector('.invite-modal-title');
+    teamBlocks = Array.from(modalEl.querySelectorAll('.invite-team'));
+    datetimeEl = modalEl.querySelector('.invite-game-datetime');
+    venueEl = modalEl.querySelector('.invite-game-venue');
+
+    optionButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        handleResponseSelection(button.dataset.response || null);
+      });
+    });
+
+    if (submitButton) {
+      submitButton.addEventListener('click', handleSubmit);
+    }
+
+    modalEl.addEventListener('hidden.bs.modal', () => {
+      const advance = modalEl.dataset.advanceQueue === 'true';
+      modalEl.dataset.advanceQueue = '';
+      activeInvite = null;
+      selectedResponse = null;
+      clearSelection();
+      feedback('');
+      if (advance) {
+        setTimeout(() => {
+          if (invitesQueue.length) {
+            showNextInvite();
+          }
+        }, 180);
+      }
+    });
+
+    return true;
+  }
+
+  function feedback(message, isError = false) {
+    if (!feedbackEl) return;
+    if (!message) {
+      feedbackEl.classList.add('d-none');
+      feedbackEl.textContent = '';
+      return;
+    }
+    feedbackEl.textContent = message;
+    feedbackEl.classList.toggle('text-danger', isError);
+    feedbackEl.classList.toggle('text-success', !isError);
+    feedbackEl.classList.remove('d-none');
+  }
+
+  function clearSelection() {
+    optionButtons.forEach((btn) => btn.classList.remove('active'));
+    selectedResponse = null;
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.classList.remove('enabled');
+    }
+  }
+
+  function handleResponseSelection(response) {
+    if (!response) return;
+    selectedResponse = response;
+    optionButtons.forEach((btn) => {
+      const isActive = btn.dataset.response === response;
+      btn.classList.toggle('active', isActive);
+    });
+    if (submitButton) {
+      submitButton.disabled = false;
+      submitButton.classList.add('enabled');
+    }
+  }
+
+  function formatDateTime(isoString) {
+    if (!isoString) return '';
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return '';
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short'
+    }).format(date);
+  }
+
+  function updateGameDetails(invite) {
+    if (!modalEl) return;
+    if (titleEl) {
+      const name = invite.ownerDisplayName || invite.ownerName || 'A friend';
+      titleEl.textContent = `${name} has invited you to a game group`;
+    }
+    if (teamBlocks.length >= 2) {
+      const teams = [invite.game?.awayTeam, invite.game?.homeTeam];
+      teamBlocks.forEach((block, index) => {
+        const team = teams[index] || {};
+        const logoEl = block.querySelector('img');
+        const nameEl = block.querySelector('.invite-team-name');
+        if (logoEl) {
+          logoEl.src = team.logo || '/images/placeholder.jpg';
+          logoEl.alt = `${team.name || 'Team'} logo`;
+        }
+        if (nameEl) {
+          nameEl.textContent = team.name || '';
+          nameEl.title = team.name || '';
+        }
+      });
+    }
+    if (datetimeEl) {
+      datetimeEl.textContent = formatDateTime(invite.game?.startDate);
+    }
+    if (venueEl) {
+      venueEl.textContent = invite.game?.venue || '';
+    }
+    clearSelection();
+  }
+
+  async function handleSubmit() {
+    if (!activeInvite || !selectedResponse || !submitButton) return;
+    submitButton.disabled = true;
+    submitButton.classList.remove('enabled');
+    feedback('');
+
+    try {
+      const res = await fetch(`/games/${activeInvite.gameId}/respond`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          response: selectedResponse,
+          ownerId: activeInvite.ownerId
+        })
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to save response');
+      }
+
+      feedback('Response saved!', false);
+      if (modalEl) {
+        modalEl.dataset.advanceQueue = 'true';
+      }
+      setTimeout(() => modalInstance.hide(), 450);
+    } catch (err) {
+      console.error('Failed to submit invite response', err);
+      feedback('We could not save your response. Please try again.', true);
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.classList.add('enabled');
+      }
+    }
+  }
+
+  function showNextInvite() {
+    if (!invitesQueue.length) {
+      return;
+    }
+    const nextInvite = invitesQueue.shift();
+    activeInvite = nextInvite;
+    updateGameDetails(nextInvite);
+    modalInstance.show();
+  }
+
+  async function fetchQueuedInvites() {
+    try {
+      const res = await fetch('/users/invites/queued', {
+        headers: {
+          'Accept': 'application/json'
+        }
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return Array.isArray(data.invites) ? data.invites : [];
+    } catch (err) {
+      console.error('Failed to fetch queued invites', err);
+      return [];
+    }
+  }
+
+  async function init() {
+    if (!window.hasQueuedGameInvites) return;
+    if (!initElements()) return;
+    const invites = await fetchQueuedInvites();
+    if (!invites.length) return;
+    invitesQueue = invites;
+    showNextInvite();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/views/partials/gameInviteModal.ejs
+++ b/views/partials/gameInviteModal.ejs
@@ -1,0 +1,44 @@
+<div class="modal fade game-invite-modal" id="gameInviteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content invite-modal-content">
+      <div class="modal-header border-0">
+        <h5 class="modal-title invite-modal-title w-100 text-center text-white fw-bold"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="invite-game-card glassy-card">
+          <div class="invite-teams d-flex align-items-center justify-content-between">
+            <div class="invite-team text-center">
+              <div class="invite-team-logo">
+                <img src="/images/placeholder.jpg" alt="Away team logo" class="img-fluid">
+              </div>
+              <div class="invite-team-name text-truncate"></div>
+            </div>
+            <div class="invite-at-symbol">@</div>
+            <div class="invite-team text-center">
+              <div class="invite-team-logo">
+                <img src="/images/placeholder.jpg" alt="Home team logo" class="img-fluid">
+              </div>
+              <div class="invite-team-name text-truncate"></div>
+            </div>
+          </div>
+          <div class="invite-game-meta text-center mt-3">
+            <div class="invite-game-datetime fw-semibold"></div>
+            <div class="invite-game-venue text-muted"></div>
+          </div>
+        </div>
+        <div class="invite-response-group mt-4">
+          <div class="invite-options d-flex justify-content-center gap-3 mb-3">
+            <button type="button" class="btn invite-option" data-response="yes">Yes</button>
+            <button type="button" class="btn invite-option" data-response="maybe">Maybe</button>
+            <button type="button" class="btn invite-option" data-response="no">No</button>
+          </div>
+          <div class="text-center">
+            <button type="button" class="btn invite-submit-btn" disabled>Submit</button>
+          </div>
+          <div class="invite-feedback text-center small text-danger mt-3 d-none"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -37,9 +37,12 @@
 </div>
 <script src="/js/inboxModal.js"></script>
 <script>window.loggedInUser = <%- JSON.stringify(loggedInUser || null) %>;</script>
+<script>window.hasQueuedGameInvites = <%= JSON.stringify(!!hasQueuedGameInvites) %>;</script>
 <script src="/js/nearbyCheckin.js"></script>
 
 <%- include('ratePromptModal') %>
+<%- include('gameInviteModal') %>
 
 <script>window.pendingRatings = <%- JSON.stringify(pendingRatings || []) %>;</script>
 <script src="/js/pendingRatingModal.js"></script>
+<script src="/js/gameInviteModal.js"></script>


### PR DESCRIPTION
## Summary
- add invite tracking to user documents and update the coordination controller to manage queued modal invites and responses
- surface queued invite state in the auth middleware and provide an authenticated JSON endpoint for pending invites
- build the invite modal UI/JS to render matchup details, capture a response, and apply the new styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf32f751c8326b6713af7a97ac312