### PR TITLE
Refactor add game modal multi-select UX

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -906,38 +906,44 @@
   padding: .35rem .65rem;
   display: flex;
   align-items: center;
+  position: relative;
+}
+
+.glass-select2 .select2-selection--multiple::before {
+  content: attr(data-placeholder);
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 600;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.glass-select2 .select2-selection--multiple.has-selection::before,
+.glass-select2 .select2-selection--multiple.is-open::before {
+  content: '';
+  opacity: 0;
 }
 
 .glass-select2 .select2-selection--multiple .select2-selection__rendered {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: .35rem;
   padding: 0;
   margin: 0;
   width: 100%;
 }
 
-.glass-select2 .select2-selection--multiple .select2-selection__placeholder {
-  color: #fff;
-  opacity: .8;
-  font-weight: 600;
-}
-
-.glass-select2 .select2-selection--multiple .select2-selection__choice {
-  background: rgba(20, 184, 166, 0.28);
-  border: 1px solid rgba(126, 34, 206, 0.35);
-  border-radius: 999px;
-  color: #fff;
-  font-weight: 600;
-  padding: .25rem .75rem;
-  display: inline-flex;
-  align-items: center;
-  gap: .35rem;
-}
-
+.glass-select2 .select2-selection--multiple .select2-selection__choice,
+.glass-select2 .select2-selection--multiple .select2-selection__placeholder,
 .glass-select2 .select2-selection--multiple .select2-selection__choice__remove {
-  color: #fff;
-  margin-right: .35rem;
+  display: none !important;
+}
+
+.glass-select2 .select2-selection--multiple .select2-search.select2-search--inline {
+  flex: 1 1 auto;
 }
 
 .glass-select2 .select2-selection--multiple .select2-search__field {
@@ -946,40 +952,6 @@
   font-weight: 600;
   padding: 0;
   margin: 0;
-}
-
-.select2-container.game-select-container.multi-mode .select2-selection--multiple {
-  align-items: center;
-}
-
-.select2-container.game-select-container.multi-mode .select2-selection__rendered {
-  position: relative;
-  width: 100%;
-}
-
-.select2-container.game-select-container.multi-mode .select2-selection__choice,
-.select2-container.game-select-container.multi-mode .select2-selection__placeholder,
-.select2-container.game-select-container.multi-mode .select2-selection__rendered .select2-selection__choice__remove {
-  display: none !important;
-}
-
-.select2-container.game-select-container.multi-mode .select2-selection__rendered::after {
-  content: attr(data-multi-summary);
-  position: absolute;
-  left: .35rem;
-  right: .35rem;
-  top: 50%;
-  transform: translateY(-50%);
-  display: block;
-  color: #fff;
-  font-weight: 600;
-  letter-spacing: .01em;
-  pointer-events: none;
-  text-align: left;
-}
-
-.select2-container.game-select-container.multi-mode .select2-search.select2-search--inline {
-  display: none !important;
 }
 
 .select2-container--default.select2-container--open .select2-selection--single {
@@ -1007,7 +979,7 @@
   color: #fff;
   font-weight: bold;
   position: relative;
-  padding-left: 1.5rem;
+  padding: .5rem .75rem;
 }
 
 .select2-container--default .select2-results__option--highlighted {
@@ -1015,37 +987,32 @@
   color: #fff !important;
 }
 
-.glass-select2.select2-dropdown.show-checkmarks .select2-results__option:not(.select2-results__message) {
-  padding-left: 2.5rem;
+.game-result-option {
+  gap: .75rem;
 }
 
-.glass-select2.select2-dropdown.show-checkmarks .select2-results__option:not(.select2-results__message)::before {
-  content: '';
-  position: absolute;
-  left: .9rem;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1rem;
-  height: 1rem;
+.game-result-option .game-select-circle {
+  margin-right: .25rem;
+}
+
+.game-select-circle {
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.55);
-  background: rgba(15, 23, 42, 0.25);
-  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.25);
-  transition: background .2s, border-color .2s;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.25);
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.glass-select2.select2-dropdown.show-checkmarks .select2-results__option[aria-selected="true"]:not(.select2-results__message)::before {
+.game-select-circle.filled {
   border-color: transparent;
-  background: linear-gradient(135deg, rgba(20, 184, 166, 0.85), rgba(126, 34, 206, 0.85));
-}
-
-.glass-select2.select2-dropdown.show-checkmarks .select2-results__option[aria-selected="true"]:not(.select2-results__message)::after {
-  content: '\2713';
-  position: absolute;
-  left: 1.07rem;
-  top: 50%;
-  transform: translate(-50%, -55%);
-  font-size: .75rem;
+  background: linear-gradient(135deg, #14b8a6, #7c3aed);
+  box-shadow: 0 0 8px rgba(126, 34, 206, 0.35);
 }
 
 .glass-select2.select2-dropdown .game-result-option {


### PR DESCRIPTION
## Summary
- replace the add game modal multi-select behaviour with a circle-based indicator inside the dropdown
- keep the rest of the modal unchanged while still supporting single- and multi-game submission flows
- refresh the dropdown styling to hide selection pills and match the teal-purple gradient motif

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e08fbe4210832685864a09e3fb1f55