### PR TITLE
Default profile navigation to stats tab

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,7 @@ app.use(async (req, res, next) => {
                     username: userDoc.username,
                     email: userDoc.email,
                     phoneNumber: userDoc.phoneNumber,
+                    venmo: userDoc.venmo || null,
                     profileImage: userDoc.profileImage,
                     newFollowers: userDoc.newFollowers || [],
                     hasQueuedGameInvites: hasQueuedInvites
@@ -255,7 +256,10 @@ app.get('/logout', (req, res) => {
     res.redirect('/login');
 });
 app.get('/thanks', requireAuth, (req, res) => { res.redirect('/profileBadges/' + req.user.id); });
-app.get('/profile', requireAuth, (req, res) => { res.redirect('/profileBadges/' + req.user.id); });
+app.get('/profile', requireAuth, (req, res) => {
+    const slug = req.user ? (req.user.venmo || req.user.id) : '';
+    return res.redirect(slug ? `/profile/${slug}/stats` : '/games');
+});
 app.get('/profileBadges/:user?', requireAuth, profileController.profileBadges);
 app.get('/profileGames/:user/:gameEntry', requireAuth, profileController.profileGameShowcase);
 app.get('/profileGames/:user?', requireAuth, profileController.profileGames);
@@ -268,6 +272,15 @@ app.post('/profile/photo', requireAuth, profileController.uploadProfilePhoto);
 app.post('/profile/location', requireAuth, profileController.setLocation);
 app.post('/profile/games', requireAuth, profileController.addGame);
 app.post('/profile/games/:id/rate', requireAuth, profileController.rateExistingGame);
+app.get('/profile/:identifier/games/:gameEntry', requireAuth, profileController.profileGameShowcase);
+app.get('/profile/:identifier/stats', requireAuth, profileController.profileStats);
+app.get('/profile/:identifier/games', requireAuth, profileController.profileGames);
+app.get('/profile/:identifier/badges', requireAuth, profileController.profileBadges);
+app.get('/profile/:identifier/waitlist', requireAuth, profileController.profileWaitlist);
+app.get('/profile/:identifier', requireAuth, (req, res) => {
+    const slug = req.params.identifier;
+    return res.redirect(`/profile/${slug}/stats`);
+});
 app.put('/gameEntry/:id', requireAuth, profileController.updateGameEntry);
 app.delete('/gameEntry/:id', requireAuth, profileController.deleteGameEntry);
 app.get('/welcome', requireAuth, (req, res) => {

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -18,8 +18,8 @@
             <span class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle inbox-dot"></span>
           <% } %>
         </a>
-        <a href="/profile" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">
-
+        <% const profileSlug = loggedInUser && (loggedInUser.venmo || loggedInUser.id); %>
+        <a href="<%= profileSlug ? `/profile/${profileSlug}/stats` : '/profile' %>" class="me-3 <%= currentPath.startsWith('/profile') ? 'active-profile' : '' %>">
           <img src="<%= navImg %>" alt="Profile" class="nav-profile-icon">
         </a>
         <a href="/logout" class="btn btn-outline-secondary">Log Out</a>

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -178,18 +178,19 @@
   </div>
   <br>
   <div class="container mt-4 pb-0">
+    <% const profileSlug = user && (user.venmo || user._id); %>
     <ul class="nav nav-tabs profile-tabs" id="profileTabs" role="tablist">
       <li class="nav-item" role="presentation">
-        <a href="/profileBadges/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='badges' ? 'active' : '' %>">Badges</a>
+        <a href="/profile/<%= profileSlug %>/stats" class="nav-link profile-tab <%= activeTab==='stats' ? 'active' : '' %>">Stats</a>
       </li>
       <li class="nav-item" role="presentation">
-        <a href="/profileGames/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='games' ? 'active' : '' %>">Games</a>
+        <a href="/profile/<%= profileSlug %>/games" class="nav-link profile-tab <%= activeTab==='games' ? 'active' : '' %>">Games</a>
       </li>
       <li class="nav-item" role="presentation">
-        <a href="/profileStats/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='stats' ? 'active' : '' %>">Stats</a>
+        <a href="/profile/<%= profileSlug %>/badges" class="nav-link profile-tab <%= activeTab==='badges' ? 'active' : '' %>">Badges</a>
       </li>
       <li class="nav-item" role="presentation">
-        <a href="/profileWaitlist/<%= user._id %>" class="nav-link profile-tab <%= activeTab==='waitlist' ? 'active' : '' %>">Waitlist</a>
+        <a href="/profile/<%= profileSlug %>/waitlist" class="nav-link profile-tab <%= activeTab==='waitlist' ? 'active' : '' %>">Waitlist</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- redirect authenticated users to the stats tab after login and when visiting /profile
- resolve profile slugs by venmo or id and expose new /profile/:identifier routes for badges, games, stats, and waitlist
- update navbar and profile tab links so the stats tab is first and becomes the default landing view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0358d8a483269da74eb95a978e44