### PR TITLE
Refine add game modal selection UX

### DIFF
--- a/controllers/gamesController.js
+++ b/controllers/gamesController.js
@@ -706,7 +706,7 @@ exports.searchPastGames = async (req, res, next) => {
       .lean();
     const teamIds = [...new Set(games.flatMap(g => [g.HomeId, g.AwayId]))];
     const teams = await Team.find({ teamId: { $in: teamIds } })
-      .select('teamId logos')
+      .select('teamId logos color alternateColor')
       .lean();
     const teamMap = {};
     teams.forEach(t => { teamMap[t.teamId] = t; });
@@ -716,6 +716,12 @@ exports.searchPastGames = async (req, res, next) => {
       awayTeamName: g.AwayTeam,
       homeLogo: teamMap[g.HomeId] && teamMap[g.HomeId].logos && teamMap[g.HomeId].logos[0],
       awayLogo: teamMap[g.AwayId] && teamMap[g.AwayId].logos && teamMap[g.AwayId].logos[0],
+      homeTeamId: g.HomeId,
+      awayTeamId: g.AwayId,
+      homeColor: teamMap[g.HomeId] ? teamMap[g.HomeId].color : undefined,
+      homeAlternateColor: teamMap[g.HomeId] ? teamMap[g.HomeId].alternateColor : undefined,
+      awayColor: teamMap[g.AwayId] ? teamMap[g.AwayId].color : undefined,
+      awayAlternateColor: teamMap[g.AwayId] ? teamMap[g.AwayId].alternateColor : undefined,
       score: `${g.HomePoints ?? ''}-${g.AwayPoints ?? ''}`,
       homePoints: g.HomePoints,
       awayPoints: g.AwayPoints,

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -19,25 +19,59 @@
 }
 
 .glass-select2 .game-result-option {
-  background: transparent;
-  color: #0f172a !important; /* match other text color */
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.5rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff !important;
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+  transition: border-color 0.3s ease, transform 0.2s ease;
+}
+
+.glass-select2 .game-result-option::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(to right, var(--game-away-color, rgba(20, 184, 166, 0.75)), var(--game-home-color, rgba(126, 34, 206, 0.75)));
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  z-index: 0;
+}
+
+.glass-select2 .game-result-option > * {
+  position: relative;
+  z-index: 1;
 }
 
 .glass-select2 .game-result-option .game-result-logo {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
-  object-fit: cover;
+  object-fit: contain;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 0.15rem;
 }
 
-.glass-select2 .game-result-option span {
+.glass-select2 .game-result-option span,
+.glass-select2 .game-result-option .game-result-score {
   color: #ffffff !important;
+  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.6);
 }
 
