### PR TITLE
Ensure social page always receives events list

### DIFF
--- a/controllers/socialController.js
+++ b/controllers/socialController.js
@@ -21,7 +21,15 @@ exports.showMostCheckedIn = async (req, res, next) => {
     }).lean();
 
     if (!pastGames.length) {
-      return res.render('social', { pastgame: null, count: 0, homeLogo: '', awayLogo: '', homeColor: '#ffffff', awayColor: '#ffffff' });
+      return res.render('social', {
+        pastgame: null,
+        count: 0,
+        homeLogo: '',
+        awayLogo: '',
+        homeColor: '#ffffff',
+        awayColor: '#ffffff',
+        events: []
+      });
     }
 
     const ids = pastGames.map(g => String(g.gameId));

--- a/views/social.ejs
+++ b/views/social.ejs
@@ -48,7 +48,7 @@
 
       <div class="row justify-content-center mt-5">
         <div class="col-md-6 timeline-wrapper">
-        <% if (events && events.length) { %>
+        <% if (typeof events !== 'undefined' && events.length) { %>
           <% events.forEach(function(ev){ %>
             <div class="timeline-event">
               <% if(ev.type === 'checkin' || ev.type === 'fanMilestone'){ %>
@@ -99,7 +99,7 @@
             </div>
           <% }); %>
         <% } else { %>
-          <p class="text-center text-white fw-bold">No recent activity.</p>
+          <p class="text-center text-white fw-bold">No recent activity yet.</p>
         <% } %>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- provide an empty events array when no past games were found in the social controller
- guard the social view against missing events and show a friendly fallback message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbda23f93c83269c6d7622b4942587