### PR TITLE
Refactor profile badges into categorized sections

### DIFF
--- a/views/profileBadges.ejs
+++ b/views/profileBadges.ejs
@@ -209,7 +209,7 @@
 <%- include('partials/profileHeader', { user, isCurrentUser, isFollowing, canMessage, viewer, activeTab: 'badges' }) %>
 <div class="container my-4 flex-grow-1">
     <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-3 mb-4">
-        <h2 class="badge-page-title text-center text-lg-start mb-0"><%= user.username %>'s Badges</h2>
+        <h2 class="badge-page-title text-center text-lg-start mb-0">Completed Badges</h2>
         <div class="filters-row d-flex flex-column flex-sm-row gap-2 ms-lg-auto">
             <select id="conferenceFilter" class="form-select">
                 <option></option>
@@ -228,32 +228,124 @@
     </div>
 
     <% if (sortedBadges && sortedBadges.length) { %>
+    <% const completedBadges = []; const inProgressBadges = []; const yetToEarnBadges = [];
+        sortedBadges.forEach(function(badge) {
+            const progressValue = userProgress[badge.badgeID] || 0;
+            if (progressValue >= badge.reqGames) {
+                completedBadges.push(badge);
+            } else if (progressValue > 0) {
+                inProgressBadges.push(badge);
+            } else {
+                yetToEarnBadges.push(badge);
+            }
+        });
+        let overallIndex = 0;
+    %>
 
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4" id="badgeGrid">
-        <% sortedBadges.forEach(function(badge, index) {
-            const teams = (badge.teamConstraints || [])[0];
-            const team = teamsData.find(t => String(t._id) === String(teams));
-            const progress = userProgress[badge.badgeID] || 0;
-            const percent = Math.round((progress / badge.reqGames) * 100);
-        %>
-        <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= index >= 9 ? 'display: none;' : '' %>">
-            <div class="card h-100 badge-card p-3 d-flex flex-column">
+    <div id="badgeGrid">
+        <% if (completedBadges.length) { %>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4 mb-4">
+            <% completedBadges.forEach(function(badge) {
+                const teams = (badge.teamConstraints || [])[0];
+                const team = teamsData.find(t => String(t._id) === String(teams));
+                const progress = userProgress[badge.badgeID] || 0;
+                const percent = Math.round((progress / badge.reqGames) * 100);
+                const cardIndex = overallIndex;
+                overallIndex++;
+                const hiddenStyle = cardIndex >= 9 ? 'display: none;' : '';
+            %>
+            <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= hiddenStyle %>">
+                <div class="card h-100 badge-card p-3 d-flex flex-column">
   <%- include('partials/badgeIcon', { badge, team, percent }) %>
 
                  <div class="diamond-text mt-2">💎 <%= badge.pointValue %></div>
 
   <div class="card-body d-flex flex-column p-0 mt-2">
-                    <h5 class="card-title badge-title">
-                        <%= badge.badgeName %> (<%= progress %>/<%= badge.reqGames %>)
-                    </h5>
-                    <p class="card-text badge-description flex-grow-1"><%= badge.description %></p>
-                    <div class="badge-link mt-auto">
-                        <a href="/games?teamId=<%= teams %>" class="text-decoration-none">See Upcoming Games →</a>
+                        <h5 class="card-title badge-title">
+                            <%= badge.badgeName %> (<%= progress %>/<%= badge.reqGames %>)
+                        </h5>
+                        <p class="card-text badge-description flex-grow-1"><%= badge.description %></p>
+                        <div class="badge-link mt-auto">
+                            <a href="/games?teamId=<%= teams %>" class="text-decoration-none">See Upcoming Games →</a>
+                        </div>
                     </div>
                 </div>
             </div>
+            <% }) %>
         </div>
-        <% }) %>
+        <% } else { %>
+        <p class="empty-tab-message text-center">No completed badges yet</p>
+        <% } %>
+
+        <h2 class="badge-page-title text-center text-lg-start my-4">In Progress</h2>
+        <% if (inProgressBadges.length) { %>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4 mb-4">
+            <% inProgressBadges.forEach(function(badge) {
+                const teams = (badge.teamConstraints || [])[0];
+                const team = teamsData.find(t => String(t._id) === String(teams));
+                const progress = userProgress[badge.badgeID] || 0;
+                const percent = Math.round((progress / badge.reqGames) * 100);
+                const cardIndex = overallIndex;
+                overallIndex++;
+                const hiddenStyle = cardIndex >= 9 ? 'display: none;' : '';
+            %>
+            <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= hiddenStyle %>">
+                <div class="card h-100 badge-card p-3 d-flex flex-column">
+  <%- include('partials/badgeIcon', { badge, team, percent }) %>
+
+                 <div class="diamond-text mt-2">💎 <%= badge.pointValue %></div>
+
+  <div class="card-body d-flex flex-column p-0 mt-2">
+                        <h5 class="card-title badge-title">
+                            <%= badge.badgeName %> (<%= progress %>/<%= badge.reqGames %>)
+                        </h5>
+                        <p class="card-text badge-description flex-grow-1"><%= badge.description %></p>
+                        <div class="badge-link mt-auto">
+                            <a href="/games?teamId=<%= teams %>" class="text-decoration-none">See Upcoming Games →</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <% }) %>
+        </div>
+        <% } else { %>
+        <p class="empty-tab-message text-center">No badges in progress</p>
+        <% } %>
+
+        <h2 class="badge-page-title text-center text-lg-start my-4">Yet to Earn</h2>
+        <% if (yetToEarnBadges.length) { %>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4">
+            <% yetToEarnBadges.forEach(function(badge) {
+                const teams = (badge.teamConstraints || [])[0];
+                const team = teamsData.find(t => String(t._id) === String(teams));
+                const progress = userProgress[badge.badgeID] || 0;
+                const percent = Math.round((progress / badge.reqGames) * 100);
+                const cardIndex = overallIndex;
+                overallIndex++;
+                const hiddenStyle = cardIndex >= 9 ? 'display: none;' : '';
+            %>
+            <div class="col badge-col" data-conferences="<%= (badge.conferenceConstraints || []).map(String).join(',') %>" data-teams="<%= (badge.teamConstraints || []).map(String).join(',') %>" style="<%= hiddenStyle %>">
+                <div class="card h-100 badge-card p-3 d-flex flex-column">
+  <%- include('partials/badgeIcon', { badge, team, percent }) %>
+
+                 <div class="diamond-text mt-2">💎 <%= badge.pointValue %></div>
+
+  <div class="card-body d-flex flex-column p-0 mt-2">
+                        <h5 class="card-title badge-title">
+                            <%= badge.badgeName %> (<%= progress %>/<%= badge.reqGames %>)
+                        </h5>
+                        <p class="card-text badge-description flex-grow-1"><%= badge.description %></p>
+                        <div class="badge-link mt-auto">
+                            <a href="/games?teamId=<%= teams %>" class="text-decoration-none">See Upcoming Games →</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <% }) %>
+        </div>
+        <% } else { %>
+        <p class="empty-tab-message text-center">No badges yet to earn</p>
+        <% } %>
     </div>
 
     <div class="text-center mt-4">


### PR DESCRIPTION
## Summary
- replace the profile badges header with "Completed Badges" and compute badge groups by progress
- render completed, in-progress, and yet-to-earn sections with existing badge cards and fallback messaging
- preserve the badge grid layout, filtering, and load-more behavior across the new sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e42cf2ea2883268b87bb3218b7f342