### PR TITLE
Refactor add game modal multi-select UI

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -952,6 +952,8 @@
   font-weight: 600;
   padding: 0;
   margin: 0;
+  width: 100% !important;
+  min-width: 100% !important;
 }
 
 .select2-container--default.select2-container--open .select2-selection--single {


### PR DESCRIPTION
## Summary
- disable Select2 token rendering for the add game multi-select and keep selection feedback inside the dropdown results
- update modal logic to toggle single vs. multi-game entry fields and maintain clean payloads when multiple games are chosen
- tweak Select2 styling so the inline search field spans the control while chips remain hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e093c4973c8326bd5e5a1ae9b747ea