-.glass-select2 .game-result-option:hover {
-  background: linear-gradient(to right, rgba(20, 184, 166, 0.1), rgba(126, 34, 206, 0.1));
+.glass-select2 .game-result-option:hover,
+.glass-select2 .game-result-option.is-selected {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.glass-select2 .game-result-option.is-selected::before {
+  opacity: 1;
 }
 
 .select2-container--default.glass-select2 .select2-selection--single,
@@ -86,8 +120,15 @@
 
 /* Fix option hover */
 .select2-container--default.glass-select2 .select2-results__option--highlighted {
-  background: linear-gradient(to right, rgba(20,184,166,0.2), rgba(126,34,206,0.2));
-  color: #0f172a !important;
+  background: transparent !important;
+}
+
+.select2-container--default.glass-select2 .select2-results__option--highlighted .game-result-option {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.select2-container--default.glass-select2 .select2-results__option--highlighted .game-result-option::before {
+  opacity: 0;
 }
 
 /* profile icon in navigation bar */
@@ -943,6 +984,22 @@
   width: 100%;
 }
 
+.glass-select2 .select2-selection--multiple .selected-game-chip {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.glass-select2 .select2-selection--multiple .selected-game-chip img {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  filter: drop-shadow(0 1px 3px rgba(15, 23, 42, 0.55));
+}
+
 .glass-select2 .select2-selection--multiple .select2-selection__choice,
 .glass-select2 .select2-selection--multiple .select2-selection__placeholder,
 .glass-select2 .select2-selection--multiple .select2-selection__choice__remove {
@@ -961,6 +1018,25 @@
   margin: 0;
   width: 100% !important;
   min-width: 100% !important;
+}
+
+.add-game-modal-body {
+  min-height: 28rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.add-game-modal-body #gameInfoStep,
+.add-game-modal-body #eloStep {
+  flex: 1 1 auto;
+  display: block;
+}
+
+.ghost-element {
+  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
 }
 
 .select2-container--default.select2-container--open .select2-selection--single {
@@ -984,70 +1060,30 @@
   color: #fff;
 }
 
-.select2-container--default .select2-results__option {
+.select2-container--default:not(.glass-select2) .select2-results__option {
   color: #fff;
   font-weight: bold;
   position: relative;
   padding: .5rem .75rem;
 }
 
-.select2-container--default .select2-results__option--highlighted {
+.select2-container--default:not(.glass-select2) .select2-results__option--highlighted {
   background-color: rgba(255, 255, 255, 0.3) !important;
   color: #fff !important;
 }
 
-.game-result-option {
-  gap: .75rem;
-}
-
-.game-result-option .game-select-circle {
-  margin-right: .25rem;
-}
-
-.game-select-circle {
-  width: 18px;
-  height: 18px;
+.glass-select2.select2-dropdown .game-result-logo,
+.select2-container .game-result-logo {
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.25);
-  background: transparent;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.game-select-circle.filled {
-  border-color: transparent;
-  background: linear-gradient(135deg, #14b8a6, #7c3aed);
-  box-shadow: 0 0 8px rgba(126, 34, 206, 0.35);
-}
-
-.glass-select2.select2-dropdown .game-result-option {
-  display: flex;
-  align-items: center;
-  gap: .35rem;
-}
-
-.glass-select2.select2-dropdown .game-result-logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255, 255, 255, 0.35);
+  object-fit: contain;
+  border: none;
 }
 
 .glass-select2.select2-dropdown .game-result-score {
   font-weight: 600;
-}
-
-.select2-container .game-result-logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.92);
 }
   
   .select2-container--default .select2-search__field {

--- a/public/js/addGameModal.js
+++ b/public/js/addGameModal.js
@@ -40,6 +40,8 @@
     const finalizedGames = eloGames.filter(g => g.finalized);
     const autoSubmitOverlay = $('#autoSubmitOverlay');
     const multiDuplicateWarning = $('#multiDuplicateWarning');
+    const multiSelectionNotice = $('#multiSelectionNotice');
+    const gameOptionCache = new Map();
     const highestElo = finalizedGames.reduce((m,g)=> g.elo>m ? g.elo : m, finalizedGames.length ? finalizedGames[0].elo : 0);
     const lowestElo = finalizedGames.reduce((m,g)=> g.elo<m ? g.elo : m, finalizedGames.length ? finalizedGames[0].elo : 0);
     let randomGame1 = null;
@@ -88,9 +90,7 @@
           searchEl.detach();
         }
         rendered.empty();
-        if(searchEl && searchEl.length){
-          rendered.append(searchEl);
-        }
+        updateSelectionDisplay({ searchEl, searchDetached: true, selection: this.$selection });
       };
     }
 
@@ -109,29 +109,168 @@
       return ids.length ? String(ids[ids.length - 1]) : null;
     }
 
