### PR TITLE
Enable multi-game additions from Add Game modal

### DIFF
--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -246,11 +246,13 @@
                     <div class="mb-3">
                         <label class="form-label">Game</label>
                         <div class="d-flex align-items-center">
-                            <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled></select>
+                            <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled multiple></select>
                             <div id="gameSpinner" class="spinner-border text-light ms-2" style="display:none;width:1.5rem;height:1.5rem;" role="status">
                                 <span class="visually-hidden">Loading...</span>
                             </div>
                         </div>
+                        <small id="multiSelectionNotice" class="text-info d-none">Selecting multiple games will skip rating and comment fields. They'll be saved for you to finish later.</small>
+                        <small id="multiDuplicateWarning" class="text-warning d-none">One or more selected games are already on your list.</small>
                     </div>
                     <div class="mb-3 position-relative" id="ratingGroup">
                         <label class="form-label d-flex justify-content-between">
@@ -261,11 +263,11 @@
                             <input type="range" id="ratingRange" name="rating" class="form-range glass-control" min="1" max="10" step="0.1" value="5" required>
                         </div>
                     </div>
-                    <div class="mb-3">
+                    <div class="mb-3" id="photoGroup">
                         <label class="form-label">Photo</label>
-                        <input type="file" name="photo" class="form-control glass-control">
+                        <input type="file" id="photoInput" name="photo" class="form-control glass-control">
                     </div>
-                    <div class="mb-3">
+                    <div class="mb-3" id="commentGroup">
                         <label class="form-label d-flex justify-content-between">
                             <span>Comment</span>
                             <small id="commentCounter">0/100</small>


### PR DESCRIPTION
## Summary
- allow the Add Game modal to search and pick multiple games at once, showing contextual messaging and hiding rating/comment inputs when multi-selecting
- update the modal client script to manage multi-select state, disable elo comparison flow, and keep the glassy styling intact
- expand the add game controller so multi-select submissions create defaulted game entries and update related team/venue lists

## Testing
- npm test *(fails: missing mongoose module in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68e066bf87c0832691b30152b8c77597