### PR TITLE
Maintain add game modal layout for multi-select

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -706,7 +706,7 @@ exports.searchPastGames = async (req, res, next) => {
       .lean();
     const teamIds = [...new Set(games.flatMap(g => [g.HomeId, g.AwayId]))];
     const teams = await Team.find({ teamId: { $in: teamIds } })
-      .select('teamId logos')
+      .select('teamId logos color alternateColor')
       .lean();
     const teamMap = {};
     teams.forEach(t => { teamMap[t.teamId] = t; });
@@ -716,6 +716,12 @@ exports.searchPastGames = async (req, res, next) => {
       awayTeamName: g.AwayTeam,
       homeLogo: teamMap[g.HomeId] && teamMap[g.HomeId].logos && teamMap[g.HomeId].logos[0],
       awayLogo: teamMap[g.AwayId] && teamMap[g.AwayId].logos && teamMap[g.AwayId].logos[0],
+      homeTeamId: g.HomeId,
+      awayTeamId: g.AwayId,
+      homeColor: teamMap[g.HomeId] ? teamMap[g.HomeId].color : undefined,
+      homeAlternateColor: teamMap[g.HomeId] ? teamMap[g.HomeId].alternateColor : undefined,
+      awayColor: teamMap[g.AwayId] ? teamMap[g.AwayId].color : undefined,
+      awayAlternateColor: teamMap[g.AwayId] ? teamMap[g.AwayId].alternateColor : undefined,
       score: `${g.HomePoints ?? ''}-${g.AwayPoints ?? ''}`,
       homePoints: g.HomePoints,
       awayPoints: g.AwayPoints,

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -19,25 +19,60 @@
 }
 
 .glass-select2 .game-result-option {
-  background: transparent;
-  color: #0f172a !important; /* match other text color */
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.5rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff !important;
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+  transition: border-color 0.3s ease, transform 0.2s ease;
+}
+
+.glass-select2 .game-result-option::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(to right, var(--game-away-color, rgba(20, 184, 166, 0.75)), var(--game-home-color, rgba(126, 34, 206, 0.75)));
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  z-index: 0;
+}
+
+.glass-select2 .game-result-option > * {
+  position: relative;
+  z-index: 1;
 }
 
 .glass-select2 .game-result-option .game-result-logo {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
-  object-fit: cover;
+  object-fit: contain;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 0.15rem;
 }
 
-.glass-select2 .game-result-option span {
+.glass-select2 .game-result-option span,
+.glass-select2 .game-result-option .game-result-score {
   color: #ffffff !important;
+  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.6);
 }
 
-.glass-select2 .game-result-option:hover {
-  background: linear-gradient(to right, rgba(20, 184, 166, 0.1), rgba(126, 34, 206, 0.1));
+.glass-select2 .game-result-option:hover,
+.glass-select2 .game-result-option.is-selected {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.glass-select2 .game-result-option:hover::before,
+.glass-select2 .game-result-option.is-selected::before {
+  opacity: 1;
 }
 
 .select2-container--default.glass-select2 .select2-selection--single,
@@ -86,8 +121,15 @@
 
 /* Fix option hover */
 .select2-container--default.glass-select2 .select2-results__option--highlighted {
-  background: linear-gradient(to right, rgba(20,184,166,0.2), rgba(126,34,206,0.2));
-  color: #0f172a !important;
+  background: transparent !important;
+}
+
+.select2-container--default.glass-select2 .select2-results__option--highlighted .game-result-option {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.select2-container--default.glass-select2 .select2-results__option--highlighted .game-result-option::before {
+  opacity: 1;
 }
 
 /* profile icon in navigation bar */
@@ -963,6 +1005,48 @@
   min-width: 100% !important;
 }
 
+.add-game-modal-body {
+  min-height: 28rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.add-game-modal-body #gameInfoStep,
+.add-game-modal-body #eloStep {
+  flex: 1 1 auto;
+  display: block;
+}
+
+#addGameModal .selected-game-logos {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 1.5rem;
+}
+
+#addGameModal .selected-game-logo {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#addGameModal .selected-game-logo img {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  filter: drop-shadow(0 1px 3px rgba(15, 23, 42, 0.55));
+}
+
+.ghost-element {
+  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
 .select2-container--default.select2-container--open .select2-selection--single {
   background-color: rgba(255, 255, 255, 0.25) !important;
 }
@@ -984,70 +1068,30 @@
   color: #fff;
 }
 