+    function normalizeHex(color){
+      if(!color && color !== 0) return null;
+      let hex = String(color).trim();
+      if(!hex) return null;
+      if(hex.startsWith('#')) hex = hex.slice(1);
+      if(hex.length === 3){
+        hex = hex.split('').map(ch => ch + ch).join('');
+      }
+      if(hex.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(hex)){
+        return null;
+      }
+      return `#${hex.toLowerCase()}`;
+    }
+
+    function hexToRgba(hex, alpha){
+      const normalized = normalizeHex(hex);
+      if(!normalized) return null;
+      const value = parseInt(normalized.slice(1), 16);
+      const r = (value >> 16) & 255;
+      const g = (value >> 8) & 255;
+      const b = value & 255;
+      const clampedAlpha = Math.min(Math.max(alpha ?? 1, 0), 1);
+      return `rgba(${r}, ${g}, ${b}, ${clampedAlpha})`;
+    }
+
+    function resolveTeamColor(primary, alternate){
+      return normalizeHex(primary) || normalizeHex(alternate) || null;
+    }
+
+    function buildGradientStops(option){
+      if(!option) return {
+        away: 'rgba(20, 184, 166, 0.78)',
+        home: 'rgba(126, 34, 206, 0.78)'
+      };
+      const awayColor = resolveTeamColor(option.awayColor, option.awayAlternateColor);
+      const homeColor = resolveTeamColor(option.homeColor, option.homeAlternateColor);
+      return {
+        away: hexToRgba(awayColor, 0.82) || 'rgba(20, 184, 166, 0.78)',
+        home: hexToRgba(homeColor, 0.82) || 'rgba(126, 34, 206, 0.78)'
+      };
+    }
+
+    function resolveOpponentLogo(gameData, selectedTeamId){
+      if(!gameData) return null;
+      const normalizedTeamId = selectedTeamId != null ? String(selectedTeamId) : null;
+      const homeId = gameData.homeTeamId != null ? String(gameData.homeTeamId) : null;
+      const awayId = gameData.awayTeamId != null ? String(gameData.awayTeamId) : null;
+      if(normalizedTeamId){
+        if(normalizedTeamId === homeId){
+          return {
+            url: gameData.awayLogo || null,
+            label: gameData.awayTeamName || 'Opponent'
+          };
+        }
+        if(normalizedTeamId === awayId){
+          return {
+            url: gameData.homeLogo || null,
+            label: gameData.homeTeamName || 'Opponent'
+          };
+        }
+      }
+      if(gameData.awayLogo){
+        return {
+          url: gameData.awayLogo,
+          label: gameData.awayTeamName || 'Away team'
+        };
+      }
+      if(gameData.homeLogo){
+        return {
+          url: gameData.homeLogo,
+          label: gameData.homeTeamName || 'Home team'
+        };
+      }
+      return null;
+    }
+
+    function upsertGameOption(option){
+      if(!option || option.id == null) return;
+      const key = String(option.id);
+      gameOptionCache.set(key, Object.assign({}, option));
+    }
+
+    function resolveCachedGame(id){
+      if(id == null) return null;
+      return gameOptionCache.get(String(id)) || null;
+    }
+
+    function renderSelectionChips(target){
+      if(!target || !target.length) return;
+      const selectedIds = getSelectedGameIds();
+      if(!selectedIds.length) return;
+      const selectedTeamId = teamSelect && teamSelect.length ? teamSelect.val() : null;
+      const fragments = [];
+      selectedIds.forEach(id => {
+        let meta = resolveCachedGame(id);
+        if(!meta && gameSelect && gameSelect.length && typeof gameSelect.select2 === 'function'){
+          const currentData = gameSelect.select2('data') || [];
+          const fallbackMeta = currentData.find(item => String(item.id) === String(id));
+          if(fallbackMeta){
+            upsertGameOption(fallbackMeta);
+            meta = fallbackMeta;
+          }
+        }
+        if(!meta) return;
+        const opponent = resolveOpponentLogo(meta, selectedTeamId);
+        const fallbackLogo = meta.awayLogo || meta.homeLogo || null;
+        const logoUrl = opponent && opponent.url ? opponent.url : fallbackLogo;
+        if(!logoUrl) return;
+        const label = opponent && opponent.label ? opponent.label : (meta.text || 'Selected game');
+        const chip = $('<span>', {
+          class: 'selected-game-chip',
+          'data-game-id': id,
+          title: label
+        });
+        const img = $('<img>', {
+          src: logoUrl,
+          alt: `${label} logo`
+        });
+        chip.append(img);
+        fragments.push(chip);
+      });
+      if(fragments.length){
+        target.append(fragments);
+      }
+    }
+
+    function updateSelectionDisplay(options){
+      const opts = options || {};
+      const rootSelection = (opts.selection && opts.selection.length) ? opts.selection : selectionElement;
+      if(!rootSelection || !rootSelection.length) return;
+      const rendered = rootSelection.find('.select2-selection__rendered');
+      if(!rendered.length) return;
+      let searchEl = opts.searchEl && opts.searchEl.length ? opts.searchEl : rendered.find('.select2-search--inline');
+      if(searchEl && searchEl.length && !opts.searchDetached){
+        searchEl.detach();
+      }
+      rendered.empty();
+      renderSelectionChips(rendered);
+      if(searchEl && searchEl.length){
+        rendered.append(searchEl);
+      }
+    }
+
     function updateSelectionPlaceholder(){
       if(!selectionElement || !selectionElement.length) return;
       const hasSelection = getSelectedGameIds().length > 0;
       selectionElement.toggleClass('has-selection', hasSelection);
+      updateSelectionDisplay();
     }
 
