### PR TITLE
Show full social activity timeline

### DIFF
--- a/views/social.ejs
+++ b/views/social.ejs
@@ -10,7 +10,7 @@
 <body class="d-flex flex-column min-vh-100 gradient-bg">
   <%- include('partials/header') %>
   <div class="container my-4 flex-grow-1">
-    <h1 class="text-center text-white fw-bold mb-4">Most Checked-In Game Yesterday</h1>
+    <h1 class="text-center text-white fw-bold mb-4">Most Checked-In Game</h1>
     <% if (pastgame) { %>
     <div class="row justify-content-center">
       <div class="col-md-6">
@@ -43,7 +43,7 @@
     <p class="text-center text-white fs-5">users checked in to <%= pastgame.AwayTeam %> vs <%= pastgame.HomeTeam %></p>
 
     <% } else { %>
-    <p class="text-center text-white fw-bold">No past games found for yesterday.</p>
+    <p class="text-center text-white fw-bold">No past games found.</p>
       <% } %>
 
       <div class="row justify-content-center mt-5">
@@ -99,7 +99,7 @@
             </div>
           <% }); %>
         <% } else { %>
-          <p class="text-center text-white fw-bold">No recent activity yet.</p>
+          <p class="text-center text-white fw-bold">No activity yet.</p>
         <% } %>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the date filter from the social controller so all past games and check-ins are considered
- reuse the aggregated check-in data when building the social timeline and top game highlight
- update the social view copy to remove "yesterday" phrasing and reflect the full activity feed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbddcec768832685129439b4a21860