-.select2-container--default .select2-results__option {
+.select2-container--default:not(.glass-select2) .select2-results__option {
   color: #fff;
   font-weight: bold;
   position: relative;
   padding: .5rem .75rem;
 }
 
-.select2-container--default .select2-results__option--highlighted {
+.select2-container--default:not(.glass-select2) .select2-results__option--highlighted {
   background-color: rgba(255, 255, 255, 0.3) !important;
   color: #fff !important;
 }
 
-.game-result-option {
-  gap: .75rem;
-}
-
-.game-result-option .game-select-circle {
-  margin-right: .25rem;
-}
-
-.game-select-circle {
-  width: 18px;
-  height: 18px;
+.glass-select2.select2-dropdown .game-result-logo,
+.select2-container .game-result-logo {
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.25);
-  background: transparent;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.game-select-circle.filled {
-  border-color: transparent;
-  background: linear-gradient(135deg, #14b8a6, #7c3aed);
-  box-shadow: 0 0 8px rgba(126, 34, 206, 0.35);
-}
-
-.glass-select2.select2-dropdown .game-result-option {
-  display: flex;
-  align-items: center;
-  gap: .35rem;
-}
-
-.glass-select2.select2-dropdown .game-result-logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255, 255, 255, 0.35);
+  object-fit: contain;
+  border: none;
 }
 
 .glass-select2.select2-dropdown .game-result-score {
   font-weight: 600;
-}
-
-.select2-container .game-result-logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.92);
 }
   
   .select2-container--default .select2-search__field {

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -40,6 +40,8 @@
     const finalizedGames = eloGames.filter(g => g.finalized);
     const autoSubmitOverlay = $('#autoSubmitOverlay');
     const multiDuplicateWarning = $('#multiDuplicateWarning');
+    const multiSelectionNotice = $('#multiSelectionNotice');
+    const selectedGameLogos = $('#selectedGameLogos');
     const highestElo = finalizedGames.reduce((m,g)=> g.elo>m ? g.elo : m, finalizedGames.length ? finalizedGames[0].elo : 0);
     const lowestElo = finalizedGames.reduce((m,g)=> g.elo<m ? g.elo : m, finalizedGames.length ? finalizedGames[0].elo : 0);
     let randomGame1 = null;
@@ -109,29 +111,127 @@
       return ids.length ? String(ids[ids.length - 1]) : null;
     }
 
+    function normalizeHex(color){
+      if(!color && color !== 0) return null;
+      let hex = String(color).trim();
+      if(!hex) return null;
+      if(hex.startsWith('#')) hex = hex.slice(1);
+      if(hex.length === 3){
+        hex = hex.split('').map(ch => ch + ch).join('');
+      }
+      if(hex.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(hex)){
+        return null;
+      }
+      return `#${hex.toLowerCase()}`;
+    }
+
+    function hexToRgba(hex, alpha){
+      const normalized = normalizeHex(hex);
+      if(!normalized) return null;
+      const value = parseInt(normalized.slice(1), 16);
+      const r = (value >> 16) & 255;
+      const g = (value >> 8) & 255;
+      const b = value & 255;
+      const clampedAlpha = Math.min(Math.max(alpha ?? 1, 0), 1);
+      return `rgba(${r}, ${g}, ${b}, ${clampedAlpha})`;
+    }
+
+    function resolveTeamColor(primary, alternate){
+      return normalizeHex(primary) || normalizeHex(alternate) || null;
+    }
+
+    function buildGradientStops(option){
+      if(!option) return {
+        away: 'rgba(20, 184, 166, 0.78)',
+        home: 'rgba(126, 34, 206, 0.78)'
+      };
+      const awayColor = resolveTeamColor(option.awayColor, option.awayAlternateColor);
+      const homeColor = resolveTeamColor(option.homeColor, option.homeAlternateColor);
+      return {
+        away: hexToRgba(awayColor, 0.82) || 'rgba(20, 184, 166, 0.78)',
+        home: hexToRgba(homeColor, 0.82) || 'rgba(126, 34, 206, 0.78)'
+      };
+    }
+
+    function resolveOpponentLogo(gameData, selectedTeamId){
+      if(!gameData) return null;
+      const normalizedTeamId = selectedTeamId != null ? String(selectedTeamId) : null;
+      const homeId = gameData.homeTeamId != null ? String(gameData.homeTeamId) : null;
+      const awayId = gameData.awayTeamId != null ? String(gameData.awayTeamId) : null;
+      if(normalizedTeamId){
+        if(normalizedTeamId === homeId){
+          return {
+            url: gameData.awayLogo || null,
+            label: gameData.awayTeamName || 'Opponent'
+          };
+        }
+        if(normalizedTeamId === awayId){
+          return {
+            url: gameData.homeLogo || null,
+            label: gameData.homeTeamName || 'Opponent'
+          };
+        }
+      }
+      if(gameData.awayLogo){
+        return {
+          url: gameData.awayLogo,
+          label: gameData.awayTeamName || 'Away team'
+        };
+      }
+      if(gameData.homeLogo){
+        return {
+          url: gameData.homeLogo,
+          label: gameData.homeTeamName || 'Home team'
+        };
+      }
+      return null;
+    }
+
+    function renderSelectedGameLogos(){
+      if(!selectedGameLogos || !selectedGameLogos.length) return;
+      selectedGameLogos.empty();
+      if(!gameSelect || !gameSelect.length || typeof gameSelect.select2 !== 'function') return;
+      const dataArr = gameSelect.select2('data') || [];
+      if(!Array.isArray(dataArr) || !dataArr.length) return;
+      const selectedTeamId = teamSelect && teamSelect.length ? teamSelect.val() : null;
+      const fragments = [];
+      dataArr.forEach(data => {
+        const opponent = resolveOpponentLogo(data, selectedTeamId);
+        if(opponent && opponent.url){
+          const altText = opponent.label || 'Opponent';
+          const $img = $('<img>', {
+            src: opponent.url,
+            alt: `${altText} logo`,
+            title: altText
+          });
+          const $wrapper = $('<div class="selected-game-logo"></div>').append($img);
+          fragments.push($wrapper);
+        }
+      });
+      if(fragments.length){
+        selectedGameLogos.append(fragments);
+      }
+    }
+
     function updateSelectionPlaceholder(){
       if(!selectionElement || !selectionElement.length) return;
       const hasSelection = getSelectedGameIds().length > 0;
       selectionElement.toggleClass('has-selection', hasSelection);
+      renderSelectedGameLogos();
     }
 