-    function refreshGameOptionIndicators() {
-  const selectedSet = new Set(getSelectedGameIds().map(String));
-  const openDropdown = document.querySelector('.select2-container--open');
-  if (!openDropdown) return;
-  const options = openDropdown.querySelectorAll('.select2-results__option');
-
-  options.forEach(option => {
-    const $option = $(option);
-    const data = $option.data('data');
-    if (!data || !data.id) return;
-    const isSelected = selectedSet.has(String(data.id));
-    const circle = $option.find('.game-select-circle');
-    if (circle.length) {
-      circle.toggleClass('filled', isSelected);
+    function refreshGameOptionIndicators(){
+      const selectedSet = new Set(getSelectedGameIds().map(String));
+      const openDropdown = document.querySelector('.select2-container--open');
+      if(!openDropdown) return;
+      const options = openDropdown.querySelectorAll('.game-result-option[data-game-id]');
+      options.forEach(optionEl => {
+        const id = optionEl.getAttribute('data-game-id');
+        if(!id) return;
+        const isSelected = selectedSet.has(String(id));
+        optionEl.classList.toggle('is-selected', isSelected);
+      });
     }
-  });
-}
 
     function attachDropdownObserver(){
       if(dropdownObserver){
@@ -554,22 +693,52 @@ worseBtn.off('click').on('click', function(){
       const homeLogo = option.homeLogo || '/images/placeholder.jpg';
       const awayLogo = option.awayLogo || '/images/placeholder.jpg';
       const scoreDisplay = option.scoreDisplay || '';
-      const selectedIds = new Set(getSelectedGameIds().map(String));
-      const isSelected = selectedIds.has(String(option.id));
-      const circleClass = isSelected ? 'game-select-circle filled' : 'game-select-circle';
-      return $(
-        `<div class="game-result-option game-option d-flex align-items-center justify-content-between w-100" data-game-id="${option.id}">`+
-          `<div class="d-flex align-items-center flex-grow-1 gap-2">`+
-            `<span class="${circleClass}" aria-hidden="true"></span>`+
-            `<img src="${awayLogo}" class="game-result-logo">`+
-            `<span class="fw-semibold text-white">${option.awayTeamName}</span>`+
-            `<span class="text-white-50">@</span>`+
-            `<img src="${homeLogo}" class="game-result-logo">`+
-            `<span class="fw-semibold text-white">${option.homeTeamName}</span>`+
-          `</div>`+
-          `<span class="game-result-score text-white-50 ms-3">${scoreDisplay}</span>`+
-        `</div>`
-      );
+      const gradients = buildGradientStops(option);
+      const container = $('<div>', {
+        class: 'game-result-option d-flex align-items-center justify-content-between w-100',
+        'data-game-id': option.id
+      });
+      container.css('--game-away-color', gradients.away);
+      container.css('--game-home-color', gradients.home);
+
+      const teamsWrapper = $('<div>', {
+        class: 'd-flex align-items-center flex-grow-1 gap-2'
+      });
+
+      teamsWrapper.append($('<img>', {
+        src: awayLogo,
+        class: 'game-result-logo',
+        alt: `${option.awayTeamName || 'Away team'} logo`
+      }));
+
+      teamsWrapper.append($('<span>', {
+        class: 'fw-semibold text-white',
+        text: option.awayTeamName || ''
+      }));
+
+      teamsWrapper.append($('<span>', {
+        class: 'text-white-50',
+        text: '@'
+      }));
+
+      teamsWrapper.append($('<img>', {
+        src: homeLogo,
+        class: 'game-result-logo',
+        alt: `${option.homeTeamName || 'Home team'} logo`
+      }));
+
+      teamsWrapper.append($('<span>', {
+        class: 'fw-semibold text-white',
+        text: option.homeTeamName || ''
+      }));
+
+      const scoreWrapper = $('<span>', {
+        class: 'game-result-score text-white-50 ms-3',
+        text: scoreDisplay
+      });
+
+      container.append(teamsWrapper, scoreWrapper);
+      return container;
     }
 
     teamSelect.select2({
@@ -620,16 +789,22 @@ worseBtn.off('click').on('click', function(){
           };
         },
         processResults:function(data){
-          return { results:data.map(g=>{
+          const results = data.map(g=>{
             const parts = g.score.split('-');
             const home = parts[0] || '';
             const away = parts[1] || '';
-            return {
+            const option = {
               id:g.id,
               homeTeamName:g.homeTeamName,
               awayTeamName:g.awayTeamName,
               homeLogo:g.homeLogo,
               awayLogo:g.awayLogo,
+              homeTeamId:g.homeTeamId,
+              awayTeamId:g.awayTeamId,
+              homeColor:g.homeColor,
+              homeAlternateColor:g.homeAlternateColor,
+              awayColor:g.awayColor,
+              awayAlternateColor:g.awayAlternateColor,
               score:g.score,
               homePoints:g.homePoints,
               awayPoints:g.awayPoints,
@@ -637,7 +812,10 @@ worseBtn.off('click').on('click', function(){
               scoreDisplay:`${away}-${home}`,
               text:`${g.awayTeamName} vs ${g.homeTeamName}`
             };
-          }) };
+            upsertGameOption(option);
+            return option;
+          });
+          return { results };
         },
         complete:function(){
           if(gameSpinner){ gameSpinner.hide(); }
@@ -648,6 +826,22 @@ worseBtn.off('click').on('click', function(){
     initSelectionElements();
     updateSelectionPlaceholder();
     updateEntryMode();
+
+    gameSelect.on('select2:selecting', function(e){
+      const data = e && e.params && e.params.args ? e.params.args.data : null;
+      const id = data && data.id != null ? String(data.id) : null;
+      if(!id) return;
+      const selected = getSelectedGameIds().map(String);
+      if(selected.includes(id)){
+        e.preventDefault();
+        const nextSelection = selected.filter(value => value !== id);
+        gameSelect.val(nextSelection).trigger('change');
+        setTimeout(function(){
+          refreshGameOptionIndicators();
+          attachDropdownObserver();
+        }, 0);
+      }
+    });
 
     gameSelect.on('select2:open', function(){
       initSelectionElements();
@@ -668,15 +862,26 @@ worseBtn.off('click').on('click', function(){
       updateSelectionPlaceholder();
     });
 
-    gameSelect.on('select2:select select2:unselect', function(){
-  // Wait one microtask for Select2 to re-render the results list
-  setTimeout(() => {
-    refreshGameOptionIndicators();     // refresh the bubbles
-    attachDropdownObserver();          // ensure live syncing continues
-    updateSelectionPlaceholder();
-    updateEntryMode();
-  }, 30); // 30ms delay is enough for Select2 to rebuild
-});
+    function scheduleSelectionSync(){
+      setTimeout(function(){
+        refreshGameOptionIndicators();
+        attachDropdownObserver();
+        updateSelectionPlaceholder();
+        updateEntryMode();
+        updateSubmitState();
+      }, 30);
+    }
+
+    gameSelect.on('select2:select', function(e){
+      if(e && e.params && e.params.data){
+        upsertGameOption(e.params.data);
+      }
+      scheduleSelectionSync();
+    });
+
+    gameSelect.on('select2:unselect', function(){
+      scheduleSelectionSync();
+    });
 
 
     function updateSubmitState(){
@@ -702,25 +907,56 @@ worseBtn.off('click').on('click', function(){
       updateDuplicateWarning(selected);
     }
 
+    function setGhostState($el, shouldGhost){
+      if(!$el || !$el.length) return;
+      if(shouldGhost){
+        $el.addClass('ghost-element');
+        $el.attr('aria-hidden', 'true');
+      } else {
+        $el.removeClass('ghost-element');
+        $el.removeAttr('aria-hidden');
+      }
+    }
+
     function updateEntryMode(){
       const selected = getSelectedGameIds();
       const multiSelected = selected.length > 1;
 
       if(commentGroup && commentGroup.length){
-        commentGroup.toggleClass('d-none', multiSelected);
+        commentGroup.removeClass('d-none');
+        setGhostState(commentGroup, multiSelected);
       }
 
       if(photoGroup && photoGroup.length){
-        photoGroup.toggleClass('d-none', multiSelected);
+        photoGroup.removeClass('d-none');
+        setGhostState(photoGroup, multiSelected);
       }
 
       if(ratingGroup && ratingGroup.length){
-        const shouldShowRating = !multiSelected && gameEntryCount < 5;
-        if(shouldShowRating){
+        const ratingEligible = gameEntryCount < 5;
+        if(ratingEligible){
           ratingGroup.removeClass('d-none').show();
+          setGhostState(ratingGroup, multiSelected);
         } else {
+          setGhostState(ratingGroup, false);
           ratingGroup.addClass('d-none').hide();
         }
+      }
+
+      if(multiSelectionNotice && multiSelectionNotice.length){
+        multiSelectionNotice.toggleClass('d-none', !multiSelected);
+      }
+
+      if(nextBtn && nextBtn.length){
+        if(multiSelected || (infoStep && !infoStep.is(':visible')) || gameEntryCount < 5){
+          nextBtn.hide();
+        } else {
+          nextBtn.show();
+        }
+      }
+
+      if(submitBtn && submitBtn.length){
+        submitBtn.text(multiSelected ? 'Add Selected Games' : originalSubmitLabel);
       }
 
       if(commentInput && commentInput.length && commentFieldName){
@@ -790,6 +1026,9 @@ worseBtn.off('click').on('click', function(){
 
     gameSelect.on('change', function(){
       const dataArr = gameSelect.select2('data') || [];
+      if(Array.isArray(dataArr)){
+        dataArr.forEach(upsertGameOption);
+      }
       if(dataArr.length === 1){
         const data = dataArr[0];
         selectedGameData = {

--- a/views/partials/profileHeader.ejs
+++ b/views/partials/profileHeader.ejs
@@ -229,7 +229,7 @@
                     <h5 class="modal-title flex-grow-1">Add Game</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body">
+                <div class="modal-body add-game-modal-body">
                     <div id="gameInfoStep">
                     <div class="mb-3">
                         <label class="form-label">League</label>


### PR DESCRIPTION
## Summary
- render selected game opponent logos inline within the Select2 control using cached matchup metadata
- allow reselection to toggle games off while keeping gradient styling limited to active selections
- simplify the modal markup and styles now that the dropdown renders compact logo chips directly inside the field

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4145a30f48326b34d299be835144d