### PR TITLE
Simplify conference stats rendering

### DIFF
--- a/views/profileStats.ejs
+++ b/views/profileStats.ejs
@@ -571,19 +571,6 @@
   flex: 2;
   text-align: left;
 }
-.stat-middle {
-  flex: 4;
-  display: flex;
-  gap: 4px;
-  justify-content: flex-start;
-  align-items: center;
-}
-.stat-percent-col {
-  flex: 1;
-  text-align: right;
-}
-
-
 .team-dot {
   display: flex;
   align-items: center;
@@ -655,18 +642,11 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
-#conferenceBlock .stat-percent-col {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
 
 #conferenceBlock .conference-percentage-text {
   margin-right: 0;
-  text-align: center;
+  text-align: right;
 }
-
 .gold-text {
   background: linear-gradient(to right, #ffd700, #ffcc00);
   -webkit-background-clip: text;
@@ -876,16 +856,7 @@
                   <% conferenceEntries.forEach(function(conf) { %>
                     <div class="stat-row">
                       <div class="stat-name-col conference-name-text"><%= conf.name %></div>
-                      <div class="stat-middle conference-dots-row">
-                        <span class="conference-percentage-text">
-                          <%= conf.totalTeams ? `${conf.count}/${conf.totalTeams}` : conf.count %>
-                        </span>
-                      </div>
-                      <div class="stat-percent-col conference-percentage-text">
-                        <% if (conf.totalTeams) { %>
-                          <%= Math.round((conf.count / conf.totalTeams) * 100) %>%
-                        <% } %>
-                      </div>
+                      <div class="conference-percentage-text"><%= conf.count %></div>
                     </div>
                   <% }) %>
                 <% } else { %>


### PR DESCRIPTION
### Motivation
- The conferences block relied on optional `totalTeams` fields and percentage calculations which are not provided by the backend causing an empty/broken UI.
- The goal is to make Conferences behave the same as Teams and Venues by showing only name and count.
- Avoid adding backend lookups or changing controller data; fix only the EJS view and styling.

### Description
- Updated `views/profileStats.ejs` to remove conditional `conf.totalTeams` checks and percentage calculations and render only the conference `name` and `count` in each row.
- Replaced the multi-column percentage markup with a single right-aligned count element (`conference-percentage-text`).
- Removed unused CSS rules for `.stat-middle` and `.stat-percent-col` and adjusted `#conferenceBlock .conference-percentage-text` alignment for a stable layout.
- Kept the existing row and column structure so the layout matches Teams and Venues without backend changes.

### Testing
- Ran a smoke test by starting the app with `node main.js`, which failed to fully start due to an external MongoDB SRV DNS lookup error in this environment.
- Verified the updated template renders conference entries correctly when `conferenceEntries` is present by inspecting the modified `views/profileStats.ejs`.
- No automated unit tests were added or run as part of this change.
- Manual inspection of the CSS and markup confirms the count is displayed and aligned consistently with Teams and Venues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d80f87fb483269e1299d4338f7022)