-    function refreshGameOptionIndicators() {
-  const selectedSet = new Set(getSelectedGameIds().map(String));
-  const openDropdown = document.querySelector('.select2-container--open');
-  if (!openDropdown) return;
-  const options = openDropdown.querySelectorAll('.select2-results__option');
-
-  options.forEach(option => {
-    const $option = $(option);
-    const data = $option.data('data');
-    if (!data || !data.id) return;
-    const isSelected = selectedSet.has(String(data.id));
-    const circle = $option.find('.game-select-circle');
-    if (circle.length) {
-      circle.toggleClass('filled', isSelected);
+    function refreshGameOptionIndicators(){
+      const selectedSet = new Set(getSelectedGameIds().map(String));
+      const openDropdown = document.querySelector('.select2-container--open');
+      if(!openDropdown) return;
+      const options = openDropdown.querySelectorAll('.game-result-option[data-game-id]');
+      options.forEach(optionEl => {
+        const id = optionEl.getAttribute('data-game-id');
+        if(!id) return;
+        const isSelected = selectedSet.has(String(id));
+        optionEl.classList.toggle('is-selected', isSelected);
+      });
     }
-  });
-}
 
     function attachDropdownObserver(){
       if(dropdownObserver){
@@ -554,22 +654,52 @@ worseBtn.off('click').on('click', function(){
       const homeLogo = option.homeLogo || '/images/placeholder.jpg';
       const awayLogo = option.awayLogo || '/images/placeholder.jpg';
       const scoreDisplay = option.scoreDisplay || '';
-      const selectedIds = new Set(getSelectedGameIds().map(String));
-      const isSelected = selectedIds.has(String(option.id));
-      const circleClass = isSelected ? 'game-select-circle filled' : 'game-select-circle';
-      return $(
-        `<div class="game-result-option game-option d-flex align-items-center justify-content-between w-100" data-game-id="${option.id}">`+
-          `<div class="d-flex align-items-center flex-grow-1 gap-2">`+
-            `<span class="${circleClass}" aria-hidden="true"></span>`+
-            `<img src="${awayLogo}" class="game-result-logo">`+
-            `<span class="fw-semibold text-white">${option.awayTeamName}</span>`+
-            `<span class="text-white-50">@</span>`+
-            `<img src="${homeLogo}" class="game-result-logo">`+
-            `<span class="fw-semibold text-white">${option.homeTeamName}</span>`+
-          `</div>`+
-          `<span class="game-result-score text-white-50 ms-3">${scoreDisplay}</span>`+
-        `</div>`
-      );
+      const gradients = buildGradientStops(option);
+      const container = $('<div>', {
+        class: 'game-result-option d-flex align-items-center justify-content-between w-100',
+        'data-game-id': option.id
+      });
+      container.css('--game-away-color', gradients.away);
+      container.css('--game-home-color', gradients.home);
+
+      const teamsWrapper = $('<div>', {
+        class: 'd-flex align-items-center flex-grow-1 gap-2'
+      });
+
+      teamsWrapper.append($('<img>', {
+        src: awayLogo,
+        class: 'game-result-logo',
+        alt: `${option.awayTeamName || 'Away team'} logo`
+      }));
+
+      teamsWrapper.append($('<span>', {
+        class: 'fw-semibold text-white',
+        text: option.awayTeamName || ''
+      }));
+
+      teamsWrapper.append($('<span>', {
+        class: 'text-white-50',
+        text: '@'
+      }));
+
+      teamsWrapper.append($('<img>', {
+        src: homeLogo,
+        class: 'game-result-logo',
+        alt: `${option.homeTeamName || 'Home team'} logo`
+      }));
+
+      teamsWrapper.append($('<span>', {
+        class: 'fw-semibold text-white',
+        text: option.homeTeamName || ''
+      }));
+
+      const scoreWrapper = $('<span>', {
+        class: 'game-result-score text-white-50 ms-3',
+        text: scoreDisplay
+      });
+
+      container.append(teamsWrapper, scoreWrapper);
+      return container;
     }
 
     teamSelect.select2({
@@ -630,6 +760,12 @@ worseBtn.off('click').on('click', function(){
               awayTeamName:g.awayTeamName,
               homeLogo:g.homeLogo,
               awayLogo:g.awayLogo,
+              homeTeamId:g.homeTeamId,
+              awayTeamId:g.awayTeamId,
+              homeColor:g.homeColor,
+              homeAlternateColor:g.homeAlternateColor,
+              awayColor:g.awayColor,
+              awayAlternateColor:g.awayAlternateColor,
               score:g.score,
               homePoints:g.homePoints,
               awayPoints:g.awayPoints,
@@ -702,25 +838,56 @@ worseBtn.off('click').on('click', function(){
       updateDuplicateWarning(selected);
     }
 
+    function setGhostState($el, shouldGhost){
+      if(!$el || !$el.length) return;
+      if(shouldGhost){
+        $el.addClass('ghost-element');
+        $el.attr('aria-hidden', 'true');
+      } else {
+        $el.removeClass('ghost-element');
+        $el.removeAttr('aria-hidden');
+      }
+    }
+
     function updateEntryMode(){
       const selected = getSelectedGameIds();
       const multiSelected = selected.length > 1;
 
       if(commentGroup && commentGroup.length){
-        commentGroup.toggleClass('d-none', multiSelected);
+        commentGroup.removeClass('d-none');
+        setGhostState(commentGroup, multiSelected);
       }
 
       if(photoGroup && photoGroup.length){
-        photoGroup.toggleClass('d-none', multiSelected);
+        photoGroup.removeClass('d-none');
+        setGhostState(photoGroup, multiSelected);
       }
 
       if(ratingGroup && ratingGroup.length){
-        const shouldShowRating = !multiSelected && gameEntryCount < 5;
-        if(shouldShowRating){
+        const ratingEligible = gameEntryCount < 5;
+        if(ratingEligible){
           ratingGroup.removeClass('d-none').show();
+          setGhostState(ratingGroup, multiSelected);
         } else {
+          setGhostState(ratingGroup, false);
           ratingGroup.addClass('d-none').hide();
         }
+      }
+
+      if(multiSelectionNotice && multiSelectionNotice.length){
+        multiSelectionNotice.toggleClass('d-none', !multiSelected);
+      }
+
+      if(nextBtn && nextBtn.length){
+        if(multiSelected || (infoStep && !infoStep.is(':visible')) || gameEntryCount < 5){
+          nextBtn.hide();
+        } else {
+          nextBtn.show();
+        }
+      }
+
+      if(submitBtn && submitBtn.length){
+        submitBtn.text(multiSelected ? 'Add Selected Games' : originalSubmitLabel);
       }
 
       if(commentInput && commentInput.length && commentFieldName){

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -229,7 +229,7 @@
                     <h5 class="modal-title flex-grow-1">Add Game</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body">
+                <div class="modal-body add-game-modal-body">
                     <div id="gameInfoStep">
                     <div class="mb-3">
                         <label class="form-label">League</label>
@@ -245,6 +245,7 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Game</label>
+                        <div id="selectedGameLogos" class="selected-game-logos mb-2"></div>
                         <div class="d-flex align-items-center">
                             <select id="gameSelect" name="gameId" class="form-select glass-control" required disabled multiple></select>
                             <div id="gameSpinner" class="spinner-border text-light ms-2" style="display:none;width:1.5rem;height:1.5rem;" role="status">


### PR DESCRIPTION
## Summary
- ghost the single-game-only form groups when multiple games are chosen so the modal keeps its single-select height
- add a helper to toggle the ghost state while keeping form submission attributes aligned with the current mode
- introduce a reusable ghost-element style to hide controls visually without collapsing their reserved space

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e4145a30f48326b34d299be835